### PR TITLE
Simplify local Windows candidate build and install

### DIFF
--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -1251,8 +1251,7 @@ function Get-SmokeExecutableBuildInfo {
     if ([string]::IsNullOrWhiteSpace($GoExecutablePath)) {
         Fail-Smoke "candidate mode requires the Go tool to inspect executable build info"
     }
-    $quotedExecutablePath = '"' + $ExecutablePath.Replace('"', '\"') + '"'
-    $result = Invoke-SmokeCommand -FilePath $GoExecutablePath -Arguments @("version", "-m", $quotedExecutablePath) -WorkingDirectory $WorkingDirectory
+    $result = Invoke-SmokeCommand -FilePath $GoExecutablePath -Arguments @("version", "-m", $ExecutablePath) -WorkingDirectory $WorkingDirectory
     if ($result.exitCode -ne 0) {
         Fail-Smoke "go version -m failed for candidate executable with exit code $($result.exitCode): $($result.stderr.Trim())"
     }
@@ -1302,14 +1301,7 @@ function Invoke-SmokeCommand {
         [int]$NetworkObserverSampleMilliseconds = 50
     )
 
-    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
-    $startInfo.FileName = $FilePath
-    $startInfo.Arguments = [string]::Join(" ", $Arguments)
-    $startInfo.WorkingDirectory = $WorkingDirectory
-    $startInfo.UseShellExecute = $false
-    $startInfo.CreateNoWindow = $true
-    $startInfo.RedirectStandardOutput = $true
-    $startInfo.RedirectStandardError = $true
+    $startInfo = New-SmokeProcessStartInfo -FilePath $FilePath -Arguments $Arguments -WorkingDirectory $WorkingDirectory
 
     $process = [System.Diagnostics.Process]::new()
     $process.StartInfo = $startInfo
@@ -1415,6 +1407,35 @@ function Convert-SmokeProcessArgumentListToCommandLine {
         [void]$quotedArguments.Add($builder.ToString())
     }
     return [string]::Join(" ", $quotedArguments.ToArray())
+}
+
+function New-SmokeProcessStartInfo {
+    param(
+        [string]$FilePath,
+        [string[]]$Arguments,
+        [string]$WorkingDirectory
+    )
+
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $FilePath
+    $argumentListProperty = $startInfo.PSObject.Properties["ArgumentList"]
+    if ($null -ne $argumentListProperty) {
+        foreach ($argument in @($Arguments)) {
+            $value = if ($null -eq $argument) { "" } else { [string]$argument }
+            [void]$startInfo.ArgumentList.Add($value)
+        }
+    } else {
+        # Windows PowerShell 5.1 uses .NET Framework, whose ProcessStartInfo
+        # has no ArgumentList. The quoting routine preserves the same token
+        # boundary without invoking a shell or reparsing a serialized list.
+        $startInfo.Arguments = Convert-SmokeProcessArgumentListToCommandLine $Arguments
+    }
+    $startInfo.WorkingDirectory = $WorkingDirectory
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    return $startInfo
 }
 
 function New-SmokeLoopbackPort {
@@ -2924,14 +2945,8 @@ function Invoke-ObserverFixture {
         $rootFilePath = "powershell.exe"
         $rootArguments = @("-NoProfile", "-NonInteractive", "-EncodedCommand", $rootEncoded)
         }
-        $rootStartInfo = [System.Diagnostics.ProcessStartInfo]::new()
-        $rootStartInfo.FileName = $rootFilePath
-        $rootStartInfo.Arguments = Convert-SmokeProcessArgumentListToCommandLine $rootArguments
-        $rootStartInfo.WorkingDirectory = if ($externalRoot) { $resolvedRootWorkingDirectory } else { $fixtureRoot }
-        $rootStartInfo.UseShellExecute = $false
-        $rootStartInfo.CreateNoWindow = $true
-        $rootStartInfo.RedirectStandardOutput = $true
-        $rootStartInfo.RedirectStandardError = $true
+        $rootWorkingDirectory = if ($externalRoot) { $resolvedRootWorkingDirectory } else { $fixtureRoot }
+        $rootStartInfo = New-SmokeProcessStartInfo -FilePath $rootFilePath -Arguments $rootArguments -WorkingDirectory $rootWorkingDirectory
         $rootProcess = [System.Diagnostics.Process]::new()
         $rootProcess.StartInfo = $rootStartInfo
         if (-not $rootProcess.Start()) { throw "observer root could not start: $rootFilePath" }

--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -1550,6 +1550,27 @@ function Invoke-ObserverFixture {
                     }
                 }
             }
+            function Remove-ObserverInactivePidIdentities {
+                param(
+                    [object]$Snapshot,
+                    [hashtable]$IdentityByPid
+                )
+
+                # A PID may be reused after its prior owned process has
+                # disappeared between intervals. Keep every creation-time
+                # identity in OwnedIdentityToPid, but compare only active PID
+                # mappings across the before/after pair so reuse during one
+                # TCP query remains fail closed.
+                $activePids = @{}
+                foreach ($record in @($Snapshot.ownedRecords)) {
+                    $activePids[[int]$record.processId] = $true
+                }
+                foreach ($processId in @($IdentityByPid.Keys)) {
+                    if (-not $activePids.ContainsKey([int]$processId)) {
+                        [void]$IdentityByPid.Remove($processId)
+                    }
+                }
+            }
             function Test-ObserverLoopbackAddress {
                 param([string]$Address)
 
@@ -1566,6 +1587,7 @@ function Invoke-ObserverFixture {
                     throw "Get-NetTCPConnection is unavailable"
                 }
                 $before = Get-ObserverProcessSnapshot $RootId
+                Remove-ObserverInactivePidIdentities $before $IdentityByPid
                 Register-ObserverIdentities $before $IdentityByPid $OwnedIdentityToPid $State
                 # One complete TCP-table query is deliberately shared by every
                 # owned process in this interval; an empty table is a valid sample.

--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -455,7 +455,9 @@ function Get-SmokeDependencyLinkTarget {
     )
 
     $targetProperty = $Item.PSObject.Properties["Target"]
-    $targets = if ($null -eq $targetProperty) { @() } else { @($targetProperty.Value) }
+    $targets = @(
+        if ($null -eq $targetProperty) { @() } else { @($targetProperty.Value) }
+    )
     if ($targets.Count -ne 1 -or [string]::IsNullOrWhiteSpace([string]$targets[0])) {
         Fail-Smoke "dependency link has ambiguous or missing target: $($Item.FullName)"
     }
@@ -860,7 +862,7 @@ function Copy-SmokeDependencyTree {
     }
     $robocopyArguments = @(
         $sourcePath, $stagePath,
-        "/E", "/SL", "/COPY:DAT", "/DCOPY:DAT", "/R:0", "/W:0",
+        "/E", "/XJ", "/COPY:DAT", "/DCOPY:DAT", "/R:0", "/W:0",
         "/NFL", "/NDL", "/NJH", "/NJS", "/NP"
     )
     $robocopyOutput = @(& robocopy.exe @robocopyArguments 2>&1)
@@ -977,7 +979,7 @@ function Invoke-SmokeDependencyStage {
         }
         $report.status = "PASS"
     } catch {
-        $report.error = $_.Exception.Message
+        $report.error = "line $($_.InvocationInfo.ScriptLineNumber): $($_.Exception.Message)"
     }
     Write-SmokeJSONEvidence -RequestedPath $reportPath -Evidence $report | Out-Null
     if ($report.status -ne "PASS") {
@@ -1047,7 +1049,7 @@ function Invoke-SmokeDependencyVerification {
         }
         $report.status = "PASS"
     } catch {
-        $report.error = $_.Exception.Message
+        $report.error = "line $($_.InvocationInfo.ScriptLineNumber): $($_.Exception.Message)"
     }
     Write-SmokeJSONEvidence -RequestedPath $reportPath -Evidence $report | Out-Null
     if ($report.status -ne "PASS") {

--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -399,9 +399,9 @@ function Get-SmokeExecutableBuildInfo {
     )
     $goPath = $GoExecutablePath
     if ([string]::IsNullOrWhiteSpace($goPath)) {
-        $go = Get-Command go.exe -CommandType Application -ErrorAction SilentlyContinue
+        $go = Get-Command go.exe -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
         if ($null -eq $go) { Fail-Smoke "Go is required to inspect executable build info" }
-        $goPath = $go.Source
+        $goPath = [string]$go.Source
     }
     $result = Invoke-CandidateCommand -FilePath $goPath `
         -ArgumentList @("version", "-m", (Resolve-SmokePath $ExecutablePath)) `
@@ -437,8 +437,18 @@ function Get-SmokeExecutableBuildInfo {
 
 function Invoke-SmokeGit {
     param([string[]]$ArgumentList)
-    $output = @(& git.exe @ArgumentList 2>&1 | ForEach-Object { [string]$_ })
-    if ($LASTEXITCODE -ne 0) { Fail-Smoke "git $($ArgumentList -join ' ') failed: $($output -join ' ')" }
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        # Windows PowerShell promotes native stderr to a terminating error when
+        # the caller uses Stop. Git writes normal clone progress there, so
+        # capture it as command evidence and classify failure by exit status.
+        $ErrorActionPreference = "Continue"
+        $output = @(& git.exe @ArgumentList 2>&1 | ForEach-Object { [string]$_ })
+        $exitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    if ($exitCode -ne 0) { Fail-Smoke "git $($ArgumentList -join ' ') failed: $($output -join ' ')" }
     return ($output -join "`n").Trim()
 }
 
@@ -536,6 +546,7 @@ function Invoke-InstalledCandidateSmoke {
         [string]$InstallerPath,
         [string]$ArchiveExecutablePath,
         [string]$Version,
+        [string]$ExpectedExecutableVersion,
         [string]$ExpectedSourceCommit,
         [string]$GoExecutablePath,
         [string]$RequestedInstallDir,
@@ -650,8 +661,11 @@ function Invoke-InstalledCandidateSmoke {
             -StdoutPath (Join-Path $smokeRoot "version.stdout") `
             -StderrPath (Join-Path $smokeRoot "version.stderr")
         [void]$commands.Add($versionCommand)
-        if ($versionCommand.exitCode -ne 0 -or $versionCommand.stdout.Trim() -cne $Version) {
-            Fail-Smoke "installed candidate version is '$($versionCommand.stdout.Trim())', want '$Version'"
+        $reportedVersion = $versionCommand.stdout.Trim()
+        $expectedVersion = if ([string]::IsNullOrWhiteSpace($ExpectedExecutableVersion)) { $Version } else { $ExpectedExecutableVersion }
+        if ($versionCommand.exitCode -ne 0 -or [string]::IsNullOrWhiteSpace($reportedVersion) -or
+            $reportedVersion -match '[\r\n]' -or $reportedVersion -cne $expectedVersion) {
+            Fail-Smoke "installed candidate version is '$reportedVersion', want '$expectedVersion'"
         }
         $rootHelpCommand = Invoke-CandidateCommand -FilePath $resolvedPath `
             -ArgumentList @("--help") -WorkingDirectory $smokeRoot `
@@ -717,6 +731,8 @@ function Invoke-InstalledCandidateSmoke {
             status = "PASS"
             installedExecutable = $installedEvidence
             pathResolution = $pathResolution
+            version = $reportedVersion
+            expectedVersion = $expectedVersion
             executableBuildInfo = $buildInfo
             commands = @($commands | ForEach-Object { $_ })
             modelCalls = 0
@@ -870,9 +886,10 @@ function Invoke-LocalCandidateSmoke {
         if ($releaseToolResult.exitCode -ne 0 -or $releaseToolResult.stdout -notmatch ("(?m)\b" + [regex]::Escape($ReleaseToolVersion) + "\b")) {
             Fail-Smoke "GoReleaser version check failed: exit=$($releaseToolResult.exitCode) output='$($releaseToolResult.stdout.Trim())'"
         }
-        $goCommand = Get-Command go.exe -CommandType Application -ErrorAction SilentlyContinue
+        $goCommand = Get-Command go.exe -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
         if ($null -eq $goCommand) { Fail-Smoke "Go 1.26.8 is required for candidate release" }
-        $goVersionResult = Invoke-CandidateCommand -FilePath $goCommand.Source `
+        $goPath = [string]$goCommand.Source
+        $goVersionResult = Invoke-CandidateCommand -FilePath $goPath `
             -ArgumentList @("version") -WorkingDirectory $checkoutPath `
             -StdoutPath (Join-Path $outputDirectory "go-version.stdout.log") `
             -StderrPath (Join-Path $outputDirectory "go-version.stderr.log")
@@ -950,11 +967,28 @@ function Invoke-LocalCandidateSmoke {
         Expand-Archive -LiteralPath $archivePath -DestinationPath $extractPath -Force
         $archiveExecutablePath = Join-Path $extractPath "you.exe"
         [void](Assert-SmokeRegularFile "archive executable" $archiveExecutablePath)
+        $archiveVersionCommand = Invoke-CandidateCommand -FilePath $archiveExecutablePath `
+            -ArgumentList @("--version") -WorkingDirectory $extractPath `
+            -StdoutPath (Join-Path $outputDirectory "archive-version.stdout.log") `
+            -StderrPath (Join-Path $outputDirectory "archive-version.stderr.log")
+        $expectedExecutableVersion = $archiveVersionCommand.stdout.Trim()
+        if ($archiveVersionCommand.exitCode -ne 0 -or [string]::IsNullOrWhiteSpace($expectedExecutableVersion) -or
+            $expectedExecutableVersion -match '[\r\n]') {
+            Fail-Smoke "archive executable version probe failed: exit=$($archiveVersionCommand.exitCode) output='$expectedExecutableVersion'"
+        }
+        $retainedExecutablePath = Join-Path $outputDirectory "you.exe"
+        Copy-Item -LiteralPath $archiveExecutablePath -Destination $retainedExecutablePath -Force
+        $archiveExecutableEvidence = Get-SmokeFileEvidence "archive executable" $archiveExecutablePath
+        $retainedExecutableEvidence = Get-SmokeFileEvidence "windows-amd64-executable" $retainedExecutablePath
+        if ($archiveExecutableEvidence.bytes -ne $retainedExecutableEvidence.bytes -or
+            $archiveExecutableEvidence.sha256 -cne $retainedExecutableEvidence.sha256) {
+            Fail-Smoke "retained executable does not match the archive member"
+        }
         $report.artifacts = @(
             Get-SmokeFileEvidence "windows-amd64-archive" $archivePath
             Get-SmokeFileEvidence "checksums" $checksumPath
             Get-SmokeFileEvidence "windows-installer" $installerPath
-            Get-SmokeFileEvidence "windows-amd64-executable" $archiveExecutablePath
+            $retainedExecutableEvidence
         )
         $installArguments = @{
             CandidateDirectory = $outputDirectory
@@ -963,8 +997,9 @@ function Invoke-LocalCandidateSmoke {
             InstallerPath = $installerPath
             ArchiveExecutablePath = $archiveExecutablePath
             Version = $version
+            ExpectedExecutableVersion = $expectedExecutableVersion
             ExpectedSourceCommit = $sourceIdentity.commit
-            GoExecutablePath = $goCommand.Source
+            GoExecutablePath = $goPath
             RequestedInstallDir = $installDirectory
             WorkDirectory = $workDirectory
         }

--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -30,6 +30,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+$SmokeMaximumTaskRootPathLength = 220
 
 function Fail-Smoke {
     param([string]$Message)
@@ -74,6 +75,14 @@ function Assert-SmokePathsDisjoint {
     }
 }
 
+function Assert-SmokeTaskRootLength {
+    param([string]$Name, [string]$Path)
+    $resolved = Resolve-SmokePath $Path
+    if ($resolved.Length -gt $SmokeMaximumTaskRootPathLength) {
+        Fail-Smoke "$Name must be at most $SmokeMaximumTaskRootPathLength characters: $resolved"
+    }
+}
+
 function Assert-SmokeCandidateRoots {
     param(
         [string]$SourcePath,
@@ -93,6 +102,9 @@ function Assert-SmokeCandidateRoots {
     }
     foreach ($entry in $paths.GetEnumerator()) {
         Assert-SmokeNoReparseAncestry $entry.Key $entry.Value
+    }
+    foreach ($ownedName in @("output", "work", "install", "report")) {
+        Assert-SmokeTaskRootLength $ownedName $paths[$ownedName]
     }
     foreach ($ownedName in @("output", "work", "install")) {
         foreach ($readName in @("source", "dependency")) {
@@ -284,6 +296,7 @@ function Invoke-CandidateCommand {
     $timedOut = $false
     $outputLimitExceeded = $false
     $terminationReason = ""
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     try {
         $job = Start-Job -ScriptBlock {
             param($Command)
@@ -358,6 +371,7 @@ function Invoke-CandidateCommand {
         }
         Remove-Item -LiteralPath $pidPath -Force -ErrorAction SilentlyContinue
     }
+    $stopwatch.Stop()
     $stdout = Protect-SmokeOutput $stdoutPath $OutputMaximumBytes
     $stderr = Protect-SmokeOutput $stderrPath $OutputMaximumBytes
     return [pscustomobject][ordered]@{
@@ -367,10 +381,57 @@ function Invoke-CandidateCommand {
         timedOut = $timedOut
         outputLimitExceeded = $outputLimitExceeded
         terminationReason = $terminationReason
+        elapsedMilliseconds = [int64][Math]::Max(0, $stopwatch.ElapsedMilliseconds)
         stdout = $stdout.text
         stderr = $stderr.text
         stdoutEvidence = $stdout.evidence
         stderrEvidence = $stderr.evidence
+    }
+}
+
+function Get-SmokeExecutableBuildInfo {
+    param(
+        [string]$ExecutablePath,
+        [string]$ExpectedRevision,
+        [string]$GoExecutablePath,
+        [string]$WorkingDirectory,
+        [string]$OutputDirectory
+    )
+    $goPath = $GoExecutablePath
+    if ([string]::IsNullOrWhiteSpace($goPath)) {
+        $go = Get-Command go.exe -CommandType Application -ErrorAction SilentlyContinue
+        if ($null -eq $go) { Fail-Smoke "Go is required to inspect executable build info" }
+        $goPath = $go.Source
+    }
+    $result = Invoke-CandidateCommand -FilePath $goPath `
+        -ArgumentList @("version", "-m", (Resolve-SmokePath $ExecutablePath)) `
+        -WorkingDirectory $WorkingDirectory `
+        -StdoutPath (Join-Path $OutputDirectory "executable-build-info.stdout.log") `
+        -StderrPath (Join-Path $OutputDirectory "executable-build-info.stderr.log")
+    if ($result.exitCode -ne 0) {
+        Fail-Smoke "go version -m failed with exit $($result.exitCode): $($result.stderr)"
+    }
+    $settings = @{}
+    foreach ($line in ($result.stdout -split "`r?`n")) {
+        if ($line -match '^\s*build\s+(vcs\.(revision|modified))=(\S+)\s*$') {
+            $key = $Matches[1]
+            if ($settings.ContainsKey($key)) { Fail-Smoke "executable build info contains duplicate $key" }
+            $settings[$key] = $Matches[3]
+        }
+    }
+    foreach ($key in @("vcs.revision", "vcs.modified")) {
+        if (-not $settings.ContainsKey($key)) { Fail-Smoke "executable build info $key is missing" }
+    }
+    if ([string]$settings["vcs.revision"] -cne $ExpectedRevision) {
+        Fail-Smoke "executable build info vcs.revision = $($settings['vcs.revision']), want $ExpectedRevision"
+    }
+    if ([string]$settings["vcs.modified"] -cne "false") {
+        Fail-Smoke "executable build info vcs.modified = $($settings['vcs.modified']), want false"
+    }
+    return [ordered]@{
+        command = $result
+        sourceRevision = [string]$settings["vcs.revision"]
+        vcsModified = $false
     }
 }
 
@@ -475,10 +536,15 @@ function Invoke-InstalledCandidateSmoke {
         [string]$InstallerPath,
         [string]$ArchiveExecutablePath,
         [string]$Version,
+        [string]$ExpectedSourceCommit,
+        [string]$GoExecutablePath,
         [string]$RequestedInstallDir,
         [string]$WorkDirectory
     )
     $installDir = Resolve-SmokePath $RequestedInstallDir
+    Assert-SmokeTaskRootLength "install directory" $installDir
+    Assert-SmokeTaskRootLength "candidate output directory" $CandidateDirectory
+    Assert-SmokeTaskRootLength "candidate work directory" $WorkDirectory
     Assert-SmokeEmptyRoot "install directory" $installDir
     $smokeRoot = Join-Path $WorkDirectory "install-smoke"
     [void][System.IO.Directory]::CreateDirectory($smokeRoot)
@@ -563,7 +629,23 @@ function Invoke-InstalledCandidateSmoke {
         if ($installedEvidence.bytes -ne $archiveEvidence.bytes -or $installedEvidence.sha256 -ne $archiveEvidence.sha256) {
             Fail-Smoke "installed executable does not match the archive member"
         }
-        $versionCommand = Invoke-CandidateCommand -FilePath $installedBinary `
+        $env:PATH = "$installDir$([System.IO.Path]::PathSeparator)$pathRoot"
+        $resolvedCommand = Get-Command you.exe -CommandType Application -ErrorAction SilentlyContinue
+        if ($null -eq $resolvedCommand) { Fail-Smoke "you.exe was not resolvable from PATH after installation" }
+        $resolvedPath = Resolve-SmokePath $resolvedCommand.Source
+        if (-not $resolvedPath.Equals((Resolve-SmokePath $installedBinary), [System.StringComparison]::OrdinalIgnoreCase)) {
+            Fail-Smoke "PATH resolved $resolvedPath instead of the installed executable $installedBinary"
+        }
+        $pathResolution = $resolvedPath
+        $buildInfo = $null
+        if (-not [string]::IsNullOrWhiteSpace($ExpectedSourceCommit)) {
+            $buildInfo = Get-SmokeExecutableBuildInfo -ExecutablePath $resolvedPath `
+                -ExpectedRevision $ExpectedSourceCommit -GoExecutablePath $GoExecutablePath `
+                -WorkingDirectory $smokeRoot `
+                -OutputDirectory $CandidateDirectory
+            [void]$commands.Add($buildInfo.command)
+        }
+        $versionCommand = Invoke-CandidateCommand -FilePath $resolvedPath `
             -ArgumentList @("--version") -WorkingDirectory $smokeRoot `
             -StdoutPath (Join-Path $smokeRoot "version.stdout") `
             -StderrPath (Join-Path $smokeRoot "version.stderr")
@@ -571,7 +653,31 @@ function Invoke-InstalledCandidateSmoke {
         if ($versionCommand.exitCode -ne 0 -or $versionCommand.stdout.Trim() -cne $Version) {
             Fail-Smoke "installed candidate version is '$($versionCommand.stdout.Trim())', want '$Version'"
         }
-        $helpCommand = Invoke-CandidateCommand -FilePath $installedBinary `
+        $rootHelpCommand = Invoke-CandidateCommand -FilePath $resolvedPath `
+            -ArgumentList @("--help") -WorkingDirectory $smokeRoot `
+            -StdoutPath (Join-Path $smokeRoot "root-help.stdout") `
+            -StderrPath (Join-Path $smokeRoot "root-help.stderr")
+        [void]$commands.Add($rootHelpCommand)
+        if ($rootHelpCommand.exitCode -ne 0 -or [string]::IsNullOrWhiteSpace($rootHelpCommand.stdout)) {
+            Fail-Smoke "installed candidate root help failed"
+        }
+        $docsCommand = Invoke-CandidateCommand -FilePath $resolvedPath `
+            -ArgumentList @("docs", "models") -WorkingDirectory $smokeRoot `
+            -StdoutPath (Join-Path $smokeRoot "models-docs.stdout") `
+            -StderrPath (Join-Path $smokeRoot "models-docs.stderr")
+        [void]$commands.Add($docsCommand)
+        if ($docsCommand.exitCode -ne 0 -or [string]::IsNullOrWhiteSpace($docsCommand.stdout)) {
+            Fail-Smoke "installed candidate models docs failed"
+        }
+        $listCommand = Invoke-CandidateCommand -FilePath $resolvedPath `
+            -ArgumentList @("models", "list") -WorkingDirectory $smokeRoot `
+            -StdoutPath (Join-Path $smokeRoot "models-list.stdout") `
+            -StderrPath (Join-Path $smokeRoot "models-list.stderr")
+        [void]$commands.Add($listCommand)
+        if ($listCommand.exitCode -ne 0) {
+            Fail-Smoke "installed candidate models list exited $($listCommand.exitCode)"
+        }
+        $helpCommand = Invoke-CandidateCommand -FilePath $resolvedPath `
             -ArgumentList @("models", "--help") -WorkingDirectory $smokeRoot `
             -StdoutPath (Join-Path $smokeRoot "models-help.stdout") `
             -StderrPath (Join-Path $smokeRoot "models-help.stderr")
@@ -583,7 +689,7 @@ function Invoke-InstalledCandidateSmoke {
             if (-not $helpCommand.stdout.Contains($name)) {
                 Fail-Smoke "installed candidate models help does not expose $name"
             }
-            $inspect = Invoke-CandidateCommand -FilePath $installedBinary `
+            $inspect = Invoke-CandidateCommand -FilePath $resolvedPath `
                 -ArgumentList @("--json", "models", "inspect", $name) `
                 -WorkingDirectory $smokeRoot `
                 -StdoutPath (Join-Path $smokeRoot "$name.stdout") `
@@ -610,6 +716,8 @@ function Invoke-InstalledCandidateSmoke {
         return [pscustomobject][ordered]@{
             status = "PASS"
             installedExecutable = $installedEvidence
+            pathResolution = $pathResolution
+            executableBuildInfo = $buildInfo
             commands = @($commands | ForEach-Object { $_ })
             modelCalls = 0
             modelBackendDownloadBytes = 0
@@ -759,8 +867,17 @@ function Invoke-LocalCandidateSmoke {
             -ArgumentList @("--version") -WorkingDirectory $checkoutPath `
             -StdoutPath (Join-Path $outputDirectory "goreleaser-version.stdout.log") `
             -StderrPath (Join-Path $outputDirectory "goreleaser-version.stderr.log")
-        if ($releaseToolResult.exitCode -ne 0 -or -not $releaseToolResult.stdout.Contains($ReleaseToolVersion)) {
+        if ($releaseToolResult.exitCode -ne 0 -or $releaseToolResult.stdout -notmatch ("(?m)\b" + [regex]::Escape($ReleaseToolVersion) + "\b")) {
             Fail-Smoke "GoReleaser version check failed: exit=$($releaseToolResult.exitCode) output='$($releaseToolResult.stdout.Trim())'"
+        }
+        $goCommand = Get-Command go.exe -CommandType Application -ErrorAction SilentlyContinue
+        if ($null -eq $goCommand) { Fail-Smoke "Go 1.26.8 is required for candidate release" }
+        $goVersionResult = Invoke-CandidateCommand -FilePath $goCommand.Source `
+            -ArgumentList @("version") -WorkingDirectory $checkoutPath `
+            -StdoutPath (Join-Path $outputDirectory "go-version.stdout.log") `
+            -StderrPath (Join-Path $outputDirectory "go-version.stderr.log")
+        if ($goVersionResult.exitCode -ne 0 -or $goVersionResult.stdout -notmatch '(?m)\bgo1\.26\.8\b') {
+            Fail-Smoke "Go version check failed: exit=$($goVersionResult.exitCode) output='$($goVersionResult.stdout.Trim())', want go1.26.8"
         }
         $statusBefore = Invoke-SmokeGit @("-C", $checkoutPath, "status", "--porcelain=v1", "--untracked-files=all")
         if ($statusBefore -ne "") {
@@ -776,6 +893,7 @@ function Invoke-LocalCandidateSmoke {
             command = $releaseToolPath
             arguments = $releaseArguments
             exitCode = $releaseResult.exitCode
+            elapsedMilliseconds = $releaseResult.elapsedMilliseconds
             timedOut = $releaseResult.timedOut
             outputLimitExceeded = $releaseResult.outputLimitExceeded
             terminationReason = $releaseResult.terminationReason
@@ -783,6 +901,7 @@ function Invoke-LocalCandidateSmoke {
             stderr = $releaseResult.stderrEvidence
             goReleaser = $releaseToolEvidence
             goReleaserVersion = $ReleaseToolVersion
+            goVersion = $goVersionResult
             config = Get-SmokeFileEvidence "goreleaser-config" (Join-Path $checkoutPath ".goreleaser.yml")
             bunLock = $sourceLock
             esbuild = $esbuildEvidence
@@ -844,10 +963,13 @@ function Invoke-LocalCandidateSmoke {
             InstallerPath = $installerPath
             ArchiveExecutablePath = $archiveExecutablePath
             Version = $version
+            ExpectedSourceCommit = $sourceIdentity.commit
+            GoExecutablePath = $goCommand.Source
             RequestedInstallDir = $installDirectory
             WorkDirectory = $workDirectory
         }
         $report.install = Invoke-InstalledCandidateSmoke @installArguments
+        $report.build.executableBuildInfo = $report.install.executableBuildInfo
         $report.status = "PASS"
     } catch {
         $failure = $_.Exception
@@ -868,6 +990,23 @@ function Invoke-LocalCandidateSmoke {
             $report.cleanup = [ordered]@{ status = "FAIL"; error = $_.Exception.Message }
             if ($null -eq $failure) { $failure = $_.Exception }
             $report.status = "FAIL"
+        }
+        if ($report.cleanup.status -eq "PASS" -and @($report.artifacts).Count -gt 0) {
+            $retainedEvidenceStable = $true
+            foreach ($artifact in @($report.artifacts)) {
+                $artifactPath = Join-Path $outputDirectory ([string]$artifact.file)
+                $currentEvidence = Get-SmokeFileEvidence ([string]$artifact.role) $artifactPath
+                if ($currentEvidence.bytes -ne [int64]$artifact.bytes -or $currentEvidence.sha256 -cne [string]$artifact.sha256) {
+                    $retainedEvidenceStable = $false
+                    break
+                }
+            }
+            $report.cleanup.retainedEvidenceHashesStable = $retainedEvidenceStable
+            if (-not $retainedEvidenceStable) {
+                $report.cleanup.status = "FAIL"
+                if ($null -eq $failure) { $failure = [System.Exception]::new("retained candidate evidence changed during install smoke cleanup") }
+                $report.status = "FAIL"
+            }
         }
         [void][System.IO.Directory]::CreateDirectory((Split-Path -Parent $reportPath))
         $report | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $reportPath -Encoding UTF8

--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -32,6 +32,218 @@ $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 $SmokeMaximumTaskRootPathLength = 220
 
+if ($null -eq ([System.Management.Automation.PSTypeName]::new("InfiniteYou.ReleaseSmoke.ProcessRunner").Type)) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InfiniteYou.ReleaseSmoke
+{
+    public sealed class CommandResult
+    {
+        public int ExitCode { get; set; }
+        public bool TimedOut { get; set; }
+        public bool OutputLimitExceeded { get; set; }
+    }
+
+    internal sealed class CaptureState
+    {
+        public long TotalBytes;
+        public int LimitExceeded;
+    }
+
+    public static class ProcessRunner
+    {
+        public static CommandResult Run(
+            string filePath,
+            string[] arguments,
+            string workingDirectory,
+            string stdoutPath,
+            string stderrPath,
+            int timeoutSeconds,
+            int outputMaximumBytes)
+        {
+            if (timeoutSeconds <= 0) throw new ArgumentOutOfRangeException("timeoutSeconds");
+            if (outputMaximumBytes <= 0) throw new ArgumentOutOfRangeException("outputMaximumBytes");
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = filePath,
+                Arguments = BuildArguments(arguments),
+                WorkingDirectory = workingDirectory,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            var process = new Process { StartInfo = startInfo };
+            var state = new CaptureState();
+            var terminationRequested = 0;
+            try
+            {
+                if (!process.Start()) throw new InvalidOperationException("process did not start");
+                Action stop = delegate
+                {
+                    if (Interlocked.Exchange(ref terminationRequested, 1) == 0)
+                    {
+                        KillProcessTree(process);
+                    }
+                };
+                Task stdoutTask = CaptureAsync(process.StandardOutput.BaseStream, stdoutPath, outputMaximumBytes, state, stop);
+                Task stderrTask = CaptureAsync(process.StandardError.BaseStream, stderrPath, outputMaximumBytes, state, stop);
+                Task processTask = Task.Run(delegate { process.WaitForExit(); });
+                Task all = Task.WhenAll(stdoutTask, stderrTask, processTask);
+                long timeoutMilliseconds = (long)timeoutSeconds * 1000L;
+                int waitMilliseconds = timeoutMilliseconds >= Int32.MaxValue ? Int32.MaxValue : (int)timeoutMilliseconds;
+                bool completed = all.Wait(waitMilliseconds);
+                bool timedOut = !completed;
+                if (timedOut)
+                {
+                    stop();
+                    try { all.Wait(10000); } catch (AggregateException) { }
+                }
+                if (!all.IsCompleted)
+                {
+                    throw new TimeoutException("process did not terminate after the bounded kill wait");
+                }
+                all.GetAwaiter().GetResult();
+                int exitCode = process.ExitCode;
+                bool outputLimitExceeded = Volatile.Read(ref state.LimitExceeded) != 0;
+                if (outputLimitExceeded) exitCode = 125;
+                else if (timedOut) exitCode = 124;
+                return new CommandResult
+                {
+                    ExitCode = exitCode,
+                    TimedOut = timedOut,
+                    OutputLimitExceeded = outputLimitExceeded
+                };
+            }
+            finally
+            {
+                try
+                {
+                    if (!process.HasExited) KillProcessTree(process);
+                }
+                catch (InvalidOperationException) { }
+                process.Dispose();
+            }
+        }
+
+        private static async Task CaptureAsync(
+            Stream input,
+            string path,
+            int maximumBytes,
+            CaptureState state,
+            Action limit)
+        {
+            using (var output = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.ReadWrite, 8192, true))
+            {
+                var buffer = new byte[8192];
+                long total = 0;
+                while (true)
+                {
+                    int read;
+                    try
+                    {
+                        read = await input.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+                    }
+                    catch (IOException)
+                    {
+                        if (Volatile.Read(ref state.LimitExceeded) != 0) return;
+                        throw;
+                    }
+                    if (read == 0) return;
+                    long previous = total;
+                    total += read;
+                    Interlocked.Exchange(ref state.TotalBytes, total);
+                    long retain = Math.Min((long)read, Math.Max(0L, (long)maximumBytes - previous + 1L));
+                    if (retain > 0) await output.WriteAsync(buffer, 0, (int)retain).ConfigureAwait(false);
+                    if (total > maximumBytes)
+                    {
+                        Interlocked.Exchange(ref state.LimitExceeded, 1);
+                        limit();
+                        return;
+                    }
+                }
+            }
+        }
+
+        private static void KillProcessTree(Process process)
+        {
+            try
+            {
+                string systemRoot = Environment.GetEnvironmentVariable("SystemRoot");
+                if (String.IsNullOrEmpty(systemRoot)) systemRoot = "C:\\Windows";
+                var killer = Process.Start(new ProcessStartInfo
+                {
+                    FileName = Path.Combine(systemRoot, "System32", "taskkill.exe"),
+                    Arguments = "/PID " + process.Id.ToString() + " /T /F",
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                });
+                if (killer != null)
+                {
+                    try { killer.WaitForExit(5000); } finally { killer.Dispose(); }
+                }
+            }
+            catch (Exception) { }
+            try
+            {
+                if (!process.HasExited) process.Kill();
+            }
+            catch (Exception) { }
+        }
+
+        private static string BuildArguments(string[] arguments)
+        {
+            var values = new string[arguments == null ? 0 : arguments.Length];
+            for (int index = 0; index < values.Length; index++) values[index] = QuoteArgument(arguments[index]);
+            return String.Join(" ", values);
+        }
+
+        private static string QuoteArgument(string argument)
+        {
+            if (argument == null) argument = String.Empty;
+            bool needsQuotes = argument.Length == 0;
+            for (int index = 0; index < argument.Length && !needsQuotes; index++)
+            {
+                needsQuotes = Char.IsWhiteSpace(argument[index]) || argument[index] == '"';
+            }
+            if (!needsQuotes) return argument;
+            var result = new StringBuilder();
+            result.Append('"');
+            int slashes = 0;
+            foreach (char value in argument)
+            {
+                if (value == '\\')
+                {
+                    slashes++;
+                    continue;
+                }
+                if (value == '"')
+                {
+                    result.Append('\\', slashes * 2 + 1);
+                    result.Append('"');
+                    slashes = 0;
+                    continue;
+                }
+                result.Append('\\', slashes);
+                result.Append(value);
+                slashes = 0;
+            }
+            result.Append('\\', slashes * 2);
+            result.Append('"');
+            return result.ToString();
+        }
+    }
+}
+'@
+}
+
 function Fail-Smoke {
     param([string]$Message)
     throw "install smoke: $Message"
@@ -194,13 +406,17 @@ function Copy-SmokeNativeToolToShortPath {
 }
 
 function Get-SmokeDirectoryBytes {
-    param([string]$Path)
+    param([string]$Path, [switch]$RejectReparsePoint)
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) { return [int64]0 }
     $total = [int64]0
     $pending = New-Object 'System.Collections.Generic.Stack[string]'
     $pending.Push((Resolve-SmokePath $Path))
     while ($pending.Count -gt 0) {
         foreach ($item in @(Get-ChildItem -LiteralPath $pending.Pop() -Force -ErrorAction Stop)) {
-            if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) { continue }
+            if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+                if ($RejectReparsePoint) { Fail-Smoke "directory byte root contains a reparse point: $($item.FullName)" }
+                continue
+            }
             if ($item.PSIsContainer) { $pending.Push($item.FullName) } else { $total += [int64]$item.Length }
         }
     }
@@ -317,104 +533,28 @@ function Invoke-CandidateCommand {
     }
     [System.IO.File]::WriteAllBytes($stdoutPath, [byte[]]@())
     [System.IO.File]::WriteAllBytes($stderrPath, [byte[]]@())
-    $pidPath = Join-Path ([System.IO.Path]::GetDirectoryName($stdoutPath)) ("command-" + [System.Guid]::NewGuid().ToString("N") + ".pid")
-    $payload = [pscustomobject]@{
-        FilePath = $FilePath
-        Arguments = @($ArgumentList)
-        WorkingDirectory = $workingDirectory
-        StdoutPath = $stdoutPath
-        StderrPath = $stderrPath
-        PidPath = $pidPath
-    }
-    $job = $null
-    $exitCode = 125
-    $timedOut = $false
-    $outputLimitExceeded = $false
-    $terminationReason = ""
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     try {
-        $job = Start-Job -ScriptBlock {
-            param($Command)
-            $ErrorActionPreference = "Continue"
-            Set-Location -LiteralPath $Command.WorkingDirectory
-            [System.IO.File]::WriteAllText($Command.PidPath, [string]$PID, [System.Text.Encoding]::ASCII)
-            $arguments = @($Command.Arguments)
-            $commandPath = [string]$Command.FilePath
-            $commandStdout = [string]$Command.StdoutPath
-            $commandStderr = [string]$Command.StderrPath
-            $commandExitCode = 125
-            & $commandPath @arguments 1> $commandStdout 2> $commandStderr
-            if ($null -ne $LASTEXITCODE) { $commandExitCode = [int]$LASTEXITCODE }
-            return $commandExitCode
-        } -ArgumentList $payload
-        $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
-        while ($job.State -notin @("Completed", "Failed", "Stopped")) {
-            Wait-Job -Job $job -Timeout 1 | Out-Null
-            foreach ($path in @($stdoutPath, $stderrPath)) {
-                $item = Get-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
-                if ($null -ne $item -and [int64]$item.Length -gt $OutputMaximumBytes) {
-                    $outputLimitExceeded = $true
-                    $terminationReason = "output exceeded $OutputMaximumBytes bytes"
-                    break
-                }
-            }
-            if ($outputLimitExceeded) { break }
-            if ([DateTime]::UtcNow -ge $deadline) {
-                $timedOut = $true
-                $terminationReason = "deadline of $TimeoutSeconds seconds exceeded"
-                break
-            }
-        }
-        foreach ($path in @($stdoutPath, $stderrPath)) {
-            $item = Get-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
-            if ($null -ne $item -and [int64]$item.Length -gt $OutputMaximumBytes) {
-                $outputLimitExceeded = $true
-                $terminationReason = "output exceeded $OutputMaximumBytes bytes"
-                break
-            }
-        }
-        if ($timedOut -or $outputLimitExceeded) {
-            $jobProcessID = 0
-            if (Test-Path -LiteralPath $pidPath -PathType Leaf) {
-                [void][int]::TryParse(([System.IO.File]::ReadAllText($pidPath).Trim()), [ref]$jobProcessID)
-            }
-            if ($jobProcessID -gt 0 -and $job.State -notin @("Completed", "Failed", "Stopped")) {
-                $taskkill = Join-Path $env:SystemRoot "System32\taskkill.exe"
-                $previousErrorActionPreference = $ErrorActionPreference
-                try {
-                    $ErrorActionPreference = "Continue"
-                    & $taskkill /PID $jobProcessID /T /F 1>$null 2>$null
-                } finally {
-                    $ErrorActionPreference = $previousErrorActionPreference
-                }
-            }
-            Wait-Job -Job $job -Timeout 10 | Out-Null
-            if ($job.State -notin @("Completed", "Failed", "Stopped")) {
-                Stop-Job -Job $job -ErrorAction SilentlyContinue
-            }
-            $exitCode = if ($timedOut) { 124 } else { 125 }
-        } elseif ($job.State -eq "Completed") {
-            $jobOutput = @(Receive-Job -Job $job -ErrorAction SilentlyContinue)
-            if ($jobOutput.Count -gt 0) { $exitCode = [int]$jobOutput[-1] }
-        } else {
-            $terminationReason = "command job ended in state $($job.State)"
-        }
-    } finally {
-        if ($null -ne $job) {
-            if ($job.State -notin @("Completed", "Failed", "Stopped")) { Stop-Job -Job $job -ErrorAction SilentlyContinue }
-            Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
-        }
-        Remove-Item -LiteralPath $pidPath -Force -ErrorAction SilentlyContinue
+        $commandResult = [InfiniteYou.ReleaseSmoke.ProcessRunner]::Run(
+            $FilePath, @($ArgumentList), $workingDirectory, $stdoutPath, $stderrPath,
+            $TimeoutSeconds, $OutputMaximumBytes)
     }
-    $stopwatch.Stop()
+    finally { $stopwatch.Stop() }
     $stdout = Protect-SmokeOutput $stdoutPath $OutputMaximumBytes
     $stderr = Protect-SmokeOutput $stderrPath $OutputMaximumBytes
+    $terminationReason = if ($commandResult.TimedOut) {
+        "deadline of $TimeoutSeconds seconds exceeded"
+    } elseif ($commandResult.OutputLimitExceeded) {
+        "output exceeded $OutputMaximumBytes bytes"
+    } else {
+        ""
+    }
     return [pscustomobject][ordered]@{
         file = $FilePath
         arguments = @($ArgumentList)
-        exitCode = $exitCode
-        timedOut = $timedOut
-        outputLimitExceeded = $outputLimitExceeded
+        exitCode = [int]$commandResult.ExitCode
+        timedOut = [bool]$commandResult.TimedOut
+        outputLimitExceeded = [bool]$commandResult.OutputLimitExceeded
         terminationReason = $terminationReason
         elapsedMilliseconds = [int64][Math]::Max(0, $stopwatch.ElapsedMilliseconds)
         stdout = $stdout.text
@@ -512,17 +652,159 @@ function Get-SmokeAvailablePort {
     try { $listener.Start(); return [int]$listener.LocalEndpoint.Port } finally { $listener.Stop() }
 }
 
+function Get-SmokeActivitySnapshot {
+    param([string]$Name, [string]$Path)
+    $resolved = Resolve-SmokePath $Path
+    $item = Get-Item -LiteralPath $resolved -Force -ErrorAction SilentlyContinue
+    if ($null -eq $item) {
+        return [pscustomobject][ordered]@{
+            name = $Name
+            path = $resolved
+            exists = $false
+            bytes = [int64]0
+        }
+    }
+    if (-not $item.PSIsContainer -or (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+        Fail-Smoke "$Name activity root is not a regular directory: $resolved"
+    }
+    return [pscustomobject][ordered]@{
+        name = $Name
+        path = $resolved
+        exists = $true
+        bytes = [int64](Get-SmokeDirectoryBytes -Path $resolved -RejectReparsePoint)
+    }
+}
+
+function Test-SmokeModelInvokeArguments {
+    param([string[]]$Arguments)
+    $values = @($Arguments)
+    for ($index = 0; $index -lt ($values.Count - 1); $index++) {
+        if ([string]$values[$index] -ieq "models" -and [string]$values[$index + 1] -ieq "invoke") {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Get-SmokeRuntimeActivity {
+    param([string]$Path)
+    $resolved = Resolve-SmokePath $Path
+    $item = Get-Item -LiteralPath $resolved -Force -ErrorAction SilentlyContinue
+    if ($null -eq $item) {
+        return [pscustomobject][ordered]@{
+            path = $resolved
+            exists = $false
+            bytes = [int64]0
+            records = 0
+            backendProcessStarts = 0
+        }
+    }
+    [void](Assert-SmokeRegularFile "model runtime evidence" $resolved)
+    $records = 0
+    $backendProcessStarts = 0
+    foreach ($line in [System.IO.File]::ReadAllLines($resolved)) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        try {
+            $record = $line | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            Fail-Smoke "model runtime evidence contains invalid JSON: $($_.Exception.Message)"
+        }
+        if ($null -eq $record) { Fail-Smoke "model runtime evidence contains an empty record" }
+        $records++
+        $kindProperty = $record.PSObject.Properties["kind"]
+        $phaseProperty = $record.PSObject.Properties["phase"]
+        $kind = if ($null -eq $kindProperty) { "" } else { [string]$kindProperty.Value }
+        $phase = if ($null -eq $phaseProperty) { "" } else { [string]$phaseProperty.Value }
+        if ($kind -eq "MANAGED_CHILD" -and $phase -eq "PROCESS_STARTED") { $backendProcessStarts++ }
+    }
+    return [pscustomobject][ordered]@{
+        path = $resolved
+        exists = $true
+        bytes = [int64]$item.Length
+        records = [int]$records
+        backendProcessStarts = [int]$backendProcessStarts
+    }
+}
+
+function Get-SmokeModelActivity {
+    param(
+        [object[]]$Before,
+        [object[]]$After,
+        [object[]]$Commands,
+        [string]$RuntimeEvidencePath
+    )
+    $beforeSnapshots = @($Before)
+    $afterSnapshots = @($After)
+    if ($beforeSnapshots.Count -eq 0 -or $beforeSnapshots.Count -ne $afterSnapshots.Count) {
+        Fail-Smoke "model activity observation has incomplete cache boundaries"
+    }
+    $beforeBytes = [int64]0
+    $afterBytes = [int64]0
+    $cacheRoots = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($snapshot in $beforeSnapshots) { $beforeBytes += [int64]$snapshot.bytes }
+    foreach ($snapshot in $afterSnapshots) {
+        $afterBytes += [int64]$snapshot.bytes
+        [void]$cacheRoots.Add([string]$snapshot.path)
+    }
+    if ($afterBytes -lt $beforeBytes) {
+        Fail-Smoke "model activity cache bytes decreased during observation"
+    }
+    $modelInvokeCommands = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($command in @($Commands)) {
+        if (Test-SmokeModelInvokeArguments -Arguments @($command.arguments)) {
+            [void]$modelInvokeCommands.Add(([string[]]@($command.arguments) -join " "))
+        }
+    }
+    $runtime = Get-SmokeRuntimeActivity $RuntimeEvidencePath
+    $cacheDelta = [int64]($afterBytes - $beforeBytes)
+    return [pscustomobject][ordered]@{
+        observed = $true
+        cacheRoots = @($cacheRoots)
+        cacheBytesBefore = $beforeBytes
+        cacheBytesAfter = $afterBytes
+        cacheBytesDelta = $cacheDelta
+        modelCalls = [int]$modelInvokeCommands.Count
+        modelInvokeCommands = @($modelInvokeCommands)
+        modelBackendDownloadBytes = $cacheDelta
+        runtimeEvidencePath = $runtime.path
+        runtimeEvidenceObserved = [bool]$runtime.exists
+        runtimeEvidenceRecords = [int]$runtime.records
+        backendProcessStarts = [int]$runtime.backendProcessStarts
+    }
+}
+
+function Assert-SmokeNoModelActivity {
+    param([object]$Activity)
+    if ($null -eq $Activity -or -not [bool]$Activity.observed) {
+        Fail-Smoke "model activity observation was unavailable"
+    }
+    if ([int]$Activity.modelCalls -ne 0 -or
+        [int64]$Activity.modelBackendDownloadBytes -ne 0 -or
+        [int64]$Activity.cacheBytesAfter -ne 0 -or
+        [int]$Activity.runtimeEvidenceRecords -ne 0 -or
+        [int]$Activity.backendProcessStarts -ne 0) {
+        $details = $Activity | ConvertTo-Json -Compress -Depth 8
+        Fail-Smoke "unexpected model or backend activity was observed: $details"
+    }
+}
+
 function Start-CandidateFileServer {
     param([string]$InstallerPath, [string]$ArchivePath, [string]$ChecksumPath, [string]$Version, [string]$ReadyPath)
     $port = Get-SmokeAvailablePort
+    $eventName = "Infinite-You-Candidate-Ready-" + [System.Guid]::NewGuid().ToString("N")
+    $createdNew = $false
+    $readyEvent = [System.Threading.EventWaitHandle]::new(
+        $false, [System.Threading.EventResetMode]::ManualReset, $eventName, [ref]$createdNew)
     $job = Start-Job -ScriptBlock {
-        param($Port, $InstallerPath, $ArchivePath, $ChecksumPath, $Version, $ReadyPath)
+        param($Port, $InstallerPath, $ArchivePath, $ChecksumPath, $Version, $ReadyPath, $EventName)
         $ErrorActionPreference = "Stop"
         $listener = [System.Net.HttpListener]::new()
+        $ready = [System.Threading.EventWaitHandle]::OpenExisting($EventName)
         $listener.Prefixes.Add("http://127.0.0.1:$Port/")
         try {
             $listener.Start()
             [System.IO.File]::WriteAllText($ReadyPath, "ready")
+            [void]$ready.Set()
             $routes = @{
                 "/download/v$Version/install.ps1" = $InstallerPath
                 "/releases/download/v$Version/$([System.IO.Path]::GetFileName($ArchivePath))" = $ArchivePath
@@ -539,26 +821,29 @@ function Start-CandidateFileServer {
                 $context.Response.OutputStream.Write($bytes, 0, $bytes.Length)
                 $context.Response.Close()
             }
+        } catch {
+            try { [void]$ready.Set() } catch { }
+            throw
         } finally {
+            try { $ready.Close() } catch { }
             if ($listener.IsListening) { $listener.Stop() }
             $listener.Close()
         }
-    } -ArgumentList $port, $InstallerPath, $ArchivePath, $ChecksumPath, $Version, $ReadyPath
-    $deadline = [DateTime]::UtcNow.AddSeconds(10)
-    while (-not (Test-Path -LiteralPath $ReadyPath -PathType Leaf) -and [DateTime]::UtcNow -lt $deadline) {
-        if ($job.State -in @("Failed", "Completed", "Stopped")) {
-            $details = Receive-Job -Job $job -Keep -ErrorAction SilentlyContinue | Out-String
-            Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
-            Fail-Smoke "candidate file server stopped before readiness: $details"
-        }
-        Start-Sleep -Milliseconds 25
+    } -ArgumentList $port, $InstallerPath, $ArchivePath, $ChecksumPath, $Version, $ReadyPath, $eventName
+    if (-not $readyEvent.WaitOne(10000)) {
+        $details = Receive-Job -Job $job -Keep -ErrorAction SilentlyContinue | Out-String
+        Stop-Job -Job $job -ErrorAction SilentlyContinue
+        Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+        $readyEvent.Close()
+        Fail-Smoke "candidate file server did not become ready: $details"
     }
     if (-not (Test-Path -LiteralPath $ReadyPath -PathType Leaf)) {
         Stop-Job -Job $job -ErrorAction SilentlyContinue
         Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
-        Fail-Smoke "candidate file server did not become ready"
+        $readyEvent.Close()
+        Fail-Smoke "candidate file server signaled readiness without its marker"
     }
-    return [pscustomobject]@{ job = $job; port = $port; baseUrl = "http://127.0.0.1:$port" }
+    return [pscustomobject]@{ job = $job; readyEvent = $readyEvent; port = $port; baseUrl = "http://127.0.0.1:$port" }
 }
 
 function Stop-CandidateFileServer {
@@ -570,6 +855,7 @@ function Stop-CandidateFileServer {
     } finally {
         if ($Server.job.State -notin @("Completed", "Failed", "Stopped")) { Stop-Job -Job $Server.job -ErrorAction SilentlyContinue }
         Remove-Job -Job $Server.job -Force -ErrorAction SilentlyContinue
+        if ($null -ne $Server.readyEvent) { $Server.readyEvent.Close() }
     }
 }
 
@@ -600,7 +886,10 @@ function Invoke-InstalledCandidateSmoke {
     $pathRoot = Join-Path $smokeRoot "path"
     $modelsRoot = Join-Path $smokeRoot "models"
     $hfRoot = Join-Path $smokeRoot "hf"
-    foreach ($path in @($homeRoot, $profileRoot, $tempRoot, $pathRoot)) {
+    $cacheRoot = Join-Path $smokeRoot "cache"
+    $moduleAnalysisCacheRoot = Join-Path $smokeRoot "module-analysis-cache"
+    $runtimeEvidencePath = Join-Path $smokeRoot "model-runtime-evidence.jsonl"
+    foreach ($path in @($homeRoot, $profileRoot, $tempRoot, $pathRoot, $modelsRoot, $hfRoot, $cacheRoot, $moduleAnalysisCacheRoot)) {
         [void][System.IO.Directory]::CreateDirectory($path)
     }
     $readyPath = Join-Path $smokeRoot "server.ready"
@@ -610,7 +899,9 @@ function Invoke-InstalledCandidateSmoke {
         "TEMP", "TMP", "PATH", "XDG_CONFIG_HOME", "XDG_CACHE_HOME",
         "INFINITE_YOU_VERSION", "INFINITE_YOU_INSTALL_DIR", "INFINITE_YOU_INSTALL_OS",
         "INFINITE_YOU_INSTALL_ARCH", "INFINITE_YOU_INSTALL_BASE_URL",
-        "INFINITE_YOU_OMNIVOICE_CACHE_DIR", "HUGGINGFACE_HUB_CACHE", "HF_HOME"
+        "INFINITE_YOU_OMNIVOICE_CACHE_DIR", "HUGGINGFACE_HUB_CACHE", "HF_HOME",
+        "INFINITE_YOU_INTEGRATION_MODEL_RUNTIME_EVIDENCE", "PSModuleAnalysisCachePath",
+        "HF_HUB_DISABLE_TELEMETRY"
     )
     $originalEnvironment = @{}
     foreach ($name in $environmentNames) {
@@ -633,7 +924,7 @@ function Invoke-InstalledCandidateSmoke {
         $env:HOMEDRIVE = $profileDrive.TrimEnd('\')
         $env:HOMEPATH = $profileRoot.Substring($profileDrive.Length - 1)
         $env:APPDATA = Join-Path $profileRoot "AppData\Roaming"
-        $env:LOCALAPPDATA = Join-Path $profileRoot "AppData\Local"
+        $env:LOCALAPPDATA = $cacheRoot
         $env:TEMP = $tempRoot
         $env:TMP = $tempRoot
         $env:PATH = $pathRoot
@@ -647,6 +938,15 @@ function Invoke-InstalledCandidateSmoke {
         $env:INFINITE_YOU_OMNIVOICE_CACHE_DIR = $modelsRoot
         $env:HUGGINGFACE_HUB_CACHE = $hfRoot
         $env:HF_HOME = $hfRoot
+        $env:INFINITE_YOU_INTEGRATION_MODEL_RUNTIME_EVIDENCE = $runtimeEvidencePath
+        $env:PSModuleAnalysisCachePath = Join-Path $moduleAnalysisCacheRoot "ModuleAnalysisCache"
+        $env:HF_HUB_DISABLE_TELEMETRY = "1"
+        $cacheRoots = @(
+            Get-SmokeActivitySnapshot "managed-model-cache" $modelsRoot
+            Get-SmokeActivitySnapshot "huggingface-backend-cache" $hfRoot
+            Get-SmokeActivitySnapshot "redirected-local-cache" $cacheRoot
+        )
+        $activityBefore = @($cacheRoots)
         $downloadedInstaller = Join-Path $smokeRoot "install.ps1"
         Invoke-WebRequest -Uri "$($server.baseUrl)/download/v$Version/install.ps1" -OutFile $downloadedInstaller -UseBasicParsing
         $installerLiteral = "'" + $downloadedInstaller.Replace("'", "''") + "'"
@@ -762,6 +1062,14 @@ function Invoke-InstalledCandidateSmoke {
                 Fail-Smoke "discovery wrote model or backend content under $path"
             }
         }
+        $activityAfter = @(
+            Get-SmokeActivitySnapshot "managed-model-cache" $modelsRoot
+            Get-SmokeActivitySnapshot "huggingface-backend-cache" $hfRoot
+            Get-SmokeActivitySnapshot "redirected-local-cache" $cacheRoot
+        )
+        $activity = Get-SmokeModelActivity -Before $activityBefore -After $activityAfter `
+            -Commands @($commands | ForEach-Object { $_ }) -RuntimeEvidencePath $runtimeEvidencePath
+        Assert-SmokeNoModelActivity $activity
         return [pscustomobject][ordered]@{
             status = "PASS"
             installedExecutable = $installedEvidence
@@ -770,8 +1078,9 @@ function Invoke-InstalledCandidateSmoke {
             expectedVersion = $expectedVersion
             executableBuildInfo = $buildInfo
             commands = @($commands | ForEach-Object { $_ })
-            modelCalls = 0
-            modelBackendDownloadBytes = 0
+            activity = $activity
+            modelCalls = [int]$activity.modelCalls
+            modelBackendDownloadBytes = [int64]$activity.modelBackendDownloadBytes
         }
     } finally {
         Stop-CandidateFileServer $server
@@ -780,6 +1089,50 @@ function Invoke-InstalledCandidateSmoke {
         }
         Remove-SmokeOwnedTree "install directory" $installDir
     }
+}
+
+function Finalize-SmokeCandidateReport {
+    param(
+        [string]$OutputDirectory,
+        [string]$ReportPath,
+        [System.Collections.IDictionary]$Report,
+        [System.Exception]$Failure
+    )
+    if ($Report.cleanup.status -eq "PASS" -and @($Report.artifacts).Count -gt 0) {
+        $retainedEvidenceStable = $true
+        $retainedEvidenceErrors = New-Object 'System.Collections.Generic.List[string]'
+        foreach ($artifact in @($Report.artifacts)) {
+            try {
+                $artifactPath = Join-Path $OutputDirectory ([string]$artifact.file)
+                $currentEvidence = Get-SmokeFileEvidence ([string]$artifact.role) $artifactPath
+                if ($currentEvidence.bytes -ne [int64]$artifact.bytes -or
+                    $currentEvidence.sha256 -cne [string]$artifact.sha256) {
+                    $retainedEvidenceStable = $false
+                    [void]$retainedEvidenceErrors.Add("$($artifact.role) changed after retention")
+                }
+            } catch {
+                $retainedEvidenceStable = $false
+                [void]$retainedEvidenceErrors.Add("$($artifact.role): $($_.Exception.Message)")
+            }
+        }
+        $Report.cleanup.retainedEvidenceHashesStable = $retainedEvidenceStable
+        if (-not $retainedEvidenceStable) {
+            $Report.cleanup.status = "FAIL"
+            $Report.cleanup.retainedEvidenceError = $retainedEvidenceErrors -join "; "
+            if ($null -eq $Failure) {
+                $Failure = [System.Exception]::new("retained candidate evidence was missing or changed during install smoke cleanup")
+            }
+            $Report.status = "FAIL"
+            if ([string]::IsNullOrWhiteSpace([string]$Report.error)) { $Report.error = $Failure.Message }
+        }
+    }
+    [void][System.IO.Directory]::CreateDirectory((Split-Path -Parent $ReportPath))
+    $Report | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $ReportPath -Encoding UTF8
+    $reportEvidence = Get-SmokeFileEvidence "candidate-report" $ReportPath
+    $reportDigestPath = Join-Path $OutputDirectory "candidate-report.sha256"
+    $reportDigest = "$($reportEvidence.sha256)  $([System.IO.Path]::GetFileName($ReportPath))`n"
+    [System.IO.File]::WriteAllText($reportDigestPath, $reportDigest, [System.Text.UTF8Encoding]::new($false))
+    return [pscustomobject][ordered]@{ report = $Report; failure = $Failure }
 }
 
 function Invoke-LocalCandidateSmoke {
@@ -1068,29 +1421,9 @@ function Invoke-LocalCandidateSmoke {
             if ($null -eq $failure) { $failure = $_.Exception }
             $report.status = "FAIL"
         }
-        if ($report.cleanup.status -eq "PASS" -and @($report.artifacts).Count -gt 0) {
-            $retainedEvidenceStable = $true
-            foreach ($artifact in @($report.artifacts)) {
-                $artifactPath = Join-Path $outputDirectory ([string]$artifact.file)
-                $currentEvidence = Get-SmokeFileEvidence ([string]$artifact.role) $artifactPath
-                if ($currentEvidence.bytes -ne [int64]$artifact.bytes -or $currentEvidence.sha256 -cne [string]$artifact.sha256) {
-                    $retainedEvidenceStable = $false
-                    break
-                }
-            }
-            $report.cleanup.retainedEvidenceHashesStable = $retainedEvidenceStable
-            if (-not $retainedEvidenceStable) {
-                $report.cleanup.status = "FAIL"
-                if ($null -eq $failure) { $failure = [System.Exception]::new("retained candidate evidence changed during install smoke cleanup") }
-                $report.status = "FAIL"
-            }
-        }
-        [void][System.IO.Directory]::CreateDirectory((Split-Path -Parent $reportPath))
-        $report | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $reportPath -Encoding UTF8
-        $reportEvidence = Get-SmokeFileEvidence "candidate-report" $reportPath
-        $reportDigestPath = Join-Path $outputDirectory "candidate-report.sha256"
-        $reportDigest = "$($reportEvidence.sha256)  $([System.IO.Path]::GetFileName($reportPath))`n"
-        [System.IO.File]::WriteAllText($reportDigestPath, $reportDigest, [System.Text.UTF8Encoding]::new($false))
+        $finalized = Finalize-SmokeCandidateReport -OutputDirectory $outputDirectory `
+            -ReportPath $reportPath -Report $report -Failure $failure
+        $failure = $finalized.failure
     }
     if ($null -ne $failure) {
         throw $failure

--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -13,7 +13,13 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-$expectedCandidateCycle = "067"
+$expectedCandidateCycle = "068"
+$expectedCandidateGoVersion = "go1.26.8"
+$expectedObserverQueryMode = "one-full-TCP-table-query-per-interval-filtered-to-owned-process-identities"
+$expectedProcessNetworkGapMilliseconds = 2000
+$expectedDiskGapMilliseconds = 2000
+$expectedDescendantMaximum = 36
+$expectedTemporaryDiskBytesMaximum = [int64]4294967296
 $expectedCandidateSourceRepository = "https://github.com/portpowered/you-agent-factory"
 $expectedCandidateSourceCommit = "059474b2c00915865306a33ca5e3d02b618bb6f0"
 $expectedCandidateSourceTree = "ae5d9c87fbc99a898ad2c11e1409105d78e4a094"
@@ -787,8 +793,8 @@ function Invoke-CandidateSmoke {
         if ([string]::IsNullOrWhiteSpace($version) -or $version -match '[\\/:*?"<>|\s]') {
             Fail-Smoke "candidate version is not a usable release version: $version"
         }
-        if ([string]::IsNullOrWhiteSpace([string]$manifest.build.cliVersion) -or [string]$manifest.build.goreleaserConfigSha256 -notmatch '^[0-9a-f]{64}$' -or $manifest.build.goreleaserVersion -ne "v2.12.7" -or $manifest.build.target.goos -ne "windows" -or $manifest.build.target.goarch -ne "amd64" -or $manifest.build.target.cgoEnabled -ne $false) {
-            Fail-Smoke "candidate build target/tool identity is not windows/amd64 with cgo disabled"
+        if ([string]::IsNullOrWhiteSpace([string]$manifest.build.cliVersion) -or $manifest.build.goVersion -ne $expectedCandidateGoVersion -or [string]$manifest.build.goreleaserConfigSha256 -notmatch '^[0-9a-f]{64}$' -or $manifest.build.goreleaserVersion -ne "v2.12.7" -or $manifest.build.target.goos -ne "windows" -or $manifest.build.target.goarch -ne "amd64" -or $manifest.build.target.cgoEnabled -ne $false) {
+            Fail-Smoke "candidate build identity is not Go $expectedCandidateGoVersion with GoReleaser v2.12.7, windows/amd64 and cgo disabled"
         }
         $requiredEnvironment = [ordered]@{
             GOSUMDB = "off"
@@ -830,13 +836,19 @@ function Invoke-CandidateSmoke {
                 Fail-Smoke "candidate control $($control.Key) = $actualControl, want $($control.Value)"
             }
         }
-        $expectedPriorCycles = @("030", "040", "042", "045", "048", "050")
+        $expectedPriorCycles = @("030", "040", "042", "045", "048", "050", "063", "067")
         $actualPriorCycles = @($manifest.attempts.priorCycles | ForEach-Object { [string]$_ })
         if ($actualPriorCycles.Count -ne $expectedPriorCycles.Count -or (Compare-Object -ReferenceObject $expectedPriorCycles -DifferenceObject $actualPriorCycles)) {
             Fail-Smoke "candidate attempts priorCycles = $($actualPriorCycles -join ', '), want $($expectedPriorCycles -join ', ')"
         }
         if ([int]$manifest.attempts.cycle063BuildMaximum -ne 1 -or [int]$manifest.attempts.cycle063BuildUsed -ne 1) {
             Fail-Smoke "candidate attempts must record cycle063BuildMaximum=1 and cycle063BuildUsed=1"
+        }
+        if ([int]$manifest.attempts.cycle067BuildMaximum -ne 2 -or [int]$manifest.attempts.cycle067BuildUsed -ne 2) {
+            Fail-Smoke "candidate attempts must record cycle067BuildMaximum=2 and cycle067BuildUsed=2"
+        }
+        if ([int]$manifest.attempts.cycle068BuildMaximum -ne 1 -or [int]$manifest.attempts.cycle068BuildUsed -ne 1) {
+            Fail-Smoke "candidate attempts must record cycle068BuildMaximum=1 and cycle068BuildUsed=1"
         }
         $archiveArtifacts = @($manifest.artifacts | Where-Object { $_.role -eq "windows-amd64-archive" })
         $installerArtifacts = @($manifest.artifacts | Where-Object { $_.role -eq "windows-installer" })
@@ -1374,13 +1386,17 @@ function Invoke-ObserverFixture {
     $rootProcess = $null
     $rootExitCode = $null
     $failure = $null
+    $cleanupErrors = New-Object 'System.Collections.Generic.List[string]'
+    $remainingTaskPaths = @()
     $processObservation = [pscustomobject]@{
         status = "FAIL"; startedBeforeRoot = $false; continuedThroughDescendantExit = $false
-        maximumGapMilliseconds = 0; nonLoopbackConnections = 0; externalTransferBytes = 0; descendantHighWater = 0
+        maximumGapMilliseconds = [int64]0; nonLoopbackConnections = 0; externalTransferBytes = [int64]0; descendantHighWater = [int64]0
+        sampleCount = 0; tcpTableQueries = 0; zeroConnectionSamples = 0; ownedConnectionMatches = 0
+        ownedProcessIdentityCount = 0; queryMode = $expectedObserverQueryMode; forbiddenProcesses = @(); error = ""
     }
     $diskObservation = [pscustomobject]@{
         status = "FAIL"; independent = $false; startPeriodicFinal = $false
-        maximumGapMilliseconds = 0; peakDeltaBytes = 0
+        maximumGapMilliseconds = [int64]0; peakDeltaBytes = [int64]0; error = ""
     }
     $goEnvironment = [ordered]@{
         GOFLAGS = [string]$env:GOFLAGS
@@ -1391,81 +1407,225 @@ function Invoke-ObserverFixture {
         $processJob = Start-Job -ScriptBlock {
             param($ReadyPath, $PidPath, $DonePath)
             $ErrorActionPreference = "Stop"
-            $startedAt = [DateTime]::UtcNow
+            $processNetworkGapMaximumMilliseconds = [int64]2000
+            $descendantMaximum = [int64]36
+            $queryMode = "one-full-TCP-table-query-per-interval-filtered-to-owned-process-identities"
+            $forbiddenNamePatterns = @("localai", "local-ai", "llama-server", "llama-cli", "vibevoice", "whisper", "piper")
             [System.IO.File]::WriteAllText($ReadyPath, "ready")
-            function Get-ObserverTree {
+            function Convert-ObserverCreationTimeTicks {
+                param($Value)
+
+                if ($Value -is [DateTime]) {
+                    return [int64]$Value.ToUniversalTime().Ticks
+                }
+                try {
+                    $date = [System.Management.ManagementDateTimeConverter]::ToDateTime([string]$Value)
+                } catch {
+                    throw "process creation time is not readable: $Value"
+                }
+                return [int64]$date.ToUniversalTime().Ticks
+            }
+            function Get-ObserverProcessSnapshot {
                 param([int]$RootId)
                 $all = @(Get-CimInstance -ClassName Win32_Process -ErrorAction Stop)
+                $byId = @{}
                 $children = @{}
                 foreach ($item in $all) {
+                    $processId = [int]$item.ProcessId
+                    if ($byId.ContainsKey($processId)) {
+                        throw "process identity is ambiguous for PID $processId"
+                    }
+                    $creationTicks = Convert-ObserverCreationTimeTicks $item.CreationDate
+                    $record = [pscustomobject]@{
+                        processId = $processId
+                        parentProcessId = [int]$item.ParentProcessId
+                        identity = "$processId/$creationTicks"
+                        name = [string]$item.Name
+                    }
+                    $byId[$processId] = $record
                     $parent = [int]$item.ParentProcessId
                     if (-not $children.ContainsKey($parent)) { $children[$parent] = @() }
-                    $children[$parent] += [int]$item.ProcessId
+                    $children[$parent] = @($children[$parent]) + $processId
                 }
-                $pending = @($RootId)
-                $descendants = @()
-                while ($pending.Count -gt 0) {
-                    $parent = [int]$pending[0]
-                    $pending = if ($pending.Count -eq 1) { @() } else { @($pending[1..($pending.Count - 1)]) }
-                    if (-not $children.ContainsKey($parent)) { continue }
-                    foreach ($child in @($children[$parent])) {
-                        if ($descendants -notcontains [int]$child) {
-                            $descendants += [int]$child
-                            $pending += [int]$child
-                        }
+                if (-not $byId.ContainsKey($RootId)) {
+                    return [pscustomobject]@{
+                        rootPresent = $false
+                        root = $null
+                        descendants = @()
+                        ownedRecords = @()
                     }
                 }
+                $pending = [System.Collections.Generic.Queue[int]]::new()
+                $visited = @{$RootId = $true}
+                $descendants = New-Object 'System.Collections.Generic.List[object]'
+                $ownedRecords = New-Object 'System.Collections.Generic.List[object]'
+                $root = $byId[$RootId]
+                [void]$ownedRecords.Add($root)
+                $pending.Enqueue($RootId)
+                while ($pending.Count -gt 0) {
+                    $parent = $pending.Dequeue()
+                    if (-not $children.ContainsKey($parent)) { continue }
+                    foreach ($childId in @($children[$parent])) {
+                        $childId = [int]$childId
+                        if ($visited.ContainsKey($childId)) {
+                            throw "owned process tree is ambiguous at PID $childId"
+                        }
+                        if (-not $byId.ContainsKey($childId)) {
+                            throw "owned process tree lost PID $childId during enumeration"
+                        }
+                        $visited[$childId] = $true
+                        $child = $byId[$childId]
+                        [void]$descendants.Add($child)
+                        [void]$ownedRecords.Add($child)
+                        $pending.Enqueue($childId)
+                    }
+                }
+                if ($descendants.Count -gt $descendantMaximum) {
+                    throw "owned descendant count $($descendants.Count) exceeds $descendantMaximum"
+                }
                 [pscustomobject]@{
-                    rootPresent = @($all | Where-Object { [int]$_.ProcessId -eq $RootId }).Count -ne 0
-                    descendantIds = @($descendants)
+                    rootPresent = $true
+                    root = $root
+                    descendants = $descendants.ToArray()
+                    ownedRecords = $ownedRecords.ToArray()
                 }
             }
+            function Register-ObserverIdentities {
+                param(
+                    [object]$Snapshot,
+                    [hashtable]$IdentityByPid,
+                    [hashtable]$OwnedIdentityToPid,
+                    [hashtable]$State
+                )
+
+                foreach ($record in @($Snapshot.ownedRecords)) {
+                    $processId = [int]$record.processId
+                    $identity = [string]$record.identity
+                    if ($IdentityByPid.ContainsKey($processId) -and [string]$IdentityByPid[$processId] -cne $identity) {
+                        throw "owned process PID $processId changed identity from $($IdentityByPid[$processId]) to $identity"
+                    }
+                    if ($OwnedIdentityToPid.ContainsKey($identity) -and [int]$OwnedIdentityToPid[$identity] -ne $processId) {
+                        throw "owned process identity $identity is ambiguous across PIDs"
+                    }
+                    $IdentityByPid[$processId] = $identity
+                    $OwnedIdentityToPid[$identity] = $processId
+                }
+                if ($Snapshot.rootPresent) {
+                    $identity = [string]$Snapshot.root.identity
+                    if ($null -eq $State["rootIdentity"]) {
+                        $State["rootIdentity"] = $identity
+                    } elseif ([string]$State["rootIdentity"] -cne $identity) {
+                        throw "owned root identity changed from $($State['rootIdentity']) to $identity"
+                    }
+                }
+            }
+            function Test-ObserverLoopbackAddress {
+                param([string]$Address)
+
+                return $Address.Trim().ToLowerInvariant() -in @("127.0.0.1", "::1", "0:0:0:0:0:0:0:1", "::ffff:127.0.0.1")
+            }
             function Get-ObserverSample {
-                param([int]$RootId)
+                param(
+                    [int]$RootId,
+                    [hashtable]$IdentityByPid,
+                    [hashtable]$OwnedIdentityToPid,
+                    [hashtable]$State
+                )
                 if ($null -eq (Get-Command Get-NetTCPConnection -ErrorAction SilentlyContinue)) {
                     throw "Get-NetTCPConnection is unavailable"
                 }
-                $tree = Get-ObserverTree $RootId
+                $before = Get-ObserverProcessSnapshot $RootId
+                Register-ObserverIdentities $before $IdentityByPid $OwnedIdentityToPid $State
+                # One complete TCP-table query is deliberately shared by every
+                # owned process in this interval; an empty table is a valid sample.
+                $connections = @(Get-NetTCPConnection -ErrorAction Stop)
+                $after = Get-ObserverProcessSnapshot $RootId
+                Register-ObserverIdentities $after $IdentityByPid $OwnedIdentityToPid $State
+                $ownedPids = @{}
+                foreach ($record in @($before.ownedRecords) + @($after.ownedRecords)) {
+                    $ownedPids[[int]$record.processId] = [string]$record.identity
+                }
                 $nonLoopback = 0
-                foreach ($processId in @($RootId) + @($tree.descendantIds)) {
-                    foreach ($connection in @(Get-NetTCPConnection -OwningProcess $processId -ErrorAction SilentlyContinue)) {
-                        $remote = [string]$connection.RemoteAddress
-                        if ($remote -notin @("127.0.0.1", "::1", "0:0:0:0:0:0:0:1")) { $nonLoopback++ }
+                $ownedMatches = 0
+                foreach ($connection in @($connections)) {
+                    if ($null -eq $connection.OwningProcess) {
+                        throw "TCP-table row has no owning process identity"
+                    }
+                    $processId = [int]$connection.OwningProcess
+                    if (-not $ownedPids.ContainsKey($processId)) {
+                        continue
+                    }
+                    $ownedMatches++
+                    if ([string]$connection.State -ne "Listen" -and -not (Test-ObserverLoopbackAddress ([string]$connection.RemoteAddress))) {
+                        $nonLoopback++
                     }
                 }
+                $forbiddenProcesses = @($before.ownedRecords + $after.ownedRecords | Where-Object {
+                    $name = ([string]$_.name).ToLowerInvariant()
+                    $forbiddenNamePatterns | Where-Object { $name -like "*$_*" }
+                } | ForEach-Object { "{0}:{1}" -f $_.processId, $_.name } | Sort-Object -Unique)
+                if ($forbiddenProcesses.Count -ne 0) {
+                    throw "forbidden owned process observed: $($forbiddenProcesses -join ', ')"
+                }
+                if ($nonLoopback -ne 0) {
+                    throw "non-loopback connection observed in owned TCP sample"
+                }
                 [pscustomobject]@{
-                    rootPresent = [bool]$tree.rootPresent
-                    descendantCount = [int]$tree.descendantIds.Count
-                    descendantIds = @($tree.descendantIds)
+                    rootPresent = [bool]$after.rootPresent
+                    descendantCount = [int]$after.descendants.Count
                     nonLoopbackConnections = [int]$nonLoopback
+                    ownedConnectionMatches = [int]$ownedMatches
+                    tcpRows = [int]$connections.Count
+                    tcpTableQueries = 1
+                    ownedProcessIdentityCount = [int]$OwnedIdentityToPid.Count
+                    forbiddenProcesses = $forbiddenProcesses
                 }
             }
+            $identityByPid = @{}
+            $ownedIdentityToPid = @{}
+            $observerState = @{rootIdentity = $null}
+            $maximumGap = [int64]0
+            $samples = 0
+            $descendantHighWater = [int64]0
+            $nonLoopbackConnections = 0
+            $tcpTableQueries = 0
+            $zeroConnectionSamples = 0
+            $ownedConnectionMatches = 0
             try {
                 $deadline = [DateTime]::UtcNow.AddSeconds(20)
                 while (-not (Test-Path -LiteralPath $PidPath) -and [DateTime]::UtcNow -lt $deadline) { Start-Sleep -Milliseconds 25 }
                 if (-not (Test-Path -LiteralPath $PidPath)) { throw "root PID was not published" }
                 $rootId = [int]([System.IO.File]::ReadAllText($PidPath)).Trim()
-                $previous = [DateTime]::UtcNow
-                $maximumGap = [int64]0
-                $samples = 0
-                $descendantHighWater = [int64]0
-                $nonLoopbackConnections = 0
+                $previous = $null
                 $rootExited = $false
                 $continuedThroughExit = $false
                 while ([DateTime]::UtcNow -lt $deadline) {
-                    $sample = Get-ObserverSample $rootId
+                    $sample = Get-ObserverSample $rootId $identityByPid $ownedIdentityToPid $observerState
                     $now = [DateTime]::UtcNow
-                    $gap = [int64]($now - $previous).TotalMilliseconds
-                    if ($gap -gt $maximumGap) { $maximumGap = $gap }
+                    if ($null -ne $previous) {
+                        $gap = [int64]($now - $previous).TotalMilliseconds
+                        if ($gap -gt $maximumGap) { $maximumGap = $gap }
+                        if ($gap -gt $processNetworkGapMaximumMilliseconds) {
+                            throw "process/network observer gap $gap ms exceeds $processNetworkGapMaximumMilliseconds ms"
+                        }
+                    }
                     $previous = $now
                     $samples++
                     if ($sample.descendantCount -gt $descendantHighWater) { $descendantHighWater = $sample.descendantCount }
+                    if ($sample.descendantCount -gt $descendantMaximum) { throw "owned descendant count $($sample.descendantCount) exceeds $descendantMaximum" }
                     $nonLoopbackConnections += [int]$sample.nonLoopbackConnections
+                    $tcpTableQueries += [int]$sample.tcpTableQueries
+                    $ownedConnectionMatches += [int]$sample.ownedConnectionMatches
+                    if ([int]$sample.ownedConnectionMatches -eq 0) { $zeroConnectionSamples++ }
+                    if ([int]$sample.nonLoopbackConnections -ne 0) { throw "non-loopback connection observed in owned TCP sample" }
                     if (Test-Path -LiteralPath $DonePath) { $rootExited = $true }
                     if ($rootExited -and -not $sample.rootPresent -and $sample.descendantCount -eq 0) {
+                        if ($null -eq $observerState["rootIdentity"]) { throw "root exited before its owned process identity was captured" }
                         $continuedThroughExit = $true
                         break
                     }
+                    # This is the measurement cadence, not a completion wait;
+                    # completion is decided from the next process/TCP sample.
                     Start-Sleep -Milliseconds 100
                 }
                 if (-not $continuedThroughExit) { throw "observer did not reach root and descendant exit" }
@@ -1473,12 +1633,19 @@ function Invoke-ObserverFixture {
                     status = "PASS"; startedBeforeRoot = $true; continuedThroughDescendantExit = $continuedThroughExit
                     maximumGapMilliseconds = $maximumGap; nonLoopbackConnections = $nonLoopbackConnections
                     externalTransferBytes = [int64]0; descendantHighWater = $descendantHighWater
+                    sampleCount = $samples; tcpTableQueries = $tcpTableQueries
+                    zeroConnectionSamples = $zeroConnectionSamples; ownedConnectionMatches = $ownedConnectionMatches
+                    ownedProcessIdentityCount = [int64]$ownedIdentityToPid.Count; queryMode = $queryMode
+                    forbiddenProcesses = @(); error = ""
                 }
             } catch {
                 [pscustomobject]@{
                     status = "FAIL"; startedBeforeRoot = $true; continuedThroughDescendantExit = $false
-                    maximumGapMilliseconds = [int64]0; nonLoopbackConnections = 0; externalTransferBytes = [int64]0
-                    descendantHighWater = $descendantHighWater
+                    maximumGapMilliseconds = $maximumGap; nonLoopbackConnections = $nonLoopbackConnections; externalTransferBytes = [int64]0
+                    descendantHighWater = $descendantHighWater; sampleCount = $samples; tcpTableQueries = $tcpTableQueries
+                    zeroConnectionSamples = $zeroConnectionSamples; ownedConnectionMatches = $ownedConnectionMatches
+                    ownedProcessIdentityCount = [int64]$ownedIdentityToPid.Count; queryMode = $queryMode
+                    forbiddenProcesses = @(); error = $_.Exception.Message
                 }
             }
         } -ArgumentList $processReadyPath, $pidPath, $donePath
@@ -1486,6 +1653,8 @@ function Invoke-ObserverFixture {
         $diskJob = Start-Job -ScriptBlock {
             param($RootPath, $ReadyPath, $DonePath)
             $ErrorActionPreference = "Stop"
+            $diskGapMaximumMilliseconds = [int64]2000
+            $temporaryDiskMaximum = [int64]4294967296
             function Get-ObserverDirectoryBytes {
                 $total = [int64]0
                 if (-not (Test-Path -LiteralPath $RootPath -PathType Container)) { return $total }
@@ -1495,35 +1664,51 @@ function Invoke-ObserverFixture {
                 }
                 return $total
             }
+            $maximumGap = [int64]0
+            $peakBytes = [int64]0
+            $samples = 0
             try {
                 $startedAt = [DateTime]::UtcNow
                 [System.IO.File]::WriteAllText($ReadyPath, "ready")
-                $previous = $startedAt
+                $previous = $null
                 $initialBytes = $null
-                $peakBytes = [int64]0
-                $maximumGap = [int64]0
-                $samples = 0
                 $finalSample = $false
                 $deadline = $startedAt.AddSeconds(20)
                 while ([DateTime]::UtcNow -lt $deadline) {
                     $bytes = [int64](Get-ObserverDirectoryBytes)
                     $now = [DateTime]::UtcNow
-                    $gap = [int64]($now - $previous).TotalMilliseconds
-                    if ($gap -gt $maximumGap) { $maximumGap = $gap }
+                    if ($null -ne $previous) {
+                        $gap = [int64]($now - $previous).TotalMilliseconds
+                        if ($gap -gt $maximumGap) { $maximumGap = $gap }
+                        if ($gap -gt $diskGapMaximumMilliseconds) {
+                            throw "disk observer gap $gap ms exceeds $diskGapMaximumMilliseconds ms"
+                        }
+                    }
                     $previous = $now
                     if ($null -eq $initialBytes) { $initialBytes = $bytes }
                     if ($bytes -gt $peakBytes) { $peakBytes = $bytes }
+                    if ($peakBytes - $initialBytes -gt $temporaryDiskMaximum) {
+                        throw "disk observer delta $($peakBytes - $initialBytes) exceeds $temporaryDiskMaximum bytes"
+                    }
                     $samples++
                     if (Test-Path -LiteralPath $DonePath) {
                         $bytes = [int64](Get-ObserverDirectoryBytes)
                         $now = [DateTime]::UtcNow
                         $gap = [int64]($now - $previous).TotalMilliseconds
                         if ($gap -gt $maximumGap) { $maximumGap = $gap }
+                        if ($gap -gt $diskGapMaximumMilliseconds) {
+                            throw "disk observer final gap $gap ms exceeds $diskGapMaximumMilliseconds ms"
+                        }
                         if ($bytes -gt $peakBytes) { $peakBytes = $bytes }
+                        if ($peakBytes - $initialBytes -gt $temporaryDiskMaximum) {
+                            throw "disk observer delta $($peakBytes - $initialBytes) exceeds $temporaryDiskMaximum bytes"
+                        }
                         $samples++
                         $finalSample = $true
                         break
                     }
+                    # This is the disk measurement cadence; completion is
+                    # decided from the observed done marker and final sample.
                     Start-Sleep -Milliseconds 100
                 }
                 if ($null -eq $initialBytes -or -not $finalSample) { throw "disk observer did not produce periodic and final samples" }
@@ -1534,12 +1719,14 @@ function Invoke-ObserverFixture {
             } catch {
                 [pscustomobject]@{
                     status = "FAIL"; independent = $true; startPeriodicFinal = $false
-                    maximumGapMilliseconds = [int64]0; peakDeltaBytes = [int64]0; error = $_.Exception.Message
+                    maximumGapMilliseconds = $maximumGap; peakDeltaBytes = [int64]$peakBytes; error = $_.Exception.Message
                 }
             }
         } -ArgumentList $fixtureRoot, $diskReadyPath, $donePath
 
         $readyDeadline = [DateTime]::UtcNow.AddSeconds(10)
+        # Readiness is polled only until both independent observer jobs publish
+        # their ready markers; sampling cadence remains inside each observer.
         while ((-not (Test-Path -LiteralPath $processReadyPath) -or -not (Test-Path -LiteralPath $diskReadyPath)) -and [DateTime]::UtcNow -lt $readyDeadline) { Start-Sleep -Milliseconds 25 }
         if (-not (Test-Path -LiteralPath $processReadyPath) -or -not (Test-Path -LiteralPath $diskReadyPath)) { throw "observers did not start before root" }
 
@@ -1562,26 +1749,39 @@ function Invoke-ObserverFixture {
         $diskObservation = $diskResults[$diskResults.Count - 1]
     } catch {
         $failure = $_.Exception
+        if ($processObservation.error -eq "") { $processObservation.error = $failure.Message }
         $jobStates = @($processJob, $diskJob) | Where-Object { $null -ne $_ } | ForEach-Object { "$($_.Name)=$($_.State)" }
         if ($jobStates.Count -ne 0) { $failure = [System.Exception]::new("$($failure.Message); observer jobs: $($jobStates -join ', ')") }
     } finally {
         if ($null -ne $rootProcess) {
             try {
                 if (-not $rootProcess.HasExited) { & taskkill.exe /PID $rootProcess.Id /T /F | Out-Null }
+                if (-not $rootProcess.HasExited) { [void]$cleanupErrors.Add("root process $($rootProcess.Id) remained running") }
             } catch {
+                [void]$cleanupErrors.Add("root process cleanup: $($_.Exception.Message)")
             }
             try { $rootProcess.Dispose() } catch { }
         }
         foreach ($job in @($processJob, $diskJob)) {
             if ($null -ne $job) {
-                try { if ($job.State -eq "Running") { Stop-Job -Job $job -ErrorAction SilentlyContinue } } catch { }
-                try { Remove-Job -Job $job -Force -ErrorAction SilentlyContinue } catch { }
+                try { if ($job.State -eq "Running") { Stop-Job -Job $job -ErrorAction Stop } } catch { [void]$cleanupErrors.Add("observer job stop: $($_.Exception.Message)") }
+                try {
+                    Wait-Job -Job $job -Timeout 5 -ErrorAction Stop | Out-Null
+                    if ($job.State -in @("Running", "NotStarted")) { [void]$cleanupErrors.Add("observer job $($job.Name) remained $($job.State)") }
+                } catch { [void]$cleanupErrors.Add("observer job wait: $($_.Exception.Message)") }
+                try { Remove-Job -Job $job -Force -ErrorAction Stop } catch { [void]$cleanupErrors.Add("observer job removal: $($_.Exception.Message)") }
             }
         }
-        if (Test-Path -LiteralPath $fixtureRoot) { Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction SilentlyContinue }
+        try {
+            if (Test-Path -LiteralPath $fixtureRoot) { Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction Stop }
+        } catch { [void]$cleanupErrors.Add("fixture root cleanup: $($_.Exception.Message)") }
+        if (Test-Path -LiteralPath $fixtureRoot) { $remainingTaskPaths += $fixtureRoot }
     }
 
-    $observerPass = $goEnvironment.GOFLAGS -eq "-p=4" -and $goEnvironment.GOMAXPROCS -eq "4" -and $processObservation.status -eq "PASS" -and $diskObservation.status -eq "PASS" -and [bool]$diskObservation.startPeriodicFinal
+    if ($cleanupErrors.Count -ne 0 -and $processObservation.error -eq "") {
+        $processObservation.error = $cleanupErrors -join "; "
+    }
+    $observerPass = $goEnvironment.GOFLAGS -eq "-p=4" -and $goEnvironment.GOMAXPROCS -eq "4" -and $processObservation.status -eq "PASS" -and $processObservation.sampleCount -gt 0 -and $processObservation.tcpTableQueries -eq $processObservation.sampleCount -and $processObservation.zeroConnectionSamples -gt 0 -and $processObservation.ownedProcessIdentityCount -gt 0 -and $processObservation.queryMode -eq $expectedObserverQueryMode -and $diskObservation.status -eq "PASS" -and [bool]$diskObservation.startPeriodicFinal -and $processObservation.maximumGapMilliseconds -le $expectedProcessNetworkGapMilliseconds -and $diskObservation.maximumGapMilliseconds -le $expectedDiskGapMilliseconds -and $diskObservation.peakDeltaBytes -le $expectedTemporaryDiskBytesMaximum -and $cleanupErrors.Count -eq 0 -and $remainingTaskPaths.Count -eq 0
     $report = [ordered]@{
         schemaVersion = "localai-windows-install-candidate-observer/v1"
         status = if ($null -eq $failure -and $rootExitCode -eq 0 -and $observerPass) { "PASS" } else { "FAIL" }
@@ -1596,6 +1796,14 @@ function Invoke-ObserverFixture {
                 status = [string]$processObservation.status
                 nonLoopbackConnections = [int]$processObservation.nonLoopbackConnections
                 externalTransferBytes = [int64]$processObservation.externalTransferBytes
+                sampleCount = [int]$processObservation.sampleCount
+                tcpTableQueries = [int]$processObservation.tcpTableQueries
+                zeroConnectionSamples = [int]$processObservation.zeroConnectionSamples
+                ownedConnectionMatches = [int]$processObservation.ownedConnectionMatches
+                ownedProcessIdentityCount = [int]$processObservation.ownedProcessIdentityCount
+                queryMode = [string]$processObservation.queryMode
+                forbiddenProcesses = @($processObservation.forbiddenProcesses)
+                error = [string]$processObservation.error
             }
             diskObserver = [ordered]@{
                 independent = [bool]$diskObservation.independent
@@ -1603,13 +1811,19 @@ function Invoke-ObserverFixture {
                 maximumGapMilliseconds = [int64]$diskObservation.maximumGapMilliseconds
                 status = [string]$diskObservation.status
                 peakDeltaBytes = [int64]$diskObservation.peakDeltaBytes
+                error = [string]$diskObservation.error
             }
-            descendantMaximum = [int64]36
+            descendantMaximum = $expectedDescendantMaximum
             descendantHighWater = [int64]$processObservation.descendantHighWater
             rootExitCode = $rootExitCode
-            failurePropagation = if ($null -eq $failure -and $rootExitCode -eq 0) { "PASS" } else { "FAIL" }
+            failurePropagation = if ($null -eq $failure -and $rootExitCode -eq 0 -and $observerPass) { "PASS" } else { "FAIL" }
             modelBackendBytes = [int64]0
             modelBackendCalls = [int64]0
+        }
+        cleanup = [ordered]@{
+            status = if ($cleanupErrors.Count -eq 0 -and $remainingTaskPaths.Count -eq 0) { "PASS" } else { "FAIL" }
+            remainingTaskPaths = $remainingTaskPaths
+            errors = $cleanupErrors.ToArray()
         }
     }
     $reportParent = Split-Path -Parent $reportPath

--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -12,6 +12,22 @@ param(
     [string]$ObserverRootCommand,
     [string[]]$ObserverRootArgumentList,
     [string]$ObserverRootWorkingDirectory,
+    [string]$ObserverRootStdoutPath,
+    [string]$ObserverRootStderrPath,
+    [int]$ObserverRootOutputMaximumBytes = 1048576,
+    [int]$ObserverRootExitCode = 0,
+    [switch]$StageDependencyClosure,
+    [switch]$VerifyDependencyClosure,
+    [string]$DependencySourceRoot,
+    [string]$DependencyStageRoot,
+    [string]$DependencySourceManifestPath,
+    [string]$DependencyStageManifestPath,
+    [string]$DependencyExpectedManifestPath,
+    [string]$DependencyPostBuildManifestPath,
+    [string]$DependencySourceAfterManifestPath,
+    [string]$DependencyReportPath,
+    [string]$DependencyExpectedLockSHA256 = "45ca702f71dbd8fbf47855dcf8cdb86b13785a009b2c107153ba52e0b20157ad",
+    [string]$DependencyExpectedLockBlob = "d6e4b715db635497bfcac0db085163ea719d21ab",
     [string]$ObserverReleaseCheckoutPath,
     [switch]$PrepareReleaseCheckout,
     [string]$ReleaseCheckoutPath,
@@ -32,6 +48,8 @@ $expectedTemporaryDiskBytesMaximum = [int64]4294967296
 $expectedCandidateSourceRepository = "https://github.com/portpowered/you-agent-factory"
 $expectedCandidateSourceCommit = "059474b2c00915865306a33ca5e3d02b618bb6f0"
 $expectedCandidateSourceTree = "ae5d9c87fbc99a898ad2c11e1409105d78e4a094"
+$expectedDependencyLockSHA256 = "45ca702f71dbd8fbf47855dcf8cdb86b13785a009b2c107153ba52e0b20157ad"
+$expectedDependencyLockBlob = "d6e4b715db635497bfcac0db085163ea719d21ab"
 
 $observerIdentityFunctionSource = @'
 function Register-ObserverIdentities {
@@ -134,6 +152,67 @@ function Get-ObserverGitStatus {
 function Fail-Smoke {
     param([string]$Message)
     throw "install smoke: $Message"
+}
+
+function Get-SmokeRootOutputEvidence {
+    param(
+        [string]$RawPath,
+        [string]$RetainedPath,
+        [int]$MaximumBytes
+    )
+
+    if ($MaximumBytes -le 0) {
+        Fail-Smoke "root output maximum must be positive"
+    }
+    Ensure-SmokeFileHashCommand
+    $rawItem = Get-Item -LiteralPath $RawPath -Force -ErrorAction SilentlyContinue
+    if ($null -eq $rawItem -or $rawItem.PSIsContainer -or (($rawItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+        Fail-Smoke "root output evidence is missing or not a regular file: $RawPath"
+    }
+    $retainedPath = Resolve-SmokeAbsolutePath $RetainedPath
+    $retainedParent = Split-Path -Parent $retainedPath
+    if (-not (Test-Path -LiteralPath $retainedParent -PathType Container)) {
+        Fail-Smoke "root output evidence parent does not exist: $retainedParent"
+    }
+    $rawBytes = [System.IO.File]::ReadAllBytes($RawPath)
+    $totalBytes = [int64]$rawBytes.Length
+    $capturedByteCount = [int][Math]::Min([int64]$MaximumBytes, $totalBytes)
+    $capturedBytes = New-Object byte[] $capturedByteCount
+    if ($capturedByteCount -gt 0) {
+        [System.Array]::Copy($rawBytes, $capturedBytes, $capturedByteCount)
+    }
+    $text = [System.Text.Encoding]::UTF8.GetString($capturedBytes)
+    $redactionPattern = '(?i)(token|password|secret|api[_-]?key|authorization)\s*([:=])\s*[^\s,;]+'
+    $redactedBytes = [int64]0
+    foreach ($match in [System.Text.RegularExpressions.Regex]::Matches($text, $redactionPattern)) {
+        $value = [string]$match.Value
+        $separatorIndex = $value.IndexOfAny([char[]]@(':', '='))
+        if ($separatorIndex -ge 0 -and $separatorIndex + 1 -lt $value.Length) {
+            $redactedValue = $value.Substring($separatorIndex + 1).Trim()
+            $redactedBytes += [int64][System.Text.Encoding]::UTF8.GetByteCount($redactedValue)
+        }
+    }
+    $redactedText = [System.Text.RegularExpressions.Regex]::Replace($text, $redactionPattern, '$1$2<redacted>')
+    [System.IO.File]::WriteAllText($retainedPath, $redactedText, [System.Text.UTF8Encoding]::new($false))
+    $retainedItem = Get-Item -LiteralPath $retainedPath -Force -ErrorAction Stop
+    if ($retainedItem.PSIsContainer -or (($retainedItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+        Fail-Smoke "retained root output evidence is not a regular file: $retainedPath"
+    }
+    try {
+        Remove-Item -LiteralPath $RawPath -Force -ErrorAction Stop
+    } catch {
+        Fail-Smoke "unredacted root output evidence could not be removed: $RawPath; $($_.Exception.Message)"
+    }
+    return [ordered]@{
+        status = "PASS"
+        path = $retainedPath
+        present = $true
+        totalBytes = $totalBytes
+        capturedBytes = [int64]$capturedByteCount
+        truncated = ($totalBytes -gt $MaximumBytes)
+        redactedBytes = $redactedBytes
+        sha256 = ((Get-FileHash -LiteralPath $retainedPath -Algorithm SHA256).Hash.ToLowerInvariant())
+    }
 }
 
 function Ensure-SmokeFileHashCommand {
@@ -316,6 +395,665 @@ function Assert-SmokeDisposableRoot {
     if ($entries.Count -ne 0) {
         Fail-Smoke "declared root '$Name' is not empty: $((($entries | ForEach-Object Name) -join ', '))"
     }
+}
+
+function Assert-SmokeNewEvidenceFile {
+    param(
+        [string]$Name,
+        [string]$RequestedPath
+    )
+
+    $path = Resolve-SmokeAbsolutePath $RequestedPath
+    $parent = Split-Path -Parent $path
+    if (-not (Test-Path -LiteralPath $parent -PathType Container)) {
+        Fail-Smoke "$Name parent does not exist: $parent"
+    }
+    $item = Get-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+    if ($null -ne $item) {
+        Fail-Smoke "$Name already exists; prior evidence cannot be reused: $path"
+    }
+    return $path
+}
+
+function Get-SmokeSHA256 {
+    param([string]$Path)
+
+    $hasher = [System.Security.Cryptography.SHA256]::Create()
+    $stream = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    try {
+        $digest = $hasher.ComputeHash($stream)
+    } finally {
+        $stream.Dispose()
+        $hasher.Dispose()
+    }
+    return ([System.BitConverter]::ToString($digest).Replace("-", "").ToLowerInvariant())
+}
+
+function Get-SmokeRelativePath {
+    param(
+        [string]$RootPath,
+        [string]$CandidatePath,
+        [string]$Role = "path"
+    )
+
+    $root = [System.IO.Path]::GetFullPath($RootPath).TrimEnd([char[]]"\/")
+    $candidate = [System.IO.Path]::GetFullPath($CandidatePath)
+    if ($candidate.Equals($root, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return "."
+    }
+    $prefix = $root + [System.IO.Path]::DirectorySeparatorChar
+    if (-not $candidate.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        Fail-Smoke "$Role resolves outside the contained root: $candidate"
+    }
+    return $candidate.Substring($prefix.Length).Replace([System.IO.Path]::DirectorySeparatorChar, '/')
+}
+
+function Get-SmokeDependencyLinkTarget {
+    param(
+        [object]$Item,
+        [string]$ContainmentRoot
+    )
+
+    $targetProperty = $Item.PSObject.Properties["Target"]
+    $targets = if ($null -eq $targetProperty) { @() } else { @($targetProperty.Value) }
+    if ($targets.Count -ne 1 -or [string]::IsNullOrWhiteSpace([string]$targets[0])) {
+        Fail-Smoke "dependency link has ambiguous or missing target: $($Item.FullName)"
+    }
+    $target = [string]$targets[0]
+    if (-not [System.IO.Path]::IsPathRooted($target)) {
+        $target = Join-Path (Split-Path -Parent $Item.FullName) $target
+    }
+    $target = [System.IO.Path]::GetFullPath($target)
+    $targetItem = Get-Item -LiteralPath $target -Force -ErrorAction SilentlyContinue
+    if ($null -eq $targetItem) {
+        Fail-Smoke "dependency link target is missing: $($Item.FullName) -> $target"
+    }
+    $targetRelative = Get-SmokeRelativePath -RootPath $ContainmentRoot -CandidatePath $target -Role "dependency link target"
+    return [pscustomobject]@{
+        absolute = $target
+        relative = $targetRelative
+    }
+}
+
+function Get-SmokeDependencyLinkItems {
+    param([string]$RootPath)
+
+    $rootItem = Get-Item -LiteralPath $RootPath -Force -ErrorAction Stop
+    $pending = New-Object 'System.Collections.Generic.Queue[string]'
+    $links = New-Object 'System.Collections.Generic.List[object]'
+    $pending.Enqueue($rootItem.FullName)
+    while ($pending.Count -gt 0) {
+        $directory = $pending.Dequeue()
+        foreach ($item in @(Get-ChildItem -LiteralPath $directory -Force -ErrorAction Stop)) {
+            $isReparse = (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)
+            if ($isReparse) {
+                [void]$links.Add($item)
+                continue
+            }
+            if ($item.PSIsContainer) {
+                $pending.Enqueue($item.FullName)
+            }
+        }
+    }
+    return @($links.ToArray())
+}
+
+function Get-SmokeDependencyEntries {
+    param(
+        [string]$RootPath,
+        [string]$ContainmentRoot
+    )
+
+    $rootItem = Get-Item -LiteralPath $RootPath -Force -ErrorAction Stop
+    if (-not $rootItem.PSIsContainer -or (($rootItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+        Fail-Smoke "dependency root is not a regular directory: $RootPath"
+    }
+    $rootFullPath = [System.IO.Path]::GetFullPath($rootItem.FullName)
+    $containmentFullPath = [System.IO.Path]::GetFullPath($ContainmentRoot)
+    $entries = New-Object 'System.Collections.Generic.List[object]'
+    [void]$entries.Add([ordered]@{
+            path = "."
+            type = "directory"
+            bytes = [int64]0
+            sha256 = ""
+            target = $null
+        })
+    $pending = New-Object 'System.Collections.Generic.Queue[string]'
+    $pending.Enqueue($rootFullPath)
+    while ($pending.Count -gt 0) {
+        $directory = $pending.Dequeue()
+        foreach ($item in @(Get-ChildItem -LiteralPath $directory -Force -ErrorAction Stop)) {
+            $relative = Get-SmokeRelativePath -RootPath $rootFullPath -CandidatePath $item.FullName -Role "dependency entry"
+            $isReparse = (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)
+            if ($isReparse) {
+                $linkTypeProperty = $item.PSObject.Properties["LinkType"]
+                $linkType = if ($null -eq $linkTypeProperty) { "" } else { [string]$linkTypeProperty.Value }
+                $link = Get-SmokeDependencyLinkTarget -Item $item -ContainmentRoot $containmentFullPath
+                $type = if ($linkType -eq "Junction") { "junction" } elseif ($linkType -eq "SymbolicLink") { "symlink" } else { "" }
+                if ([string]::IsNullOrWhiteSpace($type)) {
+                    Fail-Smoke "dependency entry has unsupported link type '$linkType': $($item.FullName)"
+                }
+                [void]$entries.Add([ordered]@{
+                        path = $relative
+                        type = $type
+                        bytes = [int64]0
+                        sha256 = ""
+                        target = $link.relative
+                    })
+                continue
+            }
+            if ($item.PSIsContainer) {
+                [void]$entries.Add([ordered]@{
+                        path = $relative
+                        type = "directory"
+                        bytes = [int64]0
+                        sha256 = ""
+                        target = $null
+                    })
+                $pending.Enqueue($item.FullName)
+                continue
+            }
+            $fileBytes = [int64]$item.Length
+            [void]$entries.Add([ordered]@{
+                    path = $relative
+                    type = "file"
+                    bytes = $fileBytes
+                    sha256 = (Get-SmokeSHA256 -Path $item.FullName)
+                    target = $null
+                })
+        }
+    }
+    return @($entries.ToArray())
+}
+
+function New-SmokeDependencyManifest {
+    param(
+        [string]$RootPath,
+        [string]$ContainmentRoot,
+        [string]$ManifestPath
+    )
+
+    $manifestPath = Assert-SmokeNewEvidenceFile -Name "dependency manifest" -RequestedPath $ManifestPath
+    $entries = @(Get-SmokeDependencyEntries -RootPath $RootPath -ContainmentRoot $ContainmentRoot)
+    $sortedEntries = @($entries | Sort-Object -Property path)
+    $writer = [System.IO.StreamWriter]::new($manifestPath, $false, [System.Text.UTF8Encoding]::new($false))
+    try {
+        foreach ($entry in $sortedEntries) {
+            $writer.WriteLine(($entry | ConvertTo-Json -Compress -Depth 5))
+        }
+    } finally {
+        $writer.Dispose()
+    }
+    $fileCount = [int64]0
+    $directoryCount = [int64]0
+    $junctionCount = [int64]0
+    $symbolicLinkCount = [int64]0
+    $totalBytes = [int64]0
+    foreach ($entry in $sortedEntries) {
+        switch ([string]$entry.type) {
+            "file" { $fileCount++; $totalBytes += [int64]$entry.bytes }
+            "directory" { $directoryCount++ }
+            "junction" { $junctionCount++ }
+            "symlink" { $symbolicLinkCount++ }
+        }
+    }
+    return [ordered]@{
+        status = "PASS"
+        manifestPath = $manifestPath
+        manifestSHA256 = Get-SmokeSHA256 -Path $manifestPath
+        entryCount = [int64]$sortedEntries.Count
+        fileCount = $fileCount
+        directoryCount = $directoryCount
+        junctionCount = $junctionCount
+        symbolicLinkCount = $symbolicLinkCount
+        totalBytes = $totalBytes
+    }
+}
+
+function Read-SmokeStructuredJSON {
+    param([string]$Path)
+
+    $raw = [System.IO.File]::ReadAllText($Path)
+    $normalized = [System.Text.RegularExpressions.Regex]::Replace($raw, ',(?=\s*[}\]])', '')
+    try {
+        [void][System.Reflection.Assembly]::LoadWithPartialName("System.Web.Extensions")
+        $serializer = [System.Web.Script.Serialization.JavaScriptSerializer]::new()
+        return $serializer.DeserializeObject($normalized)
+    } catch {
+        Fail-Smoke "dependency JSON could not be parsed: $Path; $($_.Exception.Message)"
+    }
+}
+
+function Get-SmokeMapValue {
+    param(
+        [object]$Map,
+        [string]$Name
+    )
+
+    if ($null -eq $Map) { return $null }
+    if ($Map -is [System.Collections.IDictionary]) {
+        if ($Map.ContainsKey($Name)) { return $Map[$Name] }
+        return $null
+    }
+    $property = $Map.PSObject.Properties[$Name]
+    if ($null -eq $property) { return $null }
+    return $property.Value
+}
+
+function Get-SmokeMapEntries {
+    param([object]$Map)
+
+    if ($null -eq $Map -or -not ($Map -is [System.Collections.IDictionary])) { return @() }
+    return @($Map.GetEnumerator())
+}
+
+function Assert-SmokeDependencyMapsMatch {
+    param(
+        [object]$ManifestMap,
+        [object]$LockMap,
+        [string]$WorkspaceKey,
+        [string]$GroupName
+    )
+
+    $manifestEntries = @(Get-SmokeMapEntries $ManifestMap)
+    $lockEntries = @(Get-SmokeMapEntries $LockMap)
+    foreach ($entry in $manifestEntries) {
+        $lockValue = Get-SmokeMapValue -Map $LockMap -Name ([string]$entry.Key)
+        if ($null -eq $lockValue -or [string]$lockValue -cne [string]$entry.Value) {
+            Fail-Smoke "lock workspace '$WorkspaceKey' $GroupName drift for '$($entry.Key)'"
+        }
+    }
+    foreach ($entry in $lockEntries) {
+        $manifestValue = Get-SmokeMapValue -Map $ManifestMap -Name ([string]$entry.Key)
+        if ($null -eq $manifestValue) {
+            Fail-Smoke "lock workspace '$WorkspaceKey' has undeclared $GroupName dependency '$($entry.Key)'"
+        }
+    }
+}
+
+function Resolve-SmokeNodePackageManifest {
+    param(
+        [string]$DependencyName,
+        [string]$RequesterDirectory,
+        [string]$UIRoot
+    )
+
+    $current = [System.IO.Path]::GetFullPath($RequesterDirectory)
+    $uiFullPath = [System.IO.Path]::GetFullPath($UIRoot)
+    while ($true) {
+        $candidateDirectory = Join-Path (Join-Path $current "node_modules") $DependencyName
+        $candidateManifest = Join-Path $candidateDirectory "package.json"
+        $manifestItem = Get-Item -LiteralPath $candidateManifest -Force -ErrorAction SilentlyContinue
+        if ($null -ne $manifestItem -and -not $manifestItem.PSIsContainer -and (($manifestItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0)) {
+            return $manifestItem.FullName
+        }
+        if ($current.Equals($uiFullPath, [System.StringComparison]::OrdinalIgnoreCase)) { break }
+        if (-not ($current.StartsWith($uiFullPath + [System.IO.Path]::DirectorySeparatorChar, [System.StringComparison]::OrdinalIgnoreCase))) { break }
+        $parent = [System.IO.DirectoryInfo]$current
+        $parent = $parent.Parent
+        if ($null -eq $parent) { break }
+        $current = $parent.FullName
+    }
+    return $null
+}
+
+function Get-SmokeDependencyLockClosure {
+    param(
+        [string]$DependencyRoot,
+        [string]$ExpectedLockSHA256,
+        [string]$ExpectedLockBlob
+    )
+
+    $rootPath = Resolve-SmokeAbsolutePath $DependencyRoot
+    $uiRoot = Split-Path -Parent $rootPath
+    $lockPath = Join-Path $uiRoot "bun.lock"
+    $lockItem = Get-Item -LiteralPath $lockPath -Force -ErrorAction SilentlyContinue
+    if ($null -eq $lockItem -or $lockItem.PSIsContainer -or (($lockItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+        Fail-Smoke "dependency lock is missing or not a regular file: $lockPath"
+    }
+    $lockSHA256 = Get-SmokeSHA256 -Path $lockPath
+    if ($lockSHA256 -cne $ExpectedLockSHA256.ToLowerInvariant()) {
+        Fail-Smoke "dependency lock SHA-256 = $lockSHA256, want $ExpectedLockSHA256"
+    }
+    $lockBlob = (Invoke-SmokeGit $uiRoot @("rev-parse", "HEAD:ui/bun.lock") | Select-Object -Last 1).Trim()
+    if ($lockBlob -cne $ExpectedLockBlob.ToLowerInvariant()) {
+        Fail-Smoke "dependency lock Git blob = $lockBlob, want $ExpectedLockBlob"
+    }
+    $lock = Read-SmokeStructuredJSON $lockPath
+    $lockfileVersion = Get-SmokeMapValue -Map $lock -Name "lockfileVersion"
+    if ([int]$lockfileVersion -ne 1) {
+        Fail-Smoke "dependency lockfileVersion = $lockfileVersion, want 1"
+    }
+    $workspaces = Get-SmokeMapValue -Map $lock -Name "workspaces"
+    $packages = Get-SmokeMapValue -Map $lock -Name "packages"
+    $workspaceEntries = @(Get-SmokeMapEntries $workspaces)
+    $packageEntries = @(Get-SmokeMapEntries $packages)
+    if ($workspaceEntries.Count -eq 0 -or $packageEntries.Count -eq 0) {
+        Fail-Smoke "dependency lock has no workspace/package closure"
+    }
+
+    $workspaceManifestPaths = New-Object 'System.Collections.Generic.List[string]'
+    $rootManifestPath = Join-Path $uiRoot "package.json"
+    if (-not (Test-Path -LiteralPath $rootManifestPath -PathType Leaf)) {
+        Fail-Smoke "workspace root package manifest is missing: $rootManifestPath"
+    }
+    [void]$workspaceManifestPaths.Add($rootManifestPath)
+    $workspacePackagesRoot = Join-Path $uiRoot "packages"
+    if (-not (Test-Path -LiteralPath $workspacePackagesRoot -PathType Container)) {
+        Fail-Smoke "workspace packages root is missing: $workspacePackagesRoot"
+    }
+    foreach ($workspaceDirectory in @(Get-ChildItem -LiteralPath $workspacePackagesRoot -Directory -Force -ErrorAction Stop)) {
+        $workspaceManifestPath = Join-Path $workspaceDirectory.FullName "package.json"
+        if (Test-Path -LiteralPath $workspaceManifestPath -PathType Leaf) {
+            [void]$workspaceManifestPaths.Add($workspaceManifestPath)
+        }
+    }
+    $workspaceByName = @{}
+    $workspaceByPath = @{}
+    $workspaceRecords = New-Object 'System.Collections.Generic.List[object]'
+    foreach ($workspaceManifestPath in @($workspaceManifestPaths.ToArray())) {
+        $manifest = Read-SmokeStructuredJSON $workspaceManifestPath
+        $workspaceName = [string](Get-SmokeMapValue -Map $manifest -Name "name")
+        if ([string]::IsNullOrWhiteSpace($workspaceName)) {
+            Fail-Smoke "workspace package name is missing: $workspaceManifestPath"
+        }
+        $workspaceDirectory = Split-Path -Parent $workspaceManifestPath
+        $workspaceKey = Get-SmokeRelativePath -RootPath $uiRoot -CandidatePath $workspaceDirectory -Role "workspace"
+        if ($workspaceKey -eq ".") { $workspaceKey = "" }
+        $lockWorkspace = Get-SmokeMapValue -Map $workspaces -Name $workspaceKey
+        if ($null -eq $lockWorkspace) {
+            Fail-Smoke "lock workspace '$workspaceKey' is missing"
+        }
+        foreach ($groupName in @("dependencies", "devDependencies", "optionalDependencies")) {
+            Assert-SmokeDependencyMapsMatch -ManifestMap (Get-SmokeMapValue -Map $manifest -Name $groupName) -LockMap (Get-SmokeMapValue -Map $lockWorkspace -Name $groupName) -WorkspaceKey $workspaceKey -GroupName $groupName
+        }
+        if ($workspaceByName.ContainsKey($workspaceName)) {
+            Fail-Smoke "duplicate workspace package name '$workspaceName'"
+        }
+        $workspaceByName[$workspaceName] = $workspaceManifestPath
+        $workspaceByPath[$workspaceKey] = $workspaceManifestPath
+        [void]$workspaceRecords.Add([pscustomobject]@{ key = $workspaceKey; name = $workspaceName; manifestPath = $workspaceManifestPath })
+    }
+    $expectedWorkspaceKeys = @($workspaceByPath.Keys | Sort-Object)
+    $actualWorkspaceKeys = @($workspaces.Keys | ForEach-Object { [string]$_ } | Sort-Object)
+    if (-not ([System.Linq.Enumerable]::SequenceEqual([string[]]$expectedWorkspaceKeys, [string[]]$actualWorkspaceKeys))) {
+        Fail-Smoke "lock workspace set differs from package manifests"
+    }
+
+    $queue = New-Object 'System.Collections.Generic.Queue[string]'
+    foreach ($record in @($workspaceRecords.ToArray())) { $queue.Enqueue($record.manifestPath) }
+    $visited = @{}
+    $optionalMissing = New-Object 'System.Collections.Generic.List[string]'
+    $reachablePackageCount = [int64]0
+    while ($queue.Count -gt 0) {
+        $manifestPath = $queue.Dequeue()
+        $manifestKey = [System.IO.Path]::GetFullPath($manifestPath).ToLowerInvariant()
+        if ($visited.ContainsKey($manifestKey)) { continue }
+        $visited[$manifestKey] = $true
+        $packageManifest = Read-SmokeStructuredJSON $manifestPath
+        $packageName = [string](Get-SmokeMapValue -Map $packageManifest -Name "name")
+        if ([string]::IsNullOrWhiteSpace($packageName)) {
+            Fail-Smoke "reachable package name is missing: $manifestPath"
+        }
+        $reachablePackageCount++
+        $requesterDirectory = Split-Path -Parent $manifestPath
+        foreach ($groupName in @("dependencies", "optionalDependencies", "peerDependencies")) {
+            $dependencyMap = Get-SmokeMapValue -Map $packageManifest -Name $groupName
+            foreach ($dependency in @(Get-SmokeMapEntries $dependencyMap)) {
+                $dependencyName = [string]$dependency.Key
+                $dependencySpec = [string]$dependency.Value
+                $resolvedManifest = $null
+                if ($dependencySpec -like "workspace:*") {
+                    if (-not $workspaceByName.ContainsKey($dependencyName)) {
+                        Fail-Smoke "workspace dependency '$dependencyName' from '$packageName' is not declared"
+                    }
+                    $resolvedManifest = $workspaceByName[$dependencyName]
+                } else {
+                    $resolvedManifest = Resolve-SmokeNodePackageManifest -DependencyName $dependencyName -RequesterDirectory $requesterDirectory -UIRoot $uiRoot
+                }
+                if ([string]::IsNullOrWhiteSpace([string]$resolvedManifest)) {
+                    if ($groupName -eq "optionalDependencies") {
+                        [void]$optionalMissing.Add("$packageName->$dependencyName")
+                        continue
+                    }
+                    Fail-Smoke "dependency closure is missing required package '$dependencyName' from '$packageName'"
+                }
+                $resolvedItem = Get-Item -LiteralPath $resolvedManifest -Force -ErrorAction Stop
+                [void](Get-SmokeRelativePath -RootPath $uiRoot -CandidatePath $resolvedItem.FullName -Role "resolved dependency")
+                $queue.Enqueue($resolvedItem.FullName)
+            }
+        }
+    }
+    return [ordered]@{
+        status = "PASS"
+        lockPath = $lockPath
+        lockSHA256 = $lockSHA256
+        lockBlob = $lockBlob
+        lockfileVersion = [int]$lockfileVersion
+        workspaceCount = [int64]$workspaceEntries.Count
+        lockPackageCount = [int64]$packageEntries.Count
+        reachablePackageCount = $reachablePackageCount
+        optionalMissingCount = [int64]$optionalMissing.Count
+        optionalMissing = @($optionalMissing.ToArray())
+    }
+}
+
+function Copy-SmokeDependencyTree {
+    param(
+        [string]$SourceRoot,
+        [string]$StageRoot,
+        [string]$SourceContainmentRoot,
+        [string]$StageContainmentRoot
+    )
+
+    $sourcePath = Resolve-SmokeAbsolutePath $SourceRoot
+    $stagePath = Resolve-SmokeAbsolutePath $StageRoot
+    $sourceContainmentPath = Resolve-SmokeAbsolutePath $SourceContainmentRoot
+    $stageContainmentPath = Resolve-SmokeAbsolutePath $StageContainmentRoot
+    $sourceItem = Get-Item -LiteralPath $sourcePath -Force -ErrorAction Stop
+    if (-not $sourceItem.PSIsContainer -or (($sourceItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+        Fail-Smoke "dependency source root is not a regular directory: $sourcePath"
+    }
+    Assert-SmokeDisposableRoot -Name "dependency stage" -Path $stagePath
+    if (-not (Test-Path -LiteralPath $stagePath -PathType Container)) {
+        [void][System.IO.Directory]::CreateDirectory($stagePath)
+    }
+    $robocopyArguments = @(
+        $sourcePath, $stagePath,
+        "/E", "/SL", "/COPY:DAT", "/DCOPY:DAT", "/R:0", "/W:0",
+        "/NFL", "/NDL", "/NJH", "/NJS", "/NP"
+    )
+    $robocopyOutput = @(& robocopy.exe @robocopyArguments 2>&1)
+    $robocopyExitCode = [int]$LASTEXITCODE
+    if ($robocopyExitCode -gt 7) {
+        $diagnostic = @($robocopyOutput | ForEach-Object { [string]$_ } | Select-Object -Last 20) -join " | "
+        Fail-Smoke "exact dependency copy failed with robocopy exit code ${robocopyExitCode}: $diagnostic"
+    }
+
+    $rewrittenLinks = [int64]0
+    foreach ($sourceLink in @(Get-SmokeDependencyLinkItems -RootPath $sourcePath)) {
+        $relative = Get-SmokeRelativePath -RootPath $sourcePath -CandidatePath $sourceLink.FullName -Role "dependency link"
+        $stageLinkPath = Join-Path $stagePath ($relative.Replace('/', [System.IO.Path]::DirectorySeparatorChar))
+        $sourceLinkTarget = Get-SmokeDependencyLinkTarget -Item $sourceLink -ContainmentRoot $sourceContainmentPath
+        $stageTargetPath = Join-Path $stageContainmentPath ($sourceLinkTarget.relative.Replace('/', [System.IO.Path]::DirectorySeparatorChar))
+        if (-not (Test-Path -LiteralPath $stageTargetPath)) {
+            Fail-Smoke "staged dependency link target is missing: $stageLinkPath -> $stageTargetPath"
+        }
+        $stageLinkItem = Get-Item -LiteralPath $stageLinkPath -Force -ErrorAction SilentlyContinue
+        if ($null -ne $stageLinkItem -and (($stageLinkItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0)) {
+            Fail-Smoke "dependency copier followed a source reparse point: $stageLinkPath"
+        }
+        if ($null -ne $stageLinkItem) {
+            Remove-Item -LiteralPath $stageLinkPath -Force -ErrorAction Stop
+        }
+        $stageLinkParent = Split-Path -Parent $stageLinkPath
+        if (-not (Test-Path -LiteralPath $stageLinkParent -PathType Container)) {
+            [void][System.IO.Directory]::CreateDirectory($stageLinkParent)
+        }
+        $linkTypeProperty = $sourceLink.PSObject.Properties["LinkType"]
+        $linkType = if ($null -eq $linkTypeProperty) { "" } else { [string]$linkTypeProperty.Value }
+        if ($linkType -eq "Junction") {
+            [void](New-Item -ItemType Junction -Path $stageLinkPath -Target $stageTargetPath -ErrorAction Stop)
+        } elseif ($linkType -eq "SymbolicLink") {
+            [void](New-Item -ItemType SymbolicLink -Path $stageLinkPath -Target $stageTargetPath -ErrorAction Stop)
+        } else {
+            Fail-Smoke "dependency copier cannot reproduce link type '$linkType': $($sourceLink.FullName)"
+        }
+        $rewrittenLinks++
+    }
+    return [ordered]@{
+        status = "PASS"
+        robocopyExitCode = $robocopyExitCode
+        rewrittenLinks = $rewrittenLinks
+        outputLineCount = [int64]$robocopyOutput.Count
+    }
+}
+
+function Write-SmokeJSONEvidence {
+    param(
+        [string]$RequestedPath,
+        [object]$Evidence
+    )
+
+    $path = Assert-SmokeNewEvidenceFile -Name "dependency report" -RequestedPath $RequestedPath
+    [System.IO.File]::WriteAllText($path, ($Evidence | ConvertTo-Json -Depth 20), [System.Text.UTF8Encoding]::new($false))
+    return $path
+}
+
+function Invoke-SmokeDependencyStage {
+    param(
+        [string]$RequestedSourceRoot,
+        [string]$RequestedStageRoot,
+        [string]$RequestedSourceManifestPath,
+        [string]$RequestedStageManifestPath,
+        [string]$RequestedReportPath,
+        [string]$ExpectedLockSHA256,
+        [string]$ExpectedLockBlob
+    )
+
+    $reportPath = Resolve-SmokeAbsolutePath $RequestedReportPath
+    $report = [ordered]@{
+        schemaVersion = "localai-windows-install-candidate-dependency-stage/v1"
+        status = "FAIL"
+        phase = "stage"
+        sourceRoot = Resolve-SmokeAbsolutePath $RequestedSourceRoot
+        stageRoot = Resolve-SmokeAbsolutePath $RequestedStageRoot
+        packageInstallation = "NOT_RUN"
+        sourceManifest = $null
+        stageManifest = $null
+        sourceLockClosure = $null
+        stageLockClosure = $null
+        copy = $null
+        equality = $null
+        error = ""
+    }
+    try {
+        $sourceRoot = $report.sourceRoot
+        $stageRoot = $report.stageRoot
+        $sourceContainmentRoot = Split-Path -Parent $sourceRoot
+        $stageContainmentRoot = Split-Path -Parent $stageRoot
+        $sourceManifestPath = Assert-SmokeNewEvidenceFile -Name "source dependency manifest" -RequestedPath $RequestedSourceManifestPath
+        $stageManifestPath = Assert-SmokeNewEvidenceFile -Name "staged dependency manifest" -RequestedPath $RequestedStageManifestPath
+        $sourceClosure = Get-SmokeDependencyLockClosure -DependencyRoot $sourceRoot -ExpectedLockSHA256 $ExpectedLockSHA256 -ExpectedLockBlob $ExpectedLockBlob
+        $sourceManifest = New-SmokeDependencyManifest -RootPath $sourceRoot -ContainmentRoot $sourceContainmentRoot -ManifestPath $sourceManifestPath
+        $copy = Copy-SmokeDependencyTree -SourceRoot $sourceRoot -StageRoot $stageRoot -SourceContainmentRoot $sourceContainmentRoot -StageContainmentRoot $stageContainmentRoot
+        $stageClosure = Get-SmokeDependencyLockClosure -DependencyRoot $stageRoot -ExpectedLockSHA256 $ExpectedLockSHA256 -ExpectedLockBlob $ExpectedLockBlob
+        $stageManifest = New-SmokeDependencyManifest -RootPath $stageRoot -ContainmentRoot $stageContainmentRoot -ManifestPath $stageManifestPath
+        $manifestEqual = $sourceManifest.manifestSHA256 -ceq $stageManifest.manifestSHA256
+        if (-not $manifestEqual) {
+            Fail-Smoke "source and staged dependency manifests differ"
+        }
+        $report.sourceLockClosure = $sourceClosure
+        $report.stageLockClosure = $stageClosure
+        $report.sourceManifest = $sourceManifest
+        $report.stageManifest = $stageManifest
+        $report.copy = $copy
+        $report.equality = [ordered]@{
+            sourceStageManifestEqual = $manifestEqual
+            sourceEntryCount = $sourceManifest.entryCount
+            stageEntryCount = $stageManifest.entryCount
+            sourceTotalBytes = $sourceManifest.totalBytes
+            stageTotalBytes = $stageManifest.totalBytes
+        }
+        $report.status = "PASS"
+    } catch {
+        $report.error = $_.Exception.Message
+    }
+    Write-SmokeJSONEvidence -RequestedPath $reportPath -Evidence $report | Out-Null
+    if ($report.status -ne "PASS") {
+        throw "dependency staging failed; report=$reportPath"
+    }
+    Write-Output "dependency staging passed; report=$reportPath"
+}
+
+function Invoke-SmokeDependencyVerification {
+    param(
+        [string]$RequestedSourceRoot,
+        [string]$RequestedStageRoot,
+        [string]$RequestedExpectedManifestPath,
+        [string]$RequestedPostBuildManifestPath,
+        [string]$RequestedSourceAfterManifestPath,
+        [string]$RequestedReportPath,
+        [string]$ExpectedLockSHA256,
+        [string]$ExpectedLockBlob
+    )
+
+    $reportPath = Resolve-SmokeAbsolutePath $RequestedReportPath
+    $report = [ordered]@{
+        schemaVersion = "localai-windows-install-candidate-dependency-stage/v1"
+        status = "FAIL"
+        phase = "post-build"
+        sourceRoot = Resolve-SmokeAbsolutePath $RequestedSourceRoot
+        stageRoot = Resolve-SmokeAbsolutePath $RequestedStageRoot
+        packageInstallation = "NOT_RUN"
+        expectedManifest = $null
+        postBuildManifest = $null
+        sourceAfterBuildManifest = $null
+        sourceLockClosure = $null
+        stageLockClosure = $null
+        equality = $null
+        error = ""
+    }
+    try {
+        $sourceRoot = $report.sourceRoot
+        $stageRoot = $report.stageRoot
+        $sourceContainmentRoot = Split-Path -Parent $sourceRoot
+        $stageContainmentRoot = Split-Path -Parent $stageRoot
+        $expectedManifestPath = Resolve-SmokeAbsolutePath $RequestedExpectedManifestPath
+        if (-not (Test-Path -LiteralPath $expectedManifestPath -PathType Leaf)) {
+            Fail-Smoke "expected dependency manifest is missing: $expectedManifestPath"
+        }
+        $postBuildManifestPath = Assert-SmokeNewEvidenceFile -Name "post-build dependency manifest" -RequestedPath $RequestedPostBuildManifestPath
+        $sourceAfterManifestPath = Assert-SmokeNewEvidenceFile -Name "source-after-build dependency manifest" -RequestedPath $RequestedSourceAfterManifestPath
+        $sourceClosure = Get-SmokeDependencyLockClosure -DependencyRoot $sourceRoot -ExpectedLockSHA256 $ExpectedLockSHA256 -ExpectedLockBlob $ExpectedLockBlob
+        $stageClosure = Get-SmokeDependencyLockClosure -DependencyRoot $stageRoot -ExpectedLockSHA256 $ExpectedLockSHA256 -ExpectedLockBlob $ExpectedLockBlob
+        $postBuildManifest = New-SmokeDependencyManifest -RootPath $stageRoot -ContainmentRoot $stageContainmentRoot -ManifestPath $postBuildManifestPath
+        $sourceAfterManifest = New-SmokeDependencyManifest -RootPath $sourceRoot -ContainmentRoot $sourceContainmentRoot -ManifestPath $sourceAfterManifestPath
+        $expectedSHA256 = Get-SmokeSHA256 -Path $expectedManifestPath
+        $postBuildEqual = $expectedSHA256 -ceq $postBuildManifest.manifestSHA256
+        $sourceUnchanged = $expectedSHA256 -ceq $sourceAfterManifest.manifestSHA256
+        if (-not $postBuildEqual) { Fail-Smoke "post-build dependency manifest differs from staged manifest" }
+        if (-not $sourceUnchanged) { Fail-Smoke "source dependency manifest changed during build" }
+        $report.expectedManifest = [ordered]@{ path = $expectedManifestPath; manifestSHA256 = $expectedSHA256 }
+        $report.postBuildManifest = $postBuildManifest
+        $report.sourceAfterBuildManifest = $sourceAfterManifest
+        $report.sourceLockClosure = $sourceClosure
+        $report.stageLockClosure = $stageClosure
+        $report.equality = [ordered]@{
+            sourceStagePostBuildEqual = ($expectedSHA256 -ceq $postBuildManifest.manifestSHA256 -and $expectedSHA256 -ceq $sourceAfterManifest.manifestSHA256)
+            expectedManifestSHA256 = $expectedSHA256
+            postBuildManifestSHA256 = $postBuildManifest.manifestSHA256
+            sourceAfterBuildManifestSHA256 = $sourceAfterManifest.manifestSHA256
+        }
+        $report.status = "PASS"
+    } catch {
+        $report.error = $_.Exception.Message
+    }
+    Write-SmokeJSONEvidence -RequestedPath $reportPath -Evidence $report | Out-Null
+    if ($report.status -ne "PASS") {
+        throw "dependency post-build verification failed; report=$reportPath"
+    }
+    Write-Output "dependency post-build verification passed; report=$reportPath"
 }
 
 function Test-SmokePathResolvesYou {
@@ -645,6 +1383,36 @@ function Invoke-SmokeCommand {
     } finally {
         $process.Dispose()
     }
+}
+
+function Convert-SmokeProcessArgumentListToCommandLine {
+    param([string[]]$Arguments)
+
+    $quotedArguments = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($argument in @($Arguments)) {
+        $value = if ($null -eq $argument) { "" } else { [string]$argument }
+        $builder = [System.Text.StringBuilder]::new()
+        [void]$builder.Append('"')
+        $backslashCount = 0
+        foreach ($character in $value.ToCharArray()) {
+            if ($character -eq '\') {
+                $backslashCount++
+                continue
+            }
+            if ($character -eq '"') {
+                if ($backslashCount -gt 0) { [void]$builder.Append(('\' * ($backslashCount * 2))) }
+                [void]$builder.Append('\"')
+                $backslashCount = 0
+                continue
+            }
+            if ($backslashCount -gt 0) { [void]$builder.Append(('\' * $backslashCount)); $backslashCount = 0 }
+            [void]$builder.Append($character)
+        }
+        if ($backslashCount -gt 0) { [void]$builder.Append(('\' * ($backslashCount * 2))) }
+        [void]$builder.Append('"')
+        [void]$quotedArguments.Add($builder.ToString())
+    }
+    return [string]::Join(" ", $quotedArguments.ToArray())
 }
 
 function New-SmokeLoopbackPort {
@@ -1709,6 +2477,10 @@ function Invoke-ObserverFixture {
         [string]$RootCommand,
         [string[]]$RootArgumentList,
         [string]$RootWorkingDirectory,
+        [string]$RootStdoutPath,
+        [string]$RootStderrPath,
+        [int]$RootOutputMaximumBytes = 1048576,
+        [int]$RequestedRootExitCode = 0,
         [string]$ObserverReleaseCheckoutPath,
         [int]$TimeoutSeconds = 20
     )
@@ -1754,10 +2526,48 @@ function Invoke-ObserverFixture {
     $diskReadyPath = Join-Path $fixtureRoot "disk-ready"
     $pidPath = Join-Path $fixtureRoot "root.pid"
     $donePath = Join-Path $fixtureRoot "root.done"
+    $rootStdoutPath = if ([string]::IsNullOrWhiteSpace($RootStdoutPath)) {
+        Join-Path (Split-Path -Parent $reportPath) "observer-root.stdout.txt"
+    } else {
+        Resolve-SmokeAbsolutePath $RootStdoutPath
+    }
+    $rootStderrPath = if ([string]::IsNullOrWhiteSpace($RootStderrPath)) {
+        Join-Path (Split-Path -Parent $reportPath) "observer-root.stderr.txt"
+    } else {
+        Resolve-SmokeAbsolutePath $RootStderrPath
+    }
+    if ($RootOutputMaximumBytes -le 0) {
+        Fail-Smoke "observer root output maximum must be positive"
+    }
+    foreach ($retainedPath in @($rootStdoutPath, $rootStderrPath)) {
+        $retainedParent = Split-Path -Parent $retainedPath
+        if (-not (Test-Path -LiteralPath $retainedParent -PathType Container)) {
+            Fail-Smoke "observer root output parent does not exist: $retainedParent"
+        }
+        if (Test-Path -LiteralPath $retainedPath -PathType Leaf) {
+            Fail-Smoke "observer root output evidence already exists: $retainedPath"
+        }
+        if (Test-Path -LiteralPath $retainedPath -PathType Container) {
+            Fail-Smoke "observer root output evidence path is a directory: $retainedPath"
+        }
+    }
+    $rootStdoutCapturePath = $rootStdoutPath + ".capture"
+    $rootStderrCapturePath = $rootStderrPath + ".capture"
+    foreach ($capturePath in @($rootStdoutCapturePath, $rootStderrCapturePath)) {
+        if (Test-Path -LiteralPath $capturePath) {
+            Fail-Smoke "observer root output capture already exists: $capturePath"
+        }
+    }
     $processJob = $null
     $diskJob = $null
     $rootProcess = $null
     $rootExitCode = $null
+    $rootOutput = [ordered]@{
+        status = "FAIL"
+        maximumBytes = [int64]$RootOutputMaximumBytes
+        stdout = [ordered]@{ status = "FAIL"; path = $rootStdoutPath; present = $false; totalBytes = [int64]0; capturedBytes = [int64]0; truncated = $false; redactedBytes = [int64]0; sha256 = "" }
+        stderr = [ordered]@{ status = "FAIL"; path = $rootStderrPath; present = $false; totalBytes = [int64]0; capturedBytes = [int64]0; truncated = $false; redactedBytes = [int64]0; sha256 = "" }
+    }
     $failure = $null
     $cleanupErrors = New-Object 'System.Collections.Generic.List[string]'
     $remainingTaskPaths = @()
@@ -2099,19 +2909,42 @@ function Invoke-ObserverFixture {
         if (-not (Test-Path -LiteralPath $processReadyPath) -or -not (Test-Path -LiteralPath $diskReadyPath)) { throw "observers did not start before root" }
 
         if ($externalRoot) {
-            $rootProcess = Start-Process -FilePath $RootCommand -WorkingDirectory $resolvedRootWorkingDirectory -WindowStyle Hidden -ArgumentList @($RootArgumentList) -PassThru
+            $rootFilePath = $RootCommand
+            $rootArguments = @($RootArgumentList)
         } else {
         $childOne = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("Start-Sleep -Milliseconds 2500"))
         $childTwo = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("Start-Sleep -Milliseconds 3000"))
         $fixtureFile = (Join-Path $fixtureRoot "fixture.txt").Replace("'", "''")
-        $rootScript = "`$ErrorActionPreference = 'Stop'; Set-Content -LiteralPath '$fixtureFile' -Value ('fixture' * 64); `$one = Start-Process -FilePath 'powershell.exe' -WindowStyle Hidden -ArgumentList @('-NoProfile','-NonInteractive','-EncodedCommand','$childOne') -PassThru; `$two = Start-Process -FilePath 'powershell.exe' -WindowStyle Hidden -ArgumentList @('-NoProfile','-NonInteractive','-EncodedCommand','$childTwo') -PassThru; Wait-Process -Id @(`$one.Id, `$two.Id); exit 0"
+        if ($RequestedRootExitCode -lt 0 -or $RequestedRootExitCode -gt 255) { throw "observer root exit code must be between 0 and 255" }
+        $rootExitCommand = "exit " + ([int]$RequestedRootExitCode)
+        $rootScript = "`$ErrorActionPreference = 'Stop'; Set-Content -LiteralPath '$fixtureFile' -Value ('fixture' * 64); Write-Output 'root stdout token=observer-secret'; [Console]::Error.WriteLine('root stderr api_key=observer-secret'); `$one = Start-Process -FilePath 'powershell.exe' -WindowStyle Hidden -ArgumentList @('-NoProfile','-NonInteractive','-EncodedCommand','$childOne') -PassThru; `$two = Start-Process -FilePath 'powershell.exe' -WindowStyle Hidden -ArgumentList @('-NoProfile','-NonInteractive','-EncodedCommand','$childTwo') -PassThru; Wait-Process -Id @(`$one.Id, `$two.Id); $rootExitCommand"
         $rootEncoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($rootScript))
-        $rootProcess = Start-Process -FilePath "powershell.exe" -WorkingDirectory $fixtureRoot -WindowStyle Hidden -ArgumentList @("-NoProfile", "-NonInteractive", "-EncodedCommand", $rootEncoded) -PassThru
+        $rootFilePath = "powershell.exe"
+        $rootArguments = @("-NoProfile", "-NonInteractive", "-EncodedCommand", $rootEncoded)
         }
+        $rootStartInfo = [System.Diagnostics.ProcessStartInfo]::new()
+        $rootStartInfo.FileName = $rootFilePath
+        $rootStartInfo.Arguments = Convert-SmokeProcessArgumentListToCommandLine $rootArguments
+        $rootStartInfo.WorkingDirectory = if ($externalRoot) { $resolvedRootWorkingDirectory } else { $fixtureRoot }
+        $rootStartInfo.UseShellExecute = $false
+        $rootStartInfo.CreateNoWindow = $true
+        $rootStartInfo.RedirectStandardOutput = $true
+        $rootStartInfo.RedirectStandardError = $true
+        $rootProcess = [System.Diagnostics.Process]::new()
+        $rootProcess.StartInfo = $rootStartInfo
+        if (-not $rootProcess.Start()) { throw "observer root could not start: $rootFilePath" }
+        $rootStdoutTask = $rootProcess.StandardOutput.ReadToEndAsync()
+        $rootStderrTask = $rootProcess.StandardError.ReadToEndAsync()
         [System.IO.File]::WriteAllText($pidPath, [string]$rootProcess.Id)
         $waitMilliseconds = [int][Math]::Min([int64]2147483647, [int64]$TimeoutSeconds * 1000)
         if (-not $rootProcess.WaitForExit($waitMilliseconds)) { throw "observer root timed out" }
+        $rootProcess.Refresh()
         $rootExitCode = [int64]$rootProcess.ExitCode
+        [System.IO.File]::WriteAllText($rootStdoutCapturePath, $rootStdoutTask.GetAwaiter().GetResult(), [System.Text.UTF8Encoding]::new($false))
+        [System.IO.File]::WriteAllText($rootStderrCapturePath, $rootStderrTask.GetAwaiter().GetResult(), [System.Text.UTF8Encoding]::new($false))
+        $rootOutput.stdout = Get-SmokeRootOutputEvidence -RawPath $rootStdoutCapturePath -RetainedPath $rootStdoutPath -MaximumBytes $RootOutputMaximumBytes
+        $rootOutput.stderr = Get-SmokeRootOutputEvidence -RawPath $rootStderrCapturePath -RetainedPath $rootStderrPath -MaximumBytes $RootOutputMaximumBytes
+        $rootOutput.status = if ($rootOutput.stdout.status -eq "PASS" -and $rootOutput.stderr.status -eq "PASS") { "PASS" } else { "FAIL" }
         [System.IO.File]::WriteAllText($donePath, "done")
         $completedJobs = @(Wait-Job -Job @($processJob, $diskJob) -Timeout 25)
         if ($completedJobs.Count -ne 2) { throw "observers did not complete after root exit" }
@@ -2154,6 +2987,11 @@ function Invoke-ObserverFixture {
         try {
             if (Test-Path -LiteralPath $fixtureRoot) { Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction Stop }
         } catch { [void]$cleanupErrors.Add("fixture root cleanup: $($_.Exception.Message)") }
+        foreach ($capturePath in @($rootStdoutCapturePath, $rootStderrCapturePath)) {
+            try {
+                if (Test-Path -LiteralPath $capturePath) { Remove-Item -LiteralPath $capturePath -Force -ErrorAction Stop }
+            } catch { [void]$cleanupErrors.Add("root output capture cleanup: $($_.Exception.Message)") }
+        }
         if (Test-Path -LiteralPath $fixtureRoot) { $remainingTaskPaths += $fixtureRoot }
     }
 
@@ -2161,7 +2999,8 @@ function Invoke-ObserverFixture {
         $processObservation.error = $cleanupErrors -join "; "
     }
     $checkoutPass = [string]::IsNullOrWhiteSpace($ObserverReleaseCheckoutPath) -or ($null -ne $releaseCheckoutEvidence -and [bool]$processObservation.releaseStatusCleanBeforeRoot -and [bool]$processObservation.releaseStatusCleanDuringRoot -and [bool]$processObservation.releaseStatusCleanAfterOutput -and [bool]$releaseCheckoutEvidence.statusCleanAfterOutput)
-    $observerPass = $goEnvironment.GOFLAGS -eq "-p=4" -and $goEnvironment.GOMAXPROCS -eq "4" -and $processObservation.status -eq "PASS" -and $processObservation.sampleCount -gt 0 -and $processObservation.tcpTableQueries -eq $processObservation.sampleCount -and $processObservation.zeroConnectionSamples -gt 0 -and $processObservation.ownedProcessIdentityCount -gt 0 -and $processObservation.queryMode -eq $expectedObserverQueryMode -and $diskObservation.status -eq "PASS" -and [bool]$diskObservation.startPeriodicFinal -and $processObservation.maximumGapMilliseconds -le $expectedProcessNetworkGapMilliseconds -and $diskObservation.maximumGapMilliseconds -le $expectedDiskGapMilliseconds -and $diskObservation.peakDeltaBytes -le $expectedTemporaryDiskBytesMaximum -and $checkoutPass -and $cleanupErrors.Count -eq 0 -and $remainingTaskPaths.Count -eq 0
+    $rootOutputPass = $rootOutput.status -eq "PASS" -and $rootOutput.stdout.present -and $rootOutput.stderr.present -and $rootOutput.stdout.capturedBytes -le $RootOutputMaximumBytes -and $rootOutput.stderr.capturedBytes -le $RootOutputMaximumBytes
+    $observerPass = $goEnvironment.GOFLAGS -eq "-p=4" -and $goEnvironment.GOMAXPROCS -eq "4" -and $processObservation.status -eq "PASS" -and $processObservation.sampleCount -gt 0 -and $processObservation.tcpTableQueries -eq $processObservation.sampleCount -and $processObservation.zeroConnectionSamples -gt 0 -and $processObservation.ownedProcessIdentityCount -gt 0 -and $processObservation.queryMode -eq $expectedObserverQueryMode -and $diskObservation.status -eq "PASS" -and [bool]$diskObservation.startPeriodicFinal -and $processObservation.maximumGapMilliseconds -le $expectedProcessNetworkGapMilliseconds -and $diskObservation.maximumGapMilliseconds -le $expectedDiskGapMilliseconds -and $diskObservation.peakDeltaBytes -le $expectedTemporaryDiskBytesMaximum -and $rootOutputPass -and $checkoutPass -and $cleanupErrors.Count -eq 0 -and $remainingTaskPaths.Count -eq 0
     $report = [ordered]@{
         schemaVersion = "localai-windows-install-candidate-observer/v1"
         status = if ($null -eq $failure -and $rootExitCode -eq 0 -and $observerPass) { "PASS" } else { "FAIL" }
@@ -2200,6 +3039,7 @@ function Invoke-ObserverFixture {
             descendantMaximum = $expectedDescendantMaximum
             descendantHighWater = [int64]$processObservation.descendantHighWater
             rootExitCode = $rootExitCode
+            rootOutput = $rootOutput
             failurePropagation = if ($null -eq $failure -and $rootExitCode -eq 0 -and $observerPass) { "PASS" } else { "FAIL" }
             modelBackendBytes = [int64]0
             modelBackendCalls = [int64]0
@@ -2216,6 +3056,16 @@ function Invoke-ObserverFixture {
     [System.IO.File]::WriteAllText($reportPath, ($report | ConvertTo-Json -Depth 12))
     if ($report.status -ne "PASS") { throw "observer fixture failed; report=$reportPath" }
     Write-Output "observer fixture passed; report=$reportPath"
+}
+
+if ($StageDependencyClosure) {
+    Invoke-SmokeDependencyStage -RequestedSourceRoot $DependencySourceRoot -RequestedStageRoot $DependencyStageRoot -RequestedSourceManifestPath $DependencySourceManifestPath -RequestedStageManifestPath $DependencyStageManifestPath -RequestedReportPath $DependencyReportPath -ExpectedLockSHA256 $DependencyExpectedLockSHA256 -ExpectedLockBlob $DependencyExpectedLockBlob
+    return
+}
+
+if ($VerifyDependencyClosure) {
+    Invoke-SmokeDependencyVerification -RequestedSourceRoot $DependencySourceRoot -RequestedStageRoot $DependencyStageRoot -RequestedExpectedManifestPath $DependencyExpectedManifestPath -RequestedPostBuildManifestPath $DependencyPostBuildManifestPath -RequestedSourceAfterManifestPath $DependencySourceAfterManifestPath -RequestedReportPath $DependencyReportPath -ExpectedLockSHA256 $DependencyExpectedLockSHA256 -ExpectedLockBlob $DependencyExpectedLockBlob
+    return
 }
 
 if ($PrepareReleaseCheckout) {
@@ -2243,7 +3093,7 @@ if ($ObserverIdentityFixture) {
 }
 
 if ($ObserverFixture) {
-    Invoke-ObserverFixture -RequestedInstallDir $InstallDir -RequestedReportPath $ObserverReportPath -RootCommand $ObserverRootCommand -RootArgumentList $ObserverRootArgumentList -RootWorkingDirectory $ObserverRootWorkingDirectory -ObserverReleaseCheckoutPath $ObserverReleaseCheckoutPath -TimeoutSeconds $ObserverTimeoutSeconds
+    Invoke-ObserverFixture -RequestedInstallDir $InstallDir -RequestedReportPath $ObserverReportPath -RootCommand $ObserverRootCommand -RootArgumentList $ObserverRootArgumentList -RootWorkingDirectory $ObserverRootWorkingDirectory -RootStdoutPath $ObserverRootStdoutPath -RootStderrPath $ObserverRootStderrPath -RootOutputMaximumBytes $ObserverRootOutputMaximumBytes -RequestedRootExitCode $ObserverRootExitCode -ObserverReleaseCheckoutPath $ObserverReleaseCheckoutPath -TimeoutSeconds $ObserverTimeoutSeconds
     return
 }
 

--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -32,15 +32,33 @@ param(
     [switch]$PrepareReleaseCheckout,
     [string]$ReleaseCheckoutPath,
     [string]$ReleaseCheckoutReportPath,
+    [switch]$ValidateShortRoot,
+    [string]$ShortRootParent,
+    [string]$ShortRootPath,
+    [string]$ShortRootReportPath,
+    [int]$ShortRootMaximumPathLength = 220,
+    [switch]$NativeToolFixture,
+    [string]$NativeToolLongPath,
+    [string]$NativeToolShortPath,
+    [string]$NativeToolRoot,
+    [string]$NativeToolParent,
+    [string]$NativeToolReportPath,
+    [int]$NativeToolTimeoutMilliseconds = 10000,
     [int]$ObserverTimeoutSeconds = 20
 )
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-$expectedCandidateCycle = "070"
+$expectedCandidateCycle = "076"
 $expectedCandidateGoVersion = "go1.26.8"
 $expectedObserverQueryMode = "one-full-TCP-table-query-per-interval-filtered-to-owned-process-identities"
+$expectedNativeToolMaximumPathLength = 220
+$expectedNativeToolLongPathLength = 280
+$expectedNativeToolBytes = [int64]11386368
+$expectedNativeToolSHA256 = "44ce6728d54c891b1c5a6d7dbfb1a0f13419884cca0b090f1fbcf0dcd8bee0e9"
+$expectedNativeToolVersion = "0.27.7"
+$expectedNativeToolRelativePath = "ui/node_modules/esbuild/lib/downloaded-@esbuild-win32-x64-esbuild.exe"
 $expectedProcessNetworkGapMilliseconds = 2000
 $expectedDiskGapMilliseconds = 2000
 $expectedDescendantMaximum = 36
@@ -395,6 +413,96 @@ function Assert-SmokeDisposableRoot {
     if ($entries.Count -ne 0) {
         Fail-Smoke "declared root '$Name' is not empty: $((($entries | ForEach-Object Name) -join ', '))"
     }
+}
+
+function Assert-SmokeContainedShortRoot {
+    param(
+        [string]$Name,
+        [string]$Path,
+        [string]$ParentPath,
+        [int]$MaximumPathLength = $expectedNativeToolMaximumPathLength,
+        [switch]$RequireEmpty
+    )
+
+    $rootPath = Resolve-SmokeAbsolutePath $Path
+    $parentPath = Resolve-SmokeAbsolutePath $ParentPath
+    if ($MaximumPathLength -le 0 -or $rootPath.Length -gt $MaximumPathLength) {
+        Fail-Smoke "$Name path length = $($rootPath.Length), want at most $MaximumPathLength"
+    }
+    $parentItem = Get-Item -LiteralPath $parentPath -Force -ErrorAction SilentlyContinue
+    if ($null -eq $parentItem -or -not $parentItem.PSIsContainer -or (($parentItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+        Fail-Smoke "$Name parent is missing, not a directory, or is a reparse point: $parentPath"
+    }
+    $relative = Get-SmokeRelativePath -RootPath $parentPath -CandidatePath $rootPath -Role "$Name root"
+    if ($relative -eq ".") {
+        Fail-Smoke "$Name root must be below its declared parent: $rootPath"
+    }
+    $item = Get-Item -LiteralPath $rootPath -Force -ErrorAction SilentlyContinue
+    if ($null -eq $item) {
+        return [ordered]@{
+            status = "PASS"
+            path = $rootPath
+            parent = $parentPath
+            relativePath = $relative
+            pathLength = $rootPath.Length
+            present = $false
+            empty = $true
+        }
+    }
+    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        Fail-Smoke "$Name root is a reparse point: $rootPath"
+    }
+    if (-not $item.PSIsContainer) {
+        Fail-Smoke "$Name root is a file: $rootPath"
+    }
+    $entries = @(Get-ChildItem -LiteralPath $rootPath -Force -ErrorAction Stop)
+    if ($RequireEmpty -and $entries.Count -ne 0) {
+        Fail-Smoke "$Name root is not empty: $((($entries | ForEach-Object Name) -join ', '))"
+    }
+    return [ordered]@{
+        status = "PASS"
+        path = $rootPath
+        parent = $parentPath
+        relativePath = $relative
+        pathLength = $rootPath.Length
+        present = $true
+        empty = ($entries.Count -eq 0)
+    }
+}
+
+function Invoke-SmokeShortRootValidation {
+    param(
+        [string]$RequestedParentPath,
+        [string]$RequestedRootPath,
+        [string]$RequestedReportPath,
+        [int]$MaximumPathLength
+    )
+
+    $reportPath = Resolve-SmokeAbsolutePath $RequestedReportPath
+    $report = [ordered]@{
+        schemaVersion = "localai-windows-install-candidate-short-root/v1"
+        status = "FAIL"
+        cycle = $expectedCandidateCycle
+        property = "contained-collision-free-short-root"
+        root = $null
+        cleanup = [ordered]@{ status = "PASS"; remainingTaskPaths = @(); errors = @() }
+        error = ""
+    }
+    try {
+        $report.root = Assert-SmokeContainedShortRoot -Name "short" -Path $RequestedRootPath -ParentPath $RequestedParentPath -MaximumPathLength $MaximumPathLength -RequireEmpty
+        $report.status = "PASS"
+    } catch {
+        $report.error = "line $($_.InvocationInfo.ScriptLineNumber): $($_.Exception.Message)"
+    }
+    $reportParent = Split-Path -Parent $reportPath
+    if (-not (Test-Path -LiteralPath $reportParent -PathType Container)) {
+        Fail-Smoke "short-root report parent does not exist: $reportParent"
+    }
+    [System.IO.File]::WriteAllText($reportPath, ($report | ConvertTo-Json -Depth 12), [System.Text.UTF8Encoding]::new($false))
+    if ($report.status -ne "PASS") {
+        throw "short-root validation failed; report=$reportPath"
+    }
+    Write-Output "short-root validation passed; report=$reportPath"
 }
 
 function Assert-SmokeNewEvidenceFile {
@@ -1438,6 +1546,151 @@ function New-SmokeProcessStartInfo {
     return $startInfo
 }
 
+function Invoke-SmokeNativeTool {
+    param(
+        [string]$Path,
+        [string]$WorkingDirectory,
+        [int]$TimeoutMilliseconds
+    )
+
+    $result = [ordered]@{
+        status = "FAIL"
+        path = $Path
+        pathLength = $Path.Length
+        exitCode = $null
+        stdout = ""
+        stderr = ""
+        error = ""
+    }
+    $process = $null
+    try {
+        $startInfo = New-SmokeProcessStartInfo -FilePath $Path -Arguments @("--version") -WorkingDirectory $WorkingDirectory
+        $process = [System.Diagnostics.Process]::new()
+        $process.StartInfo = $startInfo
+        if (-not $process.Start()) {
+            throw "native tool process did not start"
+        }
+        $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+        $stderrTask = $process.StandardError.ReadToEndAsync()
+        if (-not $process.WaitForExit($TimeoutMilliseconds)) {
+            try { $process.Kill($true) } catch { try { $process.Kill() } catch { } }
+            throw "native tool exceeded ${TimeoutMilliseconds}ms"
+        }
+        $process.WaitForExit()
+        $result.exitCode = [int64]$process.ExitCode
+        $result.stdout = $stdoutTask.GetAwaiter().GetResult()
+        $result.stderr = $stderrTask.GetAwaiter().GetResult()
+        $result.status = "PASS"
+    } catch {
+        $result.error = $_.Exception.Message
+    } finally {
+        if ($null -ne $process) {
+            $process.Dispose()
+        }
+    }
+    return $result
+}
+
+function Get-SmokeNativeToolFileEvidence {
+    param(
+        [string]$Path,
+        [string]$Role,
+        [int64]$ExpectedBytes,
+        [string]$ExpectedSHA256
+    )
+
+    $item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+    if ($null -eq $item -or $item.PSIsContainer) {
+        Fail-Smoke "$Role is missing or not a regular file: $Path"
+    }
+    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        Fail-Smoke "$Role is a reparse point: $Path"
+    }
+    if ([int64]$item.Length -ne $ExpectedBytes) {
+        Fail-Smoke "$Role bytes = $($item.Length), want $ExpectedBytes"
+    }
+    $sha256 = Get-SmokeSHA256 -Path $Path
+    if ($sha256 -cne $ExpectedSHA256) {
+        Fail-Smoke "$Role SHA-256 = $sha256, want $ExpectedSHA256"
+    }
+    return [ordered]@{
+        path = [System.IO.Path]::GetFullPath($Path)
+        pathLength = ([System.IO.Path]::GetFullPath($Path)).Length
+        bytes = [int64]$item.Length
+        sha256 = $sha256
+    }
+}
+
+function Invoke-SmokeNativeToolFixture {
+    param(
+        [string]$RequestedLongPath,
+        [string]$RequestedShortPath,
+        [string]$RequestedRootPath,
+        [string]$RequestedParentPath,
+        [string]$RequestedReportPath,
+        [int]$TimeoutMilliseconds
+    )
+
+    $reportPath = Resolve-SmokeAbsolutePath $RequestedReportPath
+    $report = [ordered]@{
+        schemaVersion = "localai-windows-install-candidate-native-tool/v1"
+        status = "FAIL"
+        cycle = $expectedCandidateCycle
+        property = "exact-long-path-failure-and-short-clone-native-tool-readiness"
+        limits = [ordered]@{
+            maximumShortPathLength = $expectedNativeToolMaximumPathLength
+            characterizedLongPathLength = $expectedNativeToolLongPathLength
+        }
+        shortRoot = $null
+        longPath = $null
+        shortPath = $null
+        cleanup = [ordered]@{ status = "PASS"; remainingTaskPaths = @(); errors = @() }
+        error = ""
+    }
+    try {
+        if ($TimeoutMilliseconds -le 0) {
+            Fail-Smoke "native tool timeout must be positive"
+        }
+        $shortRootEvidence = Assert-SmokeContainedShortRoot -Name "native short" -Path $RequestedRootPath -ParentPath $RequestedParentPath -MaximumPathLength $expectedNativeToolMaximumPathLength
+        $shortRootPath = $shortRootEvidence.path
+        $longPath = [System.IO.Path]::GetFullPath($RequestedLongPath)
+        $shortPath = [System.IO.Path]::GetFullPath($RequestedShortPath)
+        if ($longPath.Length -ne $expectedNativeToolLongPathLength) {
+            Fail-Smoke "native long path length = $($longPath.Length), want $expectedNativeToolLongPathLength"
+        }
+        if ($shortPath.Length -gt $expectedNativeToolMaximumPathLength) {
+            Fail-Smoke "native short path length = $($shortPath.Length), want at most $expectedNativeToolMaximumPathLength"
+        }
+        $shortRelativePath = Get-SmokeRelativePath -RootPath $shortRootPath -CandidatePath $shortPath -Role "native short tool"
+        if ($shortRelativePath -cne $expectedNativeToolRelativePath) {
+            Fail-Smoke "native short tool relative path = $shortRelativePath, want $expectedNativeToolRelativePath"
+        }
+        $report.shortRoot = $shortRootEvidence
+        $report.longPath = Get-SmokeNativeToolFileEvidence -Path $longPath -Role "native long tool" -ExpectedBytes $expectedNativeToolBytes -ExpectedSHA256 $expectedNativeToolSHA256
+        $report.longPath.launch = Invoke-SmokeNativeTool -Path $longPath -WorkingDirectory (Split-Path -Parent $longPath) -TimeoutMilliseconds $TimeoutMilliseconds
+        if ($report.longPath.launch.status -eq "PASS") {
+            Fail-Smoke "native long tool unexpectedly launched; the characterized 280-character failure is required"
+        }
+        $report.shortPath = Get-SmokeNativeToolFileEvidence -Path $shortPath -Role "native short tool" -ExpectedBytes $expectedNativeToolBytes -ExpectedSHA256 $expectedNativeToolSHA256
+        $report.shortPath.launch = Invoke-SmokeNativeTool -Path $shortPath -WorkingDirectory $shortRootPath -TimeoutMilliseconds $TimeoutMilliseconds
+        if ($report.shortPath.launch.status -ne "PASS" -or $report.shortPath.launch.exitCode -ne 0 -or ([string]$report.shortPath.launch.stdout).Trim() -cne $expectedNativeToolVersion) {
+            Fail-Smoke "native short tool did not report $expectedNativeToolVersion with exit zero"
+        }
+        $report.status = "PASS"
+    } catch {
+        $report.error = "line $($_.InvocationInfo.ScriptLineNumber): $($_.Exception.Message)"
+    }
+    $reportParent = Split-Path -Parent $reportPath
+    if (-not (Test-Path -LiteralPath $reportParent -PathType Container)) {
+        Fail-Smoke "native tool report parent does not exist: $reportParent"
+    }
+    [System.IO.File]::WriteAllText($reportPath, ($report | ConvertTo-Json -Depth 16), [System.Text.UTF8Encoding]::new($false))
+    if ($report.status -ne "PASS") {
+        throw "native tool fixture failed; report=$reportPath"
+    }
+    Write-Output "native tool fixture passed; report=$reportPath"
+}
+
 function New-SmokeLoopbackPort {
     $reservation = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
     try {
@@ -1854,6 +2107,9 @@ function Invoke-CandidateSmoke {
         }
         if ([int]$manifest.attempts.cycle070BuildMaximum -ne 1 -or [int]$manifest.attempts.cycle070BuildUsed -ne 1) {
             Fail-Smoke "candidate attempts must record cycle070BuildMaximum=1 and cycle070BuildUsed=1"
+        }
+        if ([int]$manifest.attempts.cycle076BuildMaximum -ne 1 -or [int]$manifest.attempts.cycle076BuildUsed -ne 1) {
+            Fail-Smoke "candidate attempts must record cycle076BuildMaximum=1 and cycle076BuildUsed=1"
         }
         $archiveArtifacts = @($manifest.artifacts | Where-Object { $_.role -eq "windows-amd64-archive" })
         $installerArtifacts = @($manifest.artifacts | Where-Object { $_.role -eq "windows-installer" })
@@ -3082,6 +3338,16 @@ if ($StageDependencyClosure) {
 
 if ($VerifyDependencyClosure) {
     Invoke-SmokeDependencyVerification -RequestedSourceRoot $DependencySourceRoot -RequestedStageRoot $DependencyStageRoot -RequestedExpectedManifestPath $DependencyExpectedManifestPath -RequestedPostBuildManifestPath $DependencyPostBuildManifestPath -RequestedSourceAfterManifestPath $DependencySourceAfterManifestPath -RequestedReportPath $DependencyReportPath -ExpectedLockSHA256 $DependencyExpectedLockSHA256 -ExpectedLockBlob $DependencyExpectedLockBlob
+    return
+}
+
+if ($ValidateShortRoot) {
+    Invoke-SmokeShortRootValidation -RequestedParentPath $ShortRootParent -RequestedRootPath $ShortRootPath -RequestedReportPath $ShortRootReportPath -MaximumPathLength $ShortRootMaximumPathLength
+    return
+}
+
+if ($NativeToolFixture) {
+    Invoke-SmokeNativeToolFixture -RequestedLongPath $NativeToolLongPath -RequestedShortPath $NativeToolShortPath -RequestedRootPath $NativeToolRoot -RequestedParentPath $NativeToolParent -RequestedReportPath $NativeToolReportPath -TimeoutMilliseconds $NativeToolTimeoutMilliseconds
     return
 }
 

--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -43,6 +43,71 @@ function Resolve-SmokePath {
     return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
 }
 
+function Assert-SmokeNoReparseAncestry {
+    param([string]$Name, [string]$Path)
+    $current = Resolve-SmokePath $Path
+    while (-not [string]::IsNullOrWhiteSpace($current)) {
+        $item = Get-Item -LiteralPath $current -Force -ErrorAction SilentlyContinue
+        if ($null -ne $item -and (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+            Fail-Smoke "$Name has a reparse point in its ancestry: $($item.FullName)"
+        }
+        $parent = [System.IO.Directory]::GetParent($current)
+        if ($null -eq $parent -or $parent.FullName -eq $current) { break }
+        $current = $parent.FullName
+    }
+}
+
+function Test-SmokePathContains {
+    param([string]$Parent, [string]$Child)
+    $parentPath = (Resolve-SmokePath $Parent).TrimEnd('\') + '\'
+    $childPath = Resolve-SmokePath $Child
+    return $childPath.StartsWith($parentPath, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Assert-SmokePathsDisjoint {
+    param([string]$FirstName, [string]$FirstPath, [string]$SecondName, [string]$SecondPath)
+    $first = Resolve-SmokePath $FirstPath
+    $second = Resolve-SmokePath $SecondPath
+    $equal = $first.TrimEnd('\').Equals($second.TrimEnd('\'), [System.StringComparison]::OrdinalIgnoreCase)
+    if ($equal -or (Test-SmokePathContains $first $second) -or (Test-SmokePathContains $second $first)) {
+        Fail-Smoke "$FirstName and $SecondName must not overlap: $first ; $second"
+    }
+}
+
+function Assert-SmokeCandidateRoots {
+    param(
+        [string]$SourcePath,
+        [string]$DependencySourcePath,
+        [string]$OutputDirectory,
+        [string]$WorkDirectory,
+        [string]$InstallDirectory,
+        [string]$ReportPath
+    )
+    $paths = [ordered]@{
+        source = Resolve-SmokePath $SourcePath
+        dependency = Resolve-SmokePath $DependencySourcePath
+        output = Resolve-SmokePath $OutputDirectory
+        work = Resolve-SmokePath $WorkDirectory
+        install = Resolve-SmokePath $InstallDirectory
+        report = Resolve-SmokePath $ReportPath
+    }
+    foreach ($entry in $paths.GetEnumerator()) {
+        Assert-SmokeNoReparseAncestry $entry.Key $entry.Value
+    }
+    foreach ($ownedName in @("output", "work", "install")) {
+        foreach ($readName in @("source", "dependency")) {
+            Assert-SmokePathsDisjoint $ownedName $paths[$ownedName] $readName $paths[$readName]
+        }
+    }
+    foreach ($pair in @(@("output", "work"), @("output", "install"), @("work", "install"))) {
+        Assert-SmokePathsDisjoint $pair[0] $paths[$pair[0]] $pair[1] $paths[$pair[1]]
+    }
+    if (-not (Test-SmokePathContains $paths.output $paths.report)) {
+        Fail-Smoke "candidate report must be inside the candidate output directory: $($paths.report)"
+    }
+    return [pscustomobject]$paths
+}
+
 function Assert-SmokeEmptyRoot {
     param([string]$Name, [string]$Path)
     $item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
@@ -95,10 +160,66 @@ function Get-SmokeDirectoryBytes {
     return $total
 }
 
+function Remove-SmokeOwnedTree {
+    param([string]$Name, [string]$Path)
+    $resolved = Resolve-SmokePath $Path
+    $root = Get-Item -LiteralPath $resolved -Force -ErrorAction SilentlyContinue
+    if ($null -eq $root) { return }
+    if (-not $root.PSIsContainer -or (($root.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+        Fail-Smoke "$Name cleanup root is not a regular directory: $resolved"
+    }
+    $pending = New-Object 'System.Collections.Generic.Stack[string]'
+    $pending.Push($resolved)
+    while ($pending.Count -gt 0) {
+        foreach ($item in @(Get-ChildItem -LiteralPath $pending.Pop() -Force -ErrorAction Stop)) {
+            if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+                Fail-Smoke "$Name cleanup refused unexpected reparse point: $($item.FullName)"
+            }
+            if ($item.PSIsContainer) { $pending.Push($item.FullName) }
+        }
+    }
+    Remove-Item -LiteralPath $resolved -Recurse -Force
+}
+
+function Remove-SmokeCandidateWork {
+    param([string]$WorkDirectory, [string]$DependencyJunctionPath)
+    $work = Resolve-SmokePath $WorkDirectory
+    if (-not [string]::IsNullOrWhiteSpace($DependencyJunctionPath)) {
+        $junction = Resolve-SmokePath $DependencyJunctionPath
+        if (-not (Test-SmokePathContains $work $junction)) {
+            Fail-Smoke "dependency junction is outside the candidate work directory: $junction"
+        }
+        $item = Get-Item -LiteralPath $junction -Force -ErrorAction SilentlyContinue
+        if ($null -ne $item) {
+            if (-not $item.PSIsContainer -or (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0)) {
+                Fail-Smoke "candidate dependency junction is not a directory reparse point: $junction"
+            }
+            # Directory.Delete removes the junction entry itself and never walks
+            # into the shared dependency cache it targets.
+            [System.IO.Directory]::Delete($junction)
+        }
+    }
+    Remove-SmokeOwnedTree "candidate work directory" $work
+}
+
 function Protect-SmokeOutput {
     param([string]$Path, [int]$MaximumBytes = 1048576)
-    $bytes = [System.IO.File]::ReadAllBytes($Path)
-    $count = [Math]::Min($bytes.Length, $MaximumBytes)
+    if ($MaximumBytes -le 0) { Fail-Smoke "command output limit must be positive" }
+    $stream = [System.IO.File]::Open($Path, [System.IO.FileMode]::OpenOrCreate, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    try {
+        $totalBytes = [int64]$stream.Length
+        $count = [int][Math]::Min($totalBytes, [int64]$MaximumBytes)
+        $bytes = New-Object byte[] $count
+        $offset = 0
+        while ($offset -lt $count) {
+            $read = $stream.Read($bytes, $offset, $count - $offset)
+            if ($read -eq 0) { break }
+            $offset += $read
+        }
+        if ($offset -ne $count) { $count = $offset }
+    } finally {
+        $stream.Dispose()
+    }
     if ($count -ge 2 -and $bytes[0] -eq 0xff -and $bytes[1] -eq 0xfe) {
         $text = [System.Text.Encoding]::Unicode.GetString($bytes, 2, $count - 2)
     } elseif ($count -ge 3 -and $bytes[0] -eq 0xef -and $bytes[1] -eq 0xbb -and $bytes[2] -eq 0xbf) {
@@ -108,15 +229,23 @@ function Protect-SmokeOutput {
     }
     $pattern = '(?i)(token|password|secret|api[_-]?key|authorization)\s*([:=])\s*[^\s,;]+'
     $text = [System.Text.RegularExpressions.Regex]::Replace($text, $pattern, '$1$2<redacted>')
-    [System.IO.File]::WriteAllText($Path, $text, [System.Text.UTF8Encoding]::new($false))
+    $encoding = [System.Text.UTF8Encoding]::new($false)
+    $redactedBytes = $encoding.GetBytes($text)
+    if ($redactedBytes.Length -gt $MaximumBytes) {
+        $text = $encoding.GetString($redactedBytes, 0, $MaximumBytes)
+        while ($encoding.GetByteCount($text) -gt $MaximumBytes) {
+            $text = $text.Substring(0, $text.Length - 1)
+        }
+    }
+    [System.IO.File]::WriteAllText($Path, $text, $encoding)
     $fileEvidence = Get-SmokeFileEvidence "command-output" $Path
     $evidence = [ordered]@{
         role = $fileEvidence.role
         file = $fileEvidence.file
         bytes = $fileEvidence.bytes
         sha256 = $fileEvidence.sha256
-        totalBytes = [int64]$bytes.Length
-        truncated = $bytes.Length -gt $MaximumBytes
+        totalBytes = $totalBytes
+        truncated = $totalBytes -gt $MaximumBytes
     }
     return [pscustomobject]@{ text = $text; evidence = $evidence }
 }
@@ -127,35 +256,117 @@ function Invoke-CandidateCommand {
         [Parameter(Mandatory = $true)][string[]]$ArgumentList,
         [Parameter(Mandatory = $true)][string]$WorkingDirectory,
         [Parameter(Mandatory = $true)][string]$StdoutPath,
-        [Parameter(Mandatory = $true)][string]$StderrPath
+        [Parameter(Mandatory = $true)][string]$StderrPath,
+        [int]$TimeoutSeconds = 7200,
+        [int]$OutputMaximumBytes = 1048576
     )
+    if ($TimeoutSeconds -le 0) { Fail-Smoke "command timeout must be positive" }
+    if ($OutputMaximumBytes -le 0) { Fail-Smoke "command output limit must be positive" }
     $workingDirectory = Resolve-SmokePath $WorkingDirectory
     $stdoutPath = Resolve-SmokePath $StdoutPath
     $stderrPath = Resolve-SmokePath $StderrPath
     foreach ($parent in @((Split-Path -Parent $stdoutPath), (Split-Path -Parent $stderrPath))) {
         [void][System.IO.Directory]::CreateDirectory($parent)
     }
-    $previousLocation = Get-Location
-    $previousErrorActionPreference = $ErrorActionPreference
-    $exitCode = $null
-    try {
-        Set-Location -LiteralPath $workingDirectory
-        # Windows PowerShell promotes native stderr to ErrorRecord when the
-        # caller uses Stop. Capture it as process output and decide by exit.
-        $ErrorActionPreference = "Continue"
-        if (Test-Path Variable:\PSNativeCommandUseErrorActionPreference) { $PSNativeCommandUseErrorActionPreference = $false }
-        & $FilePath @ArgumentList 1> $stdoutPath 2> $stderrPath
-        $exitCode = [int]$LASTEXITCODE
-    } finally {
-        $ErrorActionPreference = $previousErrorActionPreference
-        Set-Location -LiteralPath $previousLocation.Path
+    [System.IO.File]::WriteAllBytes($stdoutPath, [byte[]]@())
+    [System.IO.File]::WriteAllBytes($stderrPath, [byte[]]@())
+    $pidPath = Join-Path ([System.IO.Path]::GetDirectoryName($stdoutPath)) ("command-" + [System.Guid]::NewGuid().ToString("N") + ".pid")
+    $payload = [pscustomobject]@{
+        FilePath = $FilePath
+        Arguments = @($ArgumentList)
+        WorkingDirectory = $workingDirectory
+        StdoutPath = $stdoutPath
+        StderrPath = $stderrPath
+        PidPath = $pidPath
     }
-    $stdout = Protect-SmokeOutput $stdoutPath
-    $stderr = Protect-SmokeOutput $stderrPath
+    $job = $null
+    $exitCode = 125
+    $timedOut = $false
+    $outputLimitExceeded = $false
+    $terminationReason = ""
+    try {
+        $job = Start-Job -ScriptBlock {
+            param($Command)
+            $ErrorActionPreference = "Continue"
+            Set-Location -LiteralPath $Command.WorkingDirectory
+            [System.IO.File]::WriteAllText($Command.PidPath, [string]$PID, [System.Text.Encoding]::ASCII)
+            $arguments = @($Command.Arguments)
+            $commandPath = [string]$Command.FilePath
+            $commandStdout = [string]$Command.StdoutPath
+            $commandStderr = [string]$Command.StderrPath
+            $commandExitCode = 125
+            & $commandPath @arguments 1> $commandStdout 2> $commandStderr
+            if ($null -ne $LASTEXITCODE) { $commandExitCode = [int]$LASTEXITCODE }
+            return $commandExitCode
+        } -ArgumentList $payload
+        $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+        while ($job.State -notin @("Completed", "Failed", "Stopped")) {
+            Wait-Job -Job $job -Timeout 1 | Out-Null
+            foreach ($path in @($stdoutPath, $stderrPath)) {
+                $item = Get-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+                if ($null -ne $item -and [int64]$item.Length -gt $OutputMaximumBytes) {
+                    $outputLimitExceeded = $true
+                    $terminationReason = "output exceeded $OutputMaximumBytes bytes"
+                    break
+                }
+            }
+            if ($outputLimitExceeded) { break }
+            if ([DateTime]::UtcNow -ge $deadline) {
+                $timedOut = $true
+                $terminationReason = "deadline of $TimeoutSeconds seconds exceeded"
+                break
+            }
+        }
+        foreach ($path in @($stdoutPath, $stderrPath)) {
+            $item = Get-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+            if ($null -ne $item -and [int64]$item.Length -gt $OutputMaximumBytes) {
+                $outputLimitExceeded = $true
+                $terminationReason = "output exceeded $OutputMaximumBytes bytes"
+                break
+            }
+        }
+        if ($timedOut -or $outputLimitExceeded) {
+            $jobProcessID = 0
+            if (Test-Path -LiteralPath $pidPath -PathType Leaf) {
+                [void][int]::TryParse(([System.IO.File]::ReadAllText($pidPath).Trim()), [ref]$jobProcessID)
+            }
+            if ($jobProcessID -gt 0 -and $job.State -notin @("Completed", "Failed", "Stopped")) {
+                $taskkill = Join-Path $env:SystemRoot "System32\taskkill.exe"
+                $previousErrorActionPreference = $ErrorActionPreference
+                try {
+                    $ErrorActionPreference = "Continue"
+                    & $taskkill /PID $jobProcessID /T /F 1>$null 2>$null
+                } finally {
+                    $ErrorActionPreference = $previousErrorActionPreference
+                }
+            }
+            Wait-Job -Job $job -Timeout 10 | Out-Null
+            if ($job.State -notin @("Completed", "Failed", "Stopped")) {
+                Stop-Job -Job $job -ErrorAction SilentlyContinue
+            }
+            $exitCode = if ($timedOut) { 124 } else { 125 }
+        } elseif ($job.State -eq "Completed") {
+            $jobOutput = @(Receive-Job -Job $job -ErrorAction SilentlyContinue)
+            if ($jobOutput.Count -gt 0) { $exitCode = [int]$jobOutput[-1] }
+        } else {
+            $terminationReason = "command job ended in state $($job.State)"
+        }
+    } finally {
+        if ($null -ne $job) {
+            if ($job.State -notin @("Completed", "Failed", "Stopped")) { Stop-Job -Job $job -ErrorAction SilentlyContinue }
+            Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+        }
+        Remove-Item -LiteralPath $pidPath -Force -ErrorAction SilentlyContinue
+    }
+    $stdout = Protect-SmokeOutput $stdoutPath $OutputMaximumBytes
+    $stderr = Protect-SmokeOutput $stderrPath $OutputMaximumBytes
     return [pscustomobject][ordered]@{
         file = $FilePath
         arguments = @($ArgumentList)
         exitCode = $exitCode
+        timedOut = $timedOut
+        outputLimitExceeded = $outputLimitExceeded
+        terminationReason = $terminationReason
         stdout = $stdout.text
         stderr = $stderr.text
         stdoutEvidence = $stdout.evidence
@@ -408,9 +619,7 @@ function Invoke-InstalledCandidateSmoke {
         foreach ($name in $environmentNames) {
             [System.Environment]::SetEnvironmentVariable($name, $originalEnvironment[$name], "Process")
         }
-        if (Test-Path -LiteralPath $installDir) {
-            Remove-Item -LiteralPath $installDir -Recurse -Force
-        }
+        Remove-SmokeOwnedTree "install directory" $installDir
     }
 }
 
@@ -451,12 +660,16 @@ function Invoke-LocalCandidateSmoke {
     if ($EsbuildSHA256 -notmatch '^[0-9a-fA-F]{64}$') {
         Fail-Smoke "ExpectedEsbuildSHA256 must be a SHA-256 digest"
     }
-    $sourcePath = Resolve-SmokePath $SourcePath
-    $dependencySourcePath = Resolve-SmokePath $DependencySourcePath
-    $outputDirectory = Resolve-SmokePath $OutputDirectory
-    $workDirectory = Resolve-SmokePath $WorkDirectory
-    $installDirectory = Resolve-SmokePath $RequestedInstallDir
-    $reportPath = Resolve-SmokePath $RequestedReportPath
+    $roots = Assert-SmokeCandidateRoots -SourcePath $SourcePath `
+        -DependencySourcePath $DependencySourcePath -OutputDirectory $OutputDirectory `
+        -WorkDirectory $WorkDirectory -InstallDirectory $RequestedInstallDir `
+        -ReportPath $RequestedReportPath
+    $sourcePath = $roots.source
+    $dependencySourcePath = $roots.dependency
+    $outputDirectory = $roots.output
+    $workDirectory = $roots.work
+    $installDirectory = $roots.install
+    $reportPath = $roots.report
     $releaseToolPath = Resolve-SmokePath $ReleaseToolPath
     Assert-SmokeEmptyRoot "candidate output directory" $outputDirectory
     Assert-SmokeEmptyRoot "candidate work directory" $workDirectory
@@ -464,11 +677,6 @@ function Invoke-LocalCandidateSmoke {
     [void](Assert-SmokeRegularFile "GoReleaser" $releaseToolPath)
     if ($workDirectory.Length -gt 80) {
         Fail-Smoke "candidate work directory must be at most 80 characters so Windows native tools remain below path limits"
-    }
-    foreach ($pair in @(@($outputDirectory, $workDirectory), @($outputDirectory, $installDirectory), @($workDirectory, $installDirectory))) {
-        if ($pair[0].TrimEnd('\').Equals($pair[1].TrimEnd('\'), [System.StringComparison]::OrdinalIgnoreCase)) {
-            Fail-Smoke "candidate output, work, and install directories must be distinct"
-        }
     }
     $sourceIdentity = Get-CandidateSourceIdentity -SourcePath $sourcePath `
         -Commit $SourceCommit -Repository $SourceRepository
@@ -496,6 +704,7 @@ function Invoke-LocalCandidateSmoke {
         error = ""
     }
     $failure = $null
+    $dependencyJunctionPath = $null
     try {
         $env:GOFLAGS = "-p=4"
         $env:GOMAXPROCS = "4"
@@ -529,6 +738,7 @@ function Invoke-LocalCandidateSmoke {
             Fail-Smoke "fresh candidate clone unexpectedly contains ui/node_modules"
         }
         [void](New-Item -ItemType Junction -Path $checkoutNodeModules -Target $dependencyNodeModules)
+        $dependencyJunctionPath = $checkoutNodeModules
         $esbuildPath = Join-Path $checkoutNodeModules "esbuild\lib\downloaded-@esbuild-win32-x64-esbuild.exe"
         $esbuildEvidence = Get-SmokeFileEvidence "esbuild" $esbuildPath
         if ($esbuildEvidence.sha256 -cne $EsbuildSHA256.ToLowerInvariant()) {
@@ -566,6 +776,9 @@ function Invoke-LocalCandidateSmoke {
             command = $releaseToolPath
             arguments = $releaseArguments
             exitCode = $releaseResult.exitCode
+            timedOut = $releaseResult.timedOut
+            outputLimitExceeded = $releaseResult.outputLimitExceeded
+            terminationReason = $releaseResult.terminationReason
             stdout = $releaseResult.stdoutEvidence
             stderr = $releaseResult.stderrEvidence
             goReleaser = $releaseToolEvidence
@@ -644,12 +857,8 @@ function Invoke-LocalCandidateSmoke {
             [System.Environment]::SetEnvironmentVariable($name, $originalEnvironment[$name], "Process")
         }
         try {
-            if (Test-Path -LiteralPath $installDirectory) {
-                Remove-Item -LiteralPath $installDirectory -Recurse -Force
-            }
-            if (Test-Path -LiteralPath $workDirectory) {
-                Remove-Item -LiteralPath $workDirectory -Recurse -Force
-            }
+            Remove-SmokeOwnedTree "install directory" $installDirectory
+            Remove-SmokeCandidateWork -WorkDirectory $workDirectory -DependencyJunctionPath $dependencyJunctionPath
             $report.cleanup = [ordered]@{
                 status = "PASS"
                 workDirectoryRemoved = -not (Test-Path -LiteralPath $workDirectory)

--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -7,17 +7,22 @@ param(
     [string]$CandidateManifestPath,
     [string]$ReportPath,
     [switch]$ObserverFixture,
+    [switch]$ObserverIdentityFixture,
     [string]$ObserverReportPath,
     [string]$ObserverRootCommand,
     [string[]]$ObserverRootArgumentList,
     [string]$ObserverRootWorkingDirectory,
+    [string]$ObserverReleaseCheckoutPath,
+    [switch]$PrepareReleaseCheckout,
+    [string]$ReleaseCheckoutPath,
+    [string]$ReleaseCheckoutReportPath,
     [int]$ObserverTimeoutSeconds = 20
 )
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-$expectedCandidateCycle = "068"
+$expectedCandidateCycle = "070"
 $expectedCandidateGoVersion = "go1.26.8"
 $expectedObserverQueryMode = "one-full-TCP-table-query-per-interval-filtered-to-owned-process-identities"
 $expectedProcessNetworkGapMilliseconds = 2000
@@ -27,6 +32,104 @@ $expectedTemporaryDiskBytesMaximum = [int64]4294967296
 $expectedCandidateSourceRepository = "https://github.com/portpowered/you-agent-factory"
 $expectedCandidateSourceCommit = "059474b2c00915865306a33ca5e3d02b618bb6f0"
 $expectedCandidateSourceTree = "ae5d9c87fbc99a898ad2c11e1409105d78e4a094"
+
+$observerIdentityFunctionSource = @'
+function Register-ObserverIdentities {
+    param(
+        [object]$Snapshot,
+        [hashtable]$IdentityByPid,
+        [hashtable]$OwnedIdentityToPid,
+        [hashtable]$State
+    )
+
+    foreach ($record in @($Snapshot.ownedRecords)) {
+        if ($null -eq $record) { continue }
+        $processId = [int]$record.processId
+        $identity = [string]$record.identity
+        if ($IdentityByPid.ContainsKey($processId) -and [string]$IdentityByPid[$processId] -cne $identity) {
+            throw "owned process PID $processId changed identity from $($IdentityByPid[$processId]) to $identity"
+        }
+        if ($OwnedIdentityToPid.ContainsKey($identity) -and [int]$OwnedIdentityToPid[$identity] -ne $processId) {
+            throw "owned process identity $identity is ambiguous across PIDs"
+        }
+        $IdentityByPid[$processId] = $identity
+        $OwnedIdentityToPid[$identity] = $processId
+    }
+    if ($Snapshot.rootPresent) {
+        $identity = [string]$Snapshot.root.identity
+        if ($null -eq $State["rootIdentity"]) {
+            $State["rootIdentity"] = $identity
+        } elseif ([string]$State["rootIdentity"] -cne $identity) {
+            throw "owned root identity changed from $($State['rootIdentity']) to $identity"
+        }
+    }
+}
+
+function Remove-ObserverInactivePidIdentities {
+    param(
+        [object]$Snapshot,
+        [hashtable]$IdentityByPid
+    )
+
+    # A PID may be reused after its prior owned process has disappeared
+    # between intervals. Retire both an absent PID and a PID whose current
+    # creation identity differs, but retain every identity in the historical
+    # OwnedIdentityToPid ledger. Register-ObserverIdentities still compares
+    # the before/after pair without retirement, so reuse during one TCP query
+    # remains fail closed.
+    $activeIdentities = @{}
+    foreach ($record in @($Snapshot.ownedRecords)) {
+        if ($null -ne $record) {
+            $activeIdentities[[int]$record.processId] = [string]$record.identity
+        }
+    }
+    foreach ($processId in @($IdentityByPid.Keys)) {
+        $processId = [int]$processId
+        if (-not $activeIdentities.ContainsKey($processId) -or [string]$IdentityByPid[$processId] -cne [string]$activeIdentities[$processId]) {
+            [void]$IdentityByPid.Remove($processId)
+        }
+    }
+}
+
+function Get-ObserverConnectionTable {
+    param([scriptblock]$Query)
+
+    if ($null -eq $Query) {
+        throw "TCP-table query is missing"
+    }
+    try {
+        return @(& $Query)
+    } catch {
+        throw "TCP-table query failed: $($_.Exception.Message)"
+    }
+}
+
+function Get-ObserverGitStatus {
+    param([string]$CheckoutPath)
+
+    if ([string]::IsNullOrWhiteSpace($CheckoutPath)) {
+        return ""
+    }
+    $output = @(& git.exe -C $CheckoutPath status --porcelain=v1 --untracked-files=all 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        throw "release checkout Git status failed: $($output -join ' ')"
+    }
+    return (($output | ForEach-Object { [string]$_ }) -join "`n").Trim()
+}
+'@
+
+function Get-ObserverGitStatus {
+    param([string]$CheckoutPath)
+
+    if ([string]::IsNullOrWhiteSpace($CheckoutPath)) {
+        return ""
+    }
+    $output = @(& git.exe -C $CheckoutPath status --porcelain=v1 --untracked-files=all 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        throw "release checkout Git status failed: $($output -join ' ')"
+    }
+    return (($output | ForEach-Object { [string]$_ }) -join "`n").Trim()
+}
 
 function Fail-Smoke {
     param([string]$Message)
@@ -82,6 +185,110 @@ function Resolve-SmokeAbsolutePath {
         return [System.IO.Path]::GetFullPath($Value)
     }
     return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Value))
+}
+
+function Invoke-SmokeGit {
+    param(
+        [string]$CheckoutPath,
+        [string[]]$ArgumentList
+    )
+
+    $output = @(& git.exe -C $CheckoutPath @ArgumentList 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        Fail-Smoke "git -C $CheckoutPath $($ArgumentList -join ' ') failed: $($output -join ' ')"
+    }
+    return @($output | ForEach-Object { [string]$_ })
+}
+
+function Assert-SmokeReleaseCheckout {
+    param(
+        [string]$RequestedCheckoutPath,
+        [switch]$PrepareDistExclude,
+        [switch]$RequireDistExclude
+    )
+
+    $checkoutPath = Resolve-SmokeAbsolutePath $RequestedCheckoutPath
+    $gitPath = Join-Path $checkoutPath ".git"
+    $gitItem = Get-Item -LiteralPath $gitPath -Force -ErrorAction SilentlyContinue
+    if ($null -eq $gitItem -or -not $gitItem.PSIsContainer) {
+        Fail-Smoke "release checkout .git is not a real directory: $gitPath"
+    }
+    $topLevel = (Invoke-SmokeGit $checkoutPath @("rev-parse", "--show-toplevel") | Select-Object -Last 1).Trim()
+    if ([System.IO.Path]::GetFullPath($topLevel) -ne $checkoutPath) {
+        Fail-Smoke "release checkout top-level = $topLevel, want $checkoutPath"
+    }
+    $head = (Invoke-SmokeGit $checkoutPath @("rev-parse", "HEAD") | Select-Object -Last 1).Trim()
+    if ($head -cne $expectedCandidateSourceCommit) {
+        Fail-Smoke "release checkout HEAD = $head, want $expectedCandidateSourceCommit"
+    }
+    $tree = (Invoke-SmokeGit $checkoutPath @("rev-parse", "HEAD^{tree}") | Select-Object -Last 1).Trim()
+    if ($tree -cne $expectedCandidateSourceTree) {
+        Fail-Smoke "release checkout tree = $tree, want $expectedCandidateSourceTree"
+    }
+    $branch = (Invoke-SmokeGit $checkoutPath @("rev-parse", "--abbrev-ref", "HEAD") | Select-Object -Last 1).Trim()
+    if ($branch -cne "HEAD") {
+        Fail-Smoke "release checkout is not detached: branch=$branch"
+    }
+    $origin = (Invoke-SmokeGit $checkoutPath @("remote", "get-url", "origin") | Select-Object -Last 1).Trim()
+    if ($origin -match "^(https?|ssh)://" -or $origin -match "^git@") {
+        Fail-Smoke "release checkout origin is not local-filesystem-only: $origin"
+    }
+    $statusBefore = Get-ObserverGitStatus $checkoutPath
+    if ($statusBefore -ne "") {
+        Fail-Smoke "release checkout is dirty before output production: $statusBefore"
+    }
+    $excludePath = Join-Path $gitPath "info\exclude"
+    if (-not (Test-Path -LiteralPath $excludePath -PathType Leaf)) {
+        Fail-Smoke "release checkout private exclude is missing: $excludePath"
+    }
+    $beforeLines = @([System.IO.File]::ReadAllLines($excludePath))
+    $beforeDistCount = @($beforeLines | Where-Object { $_ -ceq "/dist/" }).Count
+    if ($PrepareDistExclude) {
+        if ($beforeDistCount -ne 0) {
+            Fail-Smoke "release checkout private exclude already contains /dist/"
+        }
+        $existingText = [System.IO.File]::ReadAllText($excludePath)
+        $separator = if ($existingText.EndsWith("`n") -or $existingText.EndsWith("`r") -or $existingText.Length -eq 0) { "" } else { [Environment]::NewLine }
+        [System.IO.File]::AppendAllText($excludePath, $separator + "/dist/" + [Environment]::NewLine, [System.Text.UTF8Encoding]::new($false))
+    }
+    $afterLines = @([System.IO.File]::ReadAllLines($excludePath))
+    $afterDistCount = @($afterLines | Where-Object { $_ -ceq "/dist/" }).Count
+    if ($RequireDistExclude -and $afterDistCount -ne 1) {
+        Fail-Smoke "release checkout private exclude must contain exactly one /dist/ entry, found $afterDistCount"
+    }
+    if ($PrepareDistExclude) {
+        if ($afterLines.Count -ne $beforeLines.Count + 1 -or $afterLines[$afterLines.Count - 1] -cne "/dist/") {
+            Fail-Smoke "release checkout private exclude changed by more than the exact /dist/ addition"
+        }
+        for ($index = 0; $index -lt $beforeLines.Count; $index++) {
+            if ($afterLines[$index] -cne $beforeLines[$index]) {
+                Fail-Smoke "release checkout private exclude changed before the exact /dist/ addition"
+            }
+        }
+    }
+    $statusAfter = Get-ObserverGitStatus $checkoutPath
+    if ($statusAfter -ne "") {
+        Fail-Smoke "release checkout is dirty after private exclude preparation: $statusAfter"
+    }
+    $privateExcludeAdded = New-Object 'System.Collections.Generic.List[string]'
+    if ($PrepareDistExclude) {
+        [void]$privateExcludeAdded.Add("/dist/")
+    }
+    return [ordered]@{
+        status = "PASS"
+        gitDirIsDirectory = $true
+        checkoutPath = $checkoutPath
+        detachedHead = $true
+        head = $head
+        tree = $tree
+        origin = $origin
+        privateExcludePath = $excludePath
+        privateExcludeBefore = $beforeLines
+        privateExcludeAfter = $afterLines
+        privateExcludeAdded = $privateExcludeAdded
+        statusCleanBefore = ($statusBefore -eq "")
+        statusCleanAfterPreparation = ($statusAfter -eq "")
+    }
 }
 
 function Assert-SmokeDisposableRoot {
@@ -840,7 +1047,7 @@ function Invoke-CandidateSmoke {
                 Fail-Smoke "candidate control $($control.Key) = $actualControl, want $($control.Value)"
             }
         }
-        $expectedPriorCycles = @("030", "040", "042", "045", "048", "050", "063", "067")
+        $expectedPriorCycles = @("030", "040", "042", "045", "048", "050", "063", "067", "068")
         $actualPriorCycles = @($manifest.attempts.priorCycles | ForEach-Object { [string]$_ })
         if ($actualPriorCycles.Count -ne $expectedPriorCycles.Count -or (Compare-Object -ReferenceObject $expectedPriorCycles -DifferenceObject $actualPriorCycles)) {
             Fail-Smoke "candidate attempts priorCycles = $($actualPriorCycles -join ', '), want $($expectedPriorCycles -join ', ')"
@@ -853,6 +1060,9 @@ function Invoke-CandidateSmoke {
         }
         if ([int]$manifest.attempts.cycle068BuildMaximum -ne 1 -or [int]$manifest.attempts.cycle068BuildUsed -ne 1) {
             Fail-Smoke "candidate attempts must record cycle068BuildMaximum=1 and cycle068BuildUsed=1"
+        }
+        if ([int]$manifest.attempts.cycle070BuildMaximum -ne 1 -or [int]$manifest.attempts.cycle070BuildUsed -ne 1) {
+            Fail-Smoke "candidate attempts must record cycle070BuildMaximum=1 and cycle070BuildUsed=1"
         }
         $archiveArtifacts = @($manifest.artifacts | Where-Object { $_.role -eq "windows-amd64-archive" })
         $installerArtifacts = @($manifest.artifacts | Where-Object { $_.role -eq "windows-installer" })
@@ -1368,6 +1578,130 @@ function Invoke-CandidateSmoke {
     }
 }
 
+function Invoke-ObserverIdentityFixture {
+    param(
+        [string]$RequestedInstallDir,
+        [string]$RequestedReportPath
+    )
+
+    $reportPath = if ([string]::IsNullOrWhiteSpace($RequestedReportPath)) {
+        Join-Path (Resolve-SmokeAbsolutePath $RequestedInstallDir) "observer-identity-report.json"
+    } else {
+        Resolve-SmokeAbsolutePath $RequestedReportPath
+    }
+    $job = Start-Job -ScriptBlock {
+        param($IdentityFunctionSource, $CandidateCycle)
+        $ErrorActionPreference = "Stop"
+        Invoke-Expression $IdentityFunctionSource
+
+        function New-ObserverSyntheticSnapshot {
+            param([string]$Identity)
+
+            $root = [pscustomobject]@{ processId = 100; identity = "100/root"; name = "powershell" }
+            $descendant = [pscustomobject]@{ processId = 42; identity = $Identity; name = "powershell" }
+            return [pscustomobject]@{
+                rootPresent = $true
+                root = $root
+                descendants = @($descendant)
+                ownedRecords = @($root, $descendant)
+            }
+        }
+
+        $crossActive = @{}
+        $crossHistory = @{}
+        $crossState = @{ rootIdentity = $null }
+        Register-ObserverIdentities (New-ObserverSyntheticSnapshot "42/A") $crossActive $crossHistory $crossState
+        $emptyRows = @(Get-ObserverConnectionTable { @() })
+        Remove-ObserverInactivePidIdentities (New-ObserverSyntheticSnapshot "42/B") $crossActive
+        Register-ObserverIdentities (New-ObserverSyntheticSnapshot "42/B") $crossActive $crossHistory $crossState
+        Register-ObserverIdentities (New-ObserverSyntheticSnapshot "42/B") $crossActive $crossHistory $crossState
+        $crossPass = [string]$crossActive[42] -ceq "42/B" -and $crossHistory.ContainsKey("42/A") -and $crossHistory.ContainsKey("42/B") -and $emptyRows.Count -eq 0
+
+        $withinActive = @{}
+        $withinHistory = @{}
+        $withinState = @{ rootIdentity = $null }
+        Register-ObserverIdentities (New-ObserverSyntheticSnapshot "42/A") $withinActive $withinHistory $withinState
+        $withinRejected = $false
+        $withinError = ""
+        try {
+            [void](Get-ObserverConnectionTable { @() })
+            Register-ObserverIdentities (New-ObserverSyntheticSnapshot "42/B") $withinActive $withinHistory $withinState
+        } catch {
+            $withinRejected = $true
+            $withinError = $_.Exception.Message
+        }
+
+        $queryErrorPreserved = $false
+        $queryError = ""
+        try {
+            [void](Get-ObserverConnectionTable { throw "synthetic query error" })
+        } catch {
+            $queryError = $_.Exception.Message
+            $queryErrorPreserved = $queryError -like "*synthetic query error*"
+        }
+        [ordered]@{
+            schemaVersion = "localai-windows-install-candidate-observer-identity/v1"
+            status = if ($crossPass -and $withinRejected -and $queryErrorPreserved) { "PASS" } else { "FAIL" }
+            cycle = $CandidateCycle
+            releaseStatus = "observer-identity-fixture"
+            crossInterval = [ordered]@{
+                status = if ($crossPass) { "PASS" } else { "FAIL" }
+                activeIdentity = [string]$crossActive[42]
+                historicalIdentities = @($crossHistory.Keys | Sort-Object)
+                continued = $crossPass
+            }
+            withinSample = [ordered]@{
+                status = if ($withinRejected) { "PASS" } else { "FAIL" }
+                rejected = $withinRejected
+                error = $withinError
+            }
+            emptyTCP = [ordered]@{
+                status = if ($emptyRows.Count -eq 0) { "PASS" } else { "FAIL" }
+                rowCount = $emptyRows.Count
+            }
+            queryError = [ordered]@{
+                status = if ($queryErrorPreserved) { "PASS" } else { "FAIL" }
+                error = $queryError
+            }
+        } | ConvertTo-Json -Depth 12
+    } -ArgumentList $observerIdentityFunctionSource, $expectedCandidateCycle
+    $report = $null
+    $failure = $null
+    try {
+        $completed = Wait-Job -Job $job -Timeout 10
+        if ($null -eq $completed -or $job.State -ne "Completed") {
+            throw "observer identity fixture did not complete"
+        }
+        $results = @(Receive-Job -Job $job -ErrorAction Stop)
+        if ($results.Count -eq 0) {
+            throw "observer identity fixture returned no report"
+        }
+        $report = [string]$results[$results.Count - 1] | ConvertFrom-Json
+    } catch {
+        $failure = $_.Exception
+    } finally {
+        try { Remove-Job -Job $job -Force -ErrorAction Stop } catch { }
+    }
+    if ($null -eq $report) {
+        $report = [ordered]@{
+            schemaVersion = "localai-windows-install-candidate-observer-identity/v1"
+            status = "FAIL"
+            cycle = $expectedCandidateCycle
+            releaseStatus = "observer-identity-fixture"
+            error = if ($null -eq $failure) { "observer identity fixture returned no report" } else { $failure.Message }
+        }
+    }
+    $reportParent = Split-Path -Parent $reportPath
+    if (-not (Test-Path -LiteralPath $reportParent -PathType Container)) {
+        Fail-Smoke "observer identity report parent does not exist: $reportParent"
+    }
+    [System.IO.File]::WriteAllText($reportPath, ($report | ConvertTo-Json -Depth 12))
+    if ($report.status -ne "PASS") {
+        throw "observer identity fixture failed; report=$reportPath"
+    }
+    Write-Output "observer identity fixture passed; report=$reportPath"
+}
+
 function Invoke-ObserverFixture {
     param(
         [string]$RequestedInstallDir,
@@ -1375,6 +1709,7 @@ function Invoke-ObserverFixture {
         [string]$RootCommand,
         [string[]]$RootArgumentList,
         [string]$RootWorkingDirectory,
+        [string]$ObserverReleaseCheckoutPath,
         [int]$TimeoutSeconds = 20
     )
 
@@ -1408,6 +1743,13 @@ function Invoke-ObserverFixture {
     if (-not (Test-Path -LiteralPath $observationRoot -PathType Container)) {
         Fail-Smoke "observer observation root does not exist: $observationRoot"
     }
+    $releaseCheckoutEvidence = $null
+    if (-not [string]::IsNullOrWhiteSpace($ObserverReleaseCheckoutPath)) {
+        $releaseCheckoutEvidence = Assert-SmokeReleaseCheckout -RequestedCheckoutPath $ObserverReleaseCheckoutPath -RequireDistExclude
+        $releaseCheckoutEvidence.statusCleanDuringOutput = $false
+        $releaseCheckoutEvidence.statusCleanAfterOutput = $false
+        $releaseCheckoutEvidence.statusChecks = 0
+    }
     $processReadyPath = Join-Path $fixtureRoot "process-ready"
     $diskReadyPath = Join-Path $fixtureRoot "disk-ready"
     $pidPath = Join-Path $fixtureRoot "root.pid"
@@ -1424,6 +1766,7 @@ function Invoke-ObserverFixture {
         maximumGapMilliseconds = [int64]0; nonLoopbackConnections = 0; externalTransferBytes = [int64]0; descendantHighWater = [int64]0
         sampleCount = 0; tcpTableQueries = 0; zeroConnectionSamples = 0; ownedConnectionMatches = 0
         ownedProcessIdentityCount = 0; queryMode = $expectedObserverQueryMode; forbiddenProcesses = @(); error = ""
+        releaseStatusCleanBeforeRoot = $false; releaseStatusCleanDuringRoot = $false; releaseStatusCleanAfterOutput = $false; releaseStatusChecks = 0
     }
     $diskObservation = [pscustomobject]@{
         status = "FAIL"; independent = $false; startPeriodicFinal = $false
@@ -1436,12 +1779,24 @@ function Invoke-ObserverFixture {
 
     try {
         $processJob = Start-Job -ScriptBlock {
-            param($ReadyPath, $PidPath, $DonePath, $TimeoutSeconds)
+            param($ReadyPath, $PidPath, $DonePath, $TimeoutSeconds, $IdentityFunctionSource, $ReleaseCheckoutPath)
             $ErrorActionPreference = "Stop"
+            Invoke-Expression $IdentityFunctionSource
             $processNetworkGapMaximumMilliseconds = [int64]2000
             $descendantMaximum = [int64]36
             $queryMode = "one-full-TCP-table-query-per-interval-filtered-to-owned-process-identities"
             $forbiddenNamePatterns = @("localai", "local-ai", "llama-server", "llama-cli", "vibevoice", "whisper", "piper")
+            $releaseStatusCleanBeforeRoot = $false
+            $releaseStatusCleanDuringRoot = $false
+            $releaseStatusCleanAfterOutput = $false
+            $releaseStatusChecks = 0
+            if (-not [string]::IsNullOrWhiteSpace($ReleaseCheckoutPath)) {
+                if ((Get-ObserverGitStatus $ReleaseCheckoutPath) -ne "") {
+                    throw "release checkout is dirty before root start"
+                }
+                $releaseStatusChecks++
+                $releaseStatusCleanBeforeRoot = $true
+            }
             [System.IO.File]::WriteAllText($ReadyPath, "ready")
             function Convert-ObserverCreationTimeTicks {
                 param($Value)
@@ -1521,56 +1876,6 @@ function Invoke-ObserverFixture {
                     ownedRecords = $ownedRecords.ToArray()
                 }
             }
-            function Register-ObserverIdentities {
-                param(
-                    [object]$Snapshot,
-                    [hashtable]$IdentityByPid,
-                    [hashtable]$OwnedIdentityToPid,
-                    [hashtable]$State
-                )
-
-                foreach ($record in @($Snapshot.ownedRecords)) {
-                    $processId = [int]$record.processId
-                    $identity = [string]$record.identity
-                    if ($IdentityByPid.ContainsKey($processId) -and [string]$IdentityByPid[$processId] -cne $identity) {
-                        throw "owned process PID $processId changed identity from $($IdentityByPid[$processId]) to $identity"
-                    }
-                    if ($OwnedIdentityToPid.ContainsKey($identity) -and [int]$OwnedIdentityToPid[$identity] -ne $processId) {
-                        throw "owned process identity $identity is ambiguous across PIDs"
-                    }
-                    $IdentityByPid[$processId] = $identity
-                    $OwnedIdentityToPid[$identity] = $processId
-                }
-                if ($Snapshot.rootPresent) {
-                    $identity = [string]$Snapshot.root.identity
-                    if ($null -eq $State["rootIdentity"]) {
-                        $State["rootIdentity"] = $identity
-                    } elseif ([string]$State["rootIdentity"] -cne $identity) {
-                        throw "owned root identity changed from $($State['rootIdentity']) to $identity"
-                    }
-                }
-            }
-            function Remove-ObserverInactivePidIdentities {
-                param(
-                    [object]$Snapshot,
-                    [hashtable]$IdentityByPid
-                )
-
-                # A PID may be reused after its prior owned process has
-                # disappeared between intervals. Keep every creation-time
-                # identity in OwnedIdentityToPid, but compare only active PID
-                # mappings across the before/after pair so reuse during one
-                # TCP query remains fail closed.
-                $activePids = @{}
-                foreach ($record in @($Snapshot.ownedRecords)) {
-                    $activePids[[int]$record.processId] = $true
-                }
-                foreach ($processId in @($IdentityByPid.Keys)) {
-                    if (-not $activePids.ContainsKey([int]$processId)) {
-                        [void]$IdentityByPid.Remove($processId)
-                    }
-                }
-            }
             function Test-ObserverLoopbackAddress {
                 param([string]$Address)
 
@@ -1591,7 +1896,7 @@ function Invoke-ObserverFixture {
                 Register-ObserverIdentities $before $IdentityByPid $OwnedIdentityToPid $State
                 # One complete TCP-table query is deliberately shared by every
                 # owned process in this interval; an empty table is a valid sample.
-                $connections = @(Get-NetTCPConnection -ErrorAction Stop)
+                $connections = @(Get-ObserverConnectionTable { Get-NetTCPConnection -ErrorAction Stop })
                 $after = Get-ObserverProcessSnapshot $RootId
                 Register-ObserverIdentities $after $IdentityByPid $OwnedIdentityToPid $State
                 $ownedPids = @{}
@@ -1672,6 +1977,14 @@ function Invoke-ObserverFixture {
                     if ([int]$sample.ownedConnectionMatches -eq 0) { $zeroConnectionSamples++ }
                     if ([int]$sample.nonLoopbackConnections -ne 0) { throw "non-loopback connection observed in owned TCP sample" }
                     if (Test-Path -LiteralPath $DonePath) { $rootExited = $true }
+                    if (-not [string]::IsNullOrWhiteSpace($ReleaseCheckoutPath)) {
+                        if ((Get-ObserverGitStatus $ReleaseCheckoutPath) -ne "") {
+                            throw "release checkout became dirty during output production"
+                        }
+                        $releaseStatusChecks++
+                        $releaseStatusCleanDuringRoot = $true
+                        if ($rootExited) { $releaseStatusCleanAfterOutput = $true }
+                    }
                     if ($rootExited -and -not $sample.rootPresent -and $sample.descendantCount -eq 0) {
                         if ($null -eq $observerState["rootIdentity"]) { throw "root exited before its owned process identity was captured" }
                         $continuedThroughExit = $true
@@ -1690,6 +2003,7 @@ function Invoke-ObserverFixture {
                     zeroConnectionSamples = $zeroConnectionSamples; ownedConnectionMatches = $ownedConnectionMatches
                     ownedProcessIdentityCount = [int64]$ownedIdentityToPid.Count; queryMode = $queryMode
                     forbiddenProcesses = @(); error = ""
+                    releaseStatusCleanBeforeRoot = $releaseStatusCleanBeforeRoot; releaseStatusCleanDuringRoot = $releaseStatusCleanDuringRoot; releaseStatusCleanAfterOutput = $releaseStatusCleanAfterOutput; releaseStatusChecks = $releaseStatusChecks
                 }
             } catch {
                 [pscustomobject]@{
@@ -1699,9 +2013,10 @@ function Invoke-ObserverFixture {
                     zeroConnectionSamples = $zeroConnectionSamples; ownedConnectionMatches = $ownedConnectionMatches
                     ownedProcessIdentityCount = [int64]$ownedIdentityToPid.Count; queryMode = $queryMode
                     forbiddenProcesses = @(); error = $_.Exception.Message
+                    releaseStatusCleanBeforeRoot = $releaseStatusCleanBeforeRoot; releaseStatusCleanDuringRoot = $releaseStatusCleanDuringRoot; releaseStatusCleanAfterOutput = $releaseStatusCleanAfterOutput; releaseStatusChecks = $releaseStatusChecks
                 }
             }
-        } -ArgumentList $processReadyPath, $pidPath, $donePath, $TimeoutSeconds
+        } -ArgumentList $processReadyPath, $pidPath, $donePath, $TimeoutSeconds, $observerIdentityFunctionSource, $ObserverReleaseCheckoutPath
 
         $diskJob = Start-Job -ScriptBlock {
             param($RootPath, $ReadyPath, $DonePath, $TimeoutSeconds)
@@ -1805,6 +2120,12 @@ function Invoke-ObserverFixture {
         if ($processResults.Count -eq 0 -or $diskResults.Count -eq 0) { throw "observers returned no result" }
         $processObservation = $processResults[$processResults.Count - 1]
         $diskObservation = $diskResults[$diskResults.Count - 1]
+        if (-not [string]::IsNullOrWhiteSpace($ObserverReleaseCheckoutPath)) {
+            $finalCheckoutEvidence = Assert-SmokeReleaseCheckout -RequestedCheckoutPath $ObserverReleaseCheckoutPath -RequireDistExclude
+            $releaseCheckoutEvidence.statusCleanDuringOutput = [bool]$processObservation.releaseStatusCleanDuringRoot
+            $releaseCheckoutEvidence.statusCleanAfterOutput = [bool]$finalCheckoutEvidence.statusCleanAfterPreparation
+            $releaseCheckoutEvidence.statusChecks = [int]$processObservation.releaseStatusChecks
+        }
     } catch {
         $failure = $_.Exception
         if ($processObservation.error -eq "") { $processObservation.error = $failure.Message }
@@ -1839,7 +2160,8 @@ function Invoke-ObserverFixture {
     if ($cleanupErrors.Count -ne 0 -and $processObservation.error -eq "") {
         $processObservation.error = $cleanupErrors -join "; "
     }
-    $observerPass = $goEnvironment.GOFLAGS -eq "-p=4" -and $goEnvironment.GOMAXPROCS -eq "4" -and $processObservation.status -eq "PASS" -and $processObservation.sampleCount -gt 0 -and $processObservation.tcpTableQueries -eq $processObservation.sampleCount -and $processObservation.zeroConnectionSamples -gt 0 -and $processObservation.ownedProcessIdentityCount -gt 0 -and $processObservation.queryMode -eq $expectedObserverQueryMode -and $diskObservation.status -eq "PASS" -and [bool]$diskObservation.startPeriodicFinal -and $processObservation.maximumGapMilliseconds -le $expectedProcessNetworkGapMilliseconds -and $diskObservation.maximumGapMilliseconds -le $expectedDiskGapMilliseconds -and $diskObservation.peakDeltaBytes -le $expectedTemporaryDiskBytesMaximum -and $cleanupErrors.Count -eq 0 -and $remainingTaskPaths.Count -eq 0
+    $checkoutPass = [string]::IsNullOrWhiteSpace($ObserverReleaseCheckoutPath) -or ($null -ne $releaseCheckoutEvidence -and [bool]$processObservation.releaseStatusCleanBeforeRoot -and [bool]$processObservation.releaseStatusCleanDuringRoot -and [bool]$processObservation.releaseStatusCleanAfterOutput -and [bool]$releaseCheckoutEvidence.statusCleanAfterOutput)
+    $observerPass = $goEnvironment.GOFLAGS -eq "-p=4" -and $goEnvironment.GOMAXPROCS -eq "4" -and $processObservation.status -eq "PASS" -and $processObservation.sampleCount -gt 0 -and $processObservation.tcpTableQueries -eq $processObservation.sampleCount -and $processObservation.zeroConnectionSamples -gt 0 -and $processObservation.ownedProcessIdentityCount -gt 0 -and $processObservation.queryMode -eq $expectedObserverQueryMode -and $diskObservation.status -eq "PASS" -and [bool]$diskObservation.startPeriodicFinal -and $processObservation.maximumGapMilliseconds -le $expectedProcessNetworkGapMilliseconds -and $diskObservation.maximumGapMilliseconds -le $expectedDiskGapMilliseconds -and $diskObservation.peakDeltaBytes -le $expectedTemporaryDiskBytesMaximum -and $checkoutPass -and $cleanupErrors.Count -eq 0 -and $remainingTaskPaths.Count -eq 0
     $report = [ordered]@{
         schemaVersion = "localai-windows-install-candidate-observer/v1"
         status = if ($null -eq $failure -and $rootExitCode -eq 0 -and $observerPass) { "PASS" } else { "FAIL" }
@@ -1862,6 +2184,10 @@ function Invoke-ObserverFixture {
                 queryMode = [string]$processObservation.queryMode
                 forbiddenProcesses = @($processObservation.forbiddenProcesses)
                 error = [string]$processObservation.error
+                releaseStatusCleanBeforeRoot = [bool]$processObservation.releaseStatusCleanBeforeRoot
+                releaseStatusCleanDuringRoot = [bool]$processObservation.releaseStatusCleanDuringRoot
+                releaseStatusCleanAfterOutput = [bool]$processObservation.releaseStatusCleanAfterOutput
+                releaseStatusChecks = [int]$processObservation.releaseStatusChecks
             }
             diskObserver = [ordered]@{
                 independent = [bool]$diskObservation.independent
@@ -1883,6 +2209,7 @@ function Invoke-ObserverFixture {
             remainingTaskPaths = $remainingTaskPaths
             errors = $cleanupErrors.ToArray()
         }
+        releaseCheckout = $releaseCheckoutEvidence
     }
     $reportParent = Split-Path -Parent $reportPath
     if (-not (Test-Path -LiteralPath $reportParent -PathType Container)) { Fail-Smoke "observer report parent does not exist: $reportParent" }
@@ -1891,8 +2218,32 @@ function Invoke-ObserverFixture {
     Write-Output "observer fixture passed; report=$reportPath"
 }
 
+if ($PrepareReleaseCheckout) {
+    if ([string]::IsNullOrWhiteSpace($ReleaseCheckoutPath)) {
+        Fail-Smoke "release checkout path is required for private exclude preparation"
+    }
+    $releaseCheckoutEvidence = Assert-SmokeReleaseCheckout -RequestedCheckoutPath $ReleaseCheckoutPath -PrepareDistExclude -RequireDistExclude
+    $releaseCheckoutReportPath = if ([string]::IsNullOrWhiteSpace($ReleaseCheckoutReportPath)) {
+        Join-Path (Resolve-SmokeAbsolutePath $InstallDir) "release-checkout-report.json"
+    } else {
+        Resolve-SmokeAbsolutePath $ReleaseCheckoutReportPath
+    }
+    $releaseCheckoutReportParent = Split-Path -Parent $releaseCheckoutReportPath
+    if (-not (Test-Path -LiteralPath $releaseCheckoutReportParent -PathType Container)) {
+        Fail-Smoke "release checkout report parent does not exist: $releaseCheckoutReportParent"
+    }
+    [System.IO.File]::WriteAllText($releaseCheckoutReportPath, ($releaseCheckoutEvidence | ConvertTo-Json -Depth 12))
+    Write-Output "release checkout prepared; report=$releaseCheckoutReportPath"
+    return
+}
+
+if ($ObserverIdentityFixture) {
+    Invoke-ObserverIdentityFixture -RequestedInstallDir $InstallDir -RequestedReportPath $ObserverReportPath
+    return
+}
+
 if ($ObserverFixture) {
-    Invoke-ObserverFixture -RequestedInstallDir $InstallDir -RequestedReportPath $ObserverReportPath -RootCommand $ObserverRootCommand -RootArgumentList $ObserverRootArgumentList -RootWorkingDirectory $ObserverRootWorkingDirectory -TimeoutSeconds $ObserverTimeoutSeconds
+    Invoke-ObserverFixture -RequestedInstallDir $InstallDir -RequestedReportPath $ObserverReportPath -RootCommand $ObserverRootCommand -RootArgumentList $ObserverRootArgumentList -RootWorkingDirectory $ObserverRootWorkingDirectory -ObserverReleaseCheckoutPath $ObserverReleaseCheckoutPath -TimeoutSeconds $ObserverTimeoutSeconds
     return
 }
 

--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -7,7 +7,11 @@ param(
     [string]$CandidateManifestPath,
     [string]$ReportPath,
     [switch]$ObserverFixture,
-    [string]$ObserverReportPath
+    [string]$ObserverReportPath,
+    [string]$ObserverRootCommand,
+    [string[]]$ObserverRootArgumentList,
+    [string]$ObserverRootWorkingDirectory,
+    [int]$ObserverTimeoutSeconds = 20
 )
 
 $ErrorActionPreference = "Stop"
@@ -1367,9 +1371,28 @@ function Invoke-CandidateSmoke {
 function Invoke-ObserverFixture {
     param(
         [string]$RequestedInstallDir,
-        [string]$RequestedReportPath
+        [string]$RequestedReportPath,
+        [string]$RootCommand,
+        [string[]]$RootArgumentList,
+        [string]$RootWorkingDirectory,
+        [int]$TimeoutSeconds = 20
     )
 
+    $externalRoot = -not [string]::IsNullOrWhiteSpace($RootCommand)
+    if ($TimeoutSeconds -le 0) {
+        Fail-Smoke "observer timeout must be positive"
+    }
+    $resolvedRootWorkingDirectory = $null
+    if ($externalRoot) {
+        $resolvedRootWorkingDirectory = if ([string]::IsNullOrWhiteSpace($RootWorkingDirectory)) {
+            (Get-Location).Path
+        } else {
+            Resolve-SmokeAbsolutePath $RootWorkingDirectory
+        }
+        if (-not (Test-Path -LiteralPath $resolvedRootWorkingDirectory -PathType Container)) {
+            Fail-Smoke "observer root working directory does not exist: $resolvedRootWorkingDirectory"
+        }
+    }
     $reportPath = if ([string]::IsNullOrWhiteSpace($RequestedReportPath)) {
         Join-Path (Resolve-SmokeAbsolutePath $RequestedInstallDir) "observer-report.json"
     } else {
@@ -1377,6 +1400,14 @@ function Invoke-ObserverFixture {
     }
     $fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("infinite-you-observer-" + [System.Guid]::NewGuid().ToString("N"))
     [void][System.IO.Directory]::CreateDirectory($fixtureRoot)
+    $observationRoot = if ($externalRoot) {
+        Resolve-SmokeAbsolutePath $RequestedInstallDir
+    } else {
+        $fixtureRoot
+    }
+    if (-not (Test-Path -LiteralPath $observationRoot -PathType Container)) {
+        Fail-Smoke "observer observation root does not exist: $observationRoot"
+    }
     $processReadyPath = Join-Path $fixtureRoot "process-ready"
     $diskReadyPath = Join-Path $fixtureRoot "disk-ready"
     $pidPath = Join-Path $fixtureRoot "root.pid"
@@ -1405,7 +1436,7 @@ function Invoke-ObserverFixture {
 
     try {
         $processJob = Start-Job -ScriptBlock {
-            param($ReadyPath, $PidPath, $DonePath)
+            param($ReadyPath, $PidPath, $DonePath, $TimeoutSeconds)
             $ErrorActionPreference = "Stop"
             $processNetworkGapMaximumMilliseconds = [int64]2000
             $descendantMaximum = [int64]36
@@ -1592,7 +1623,7 @@ function Invoke-ObserverFixture {
             $zeroConnectionSamples = 0
             $ownedConnectionMatches = 0
             try {
-                $deadline = [DateTime]::UtcNow.AddSeconds(20)
+                $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
                 while (-not (Test-Path -LiteralPath $PidPath) -and [DateTime]::UtcNow -lt $deadline) { Start-Sleep -Milliseconds 25 }
                 if (-not (Test-Path -LiteralPath $PidPath)) { throw "root PID was not published" }
                 $rootId = [int]([System.IO.File]::ReadAllText($PidPath)).Trim()
@@ -1648,10 +1679,10 @@ function Invoke-ObserverFixture {
                     forbiddenProcesses = @(); error = $_.Exception.Message
                 }
             }
-        } -ArgumentList $processReadyPath, $pidPath, $donePath
+        } -ArgumentList $processReadyPath, $pidPath, $donePath, $TimeoutSeconds
 
         $diskJob = Start-Job -ScriptBlock {
-            param($RootPath, $ReadyPath, $DonePath)
+            param($RootPath, $ReadyPath, $DonePath, $TimeoutSeconds)
             $ErrorActionPreference = "Stop"
             $diskGapMaximumMilliseconds = [int64]2000
             $temporaryDiskMaximum = [int64]4294967296
@@ -1673,7 +1704,7 @@ function Invoke-ObserverFixture {
                 $previous = $null
                 $initialBytes = $null
                 $finalSample = $false
-                $deadline = $startedAt.AddSeconds(20)
+                $deadline = $startedAt.AddSeconds($TimeoutSeconds)
                 while ([DateTime]::UtcNow -lt $deadline) {
                     $bytes = [int64](Get-ObserverDirectoryBytes)
                     $now = [DateTime]::UtcNow
@@ -1722,7 +1753,7 @@ function Invoke-ObserverFixture {
                     maximumGapMilliseconds = $maximumGap; peakDeltaBytes = [int64]$peakBytes; error = $_.Exception.Message
                 }
             }
-        } -ArgumentList $fixtureRoot, $diskReadyPath, $donePath
+        } -ArgumentList $observationRoot, $diskReadyPath, $donePath, $TimeoutSeconds
 
         $readyDeadline = [DateTime]::UtcNow.AddSeconds(10)
         # Readiness is polled only until both independent observer jobs publish
@@ -1730,14 +1761,19 @@ function Invoke-ObserverFixture {
         while ((-not (Test-Path -LiteralPath $processReadyPath) -or -not (Test-Path -LiteralPath $diskReadyPath)) -and [DateTime]::UtcNow -lt $readyDeadline) { Start-Sleep -Milliseconds 25 }
         if (-not (Test-Path -LiteralPath $processReadyPath) -or -not (Test-Path -LiteralPath $diskReadyPath)) { throw "observers did not start before root" }
 
+        if ($externalRoot) {
+            $rootProcess = Start-Process -FilePath $RootCommand -WorkingDirectory $resolvedRootWorkingDirectory -WindowStyle Hidden -ArgumentList @($RootArgumentList) -PassThru
+        } else {
         $childOne = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("Start-Sleep -Milliseconds 2500"))
         $childTwo = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("Start-Sleep -Milliseconds 3000"))
         $fixtureFile = (Join-Path $fixtureRoot "fixture.txt").Replace("'", "''")
         $rootScript = "`$ErrorActionPreference = 'Stop'; Set-Content -LiteralPath '$fixtureFile' -Value ('fixture' * 64); `$one = Start-Process -FilePath 'powershell.exe' -WindowStyle Hidden -ArgumentList @('-NoProfile','-NonInteractive','-EncodedCommand','$childOne') -PassThru; `$two = Start-Process -FilePath 'powershell.exe' -WindowStyle Hidden -ArgumentList @('-NoProfile','-NonInteractive','-EncodedCommand','$childTwo') -PassThru; Wait-Process -Id @(`$one.Id, `$two.Id); exit 0"
         $rootEncoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($rootScript))
         $rootProcess = Start-Process -FilePath "powershell.exe" -WorkingDirectory $fixtureRoot -WindowStyle Hidden -ArgumentList @("-NoProfile", "-NonInteractive", "-EncodedCommand", $rootEncoded) -PassThru
+        }
         [System.IO.File]::WriteAllText($pidPath, [string]$rootProcess.Id)
-        if (-not $rootProcess.WaitForExit(15000)) { throw "observer fixture root timed out" }
+        $waitMilliseconds = [int][Math]::Min([int64]2147483647, [int64]$TimeoutSeconds * 1000)
+        if (-not $rootProcess.WaitForExit($waitMilliseconds)) { throw "observer root timed out" }
         $rootExitCode = [int64]$rootProcess.ExitCode
         [System.IO.File]::WriteAllText($donePath, "done")
         $completedJobs = @(Wait-Job -Job @($processJob, $diskJob) -Timeout 25)
@@ -1786,7 +1822,7 @@ function Invoke-ObserverFixture {
         schemaVersion = "localai-windows-install-candidate-observer/v1"
         status = if ($null -eq $failure -and $rootExitCode -eq 0 -and $observerPass) { "PASS" } else { "FAIL" }
         cycle = $expectedCandidateCycle
-        releaseStatus = "observer-fixture"
+        releaseStatus = if ($externalRoot) { "observed-command" } else { "observer-fixture" }
         observation = [ordered]@{
             environment = $goEnvironment
             processNetworkObserver = [ordered]@{
@@ -1834,7 +1870,7 @@ function Invoke-ObserverFixture {
 }
 
 if ($ObserverFixture) {
-    Invoke-ObserverFixture -RequestedInstallDir $InstallDir -RequestedReportPath $ObserverReportPath
+    Invoke-ObserverFixture -RequestedInstallDir $InstallDir -RequestedReportPath $ObserverReportPath -RootCommand $ObserverRootCommand -RootArgumentList $ObserverRootArgumentList -RootWorkingDirectory $ObserverRootWorkingDirectory -TimeoutSeconds $ObserverTimeoutSeconds
     return
 }
 

--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -158,6 +158,41 @@ function Get-SmokeFileEvidence {
     }
 }
 
+function Copy-SmokeNativeToolToShortPath {
+    param(
+        [string]$SourcePath,
+        [string]$DestinationPath,
+        [string]$ExpectedSHA256
+    )
+    if ($ExpectedSHA256 -notmatch '^[0-9a-fA-F]{64}$') {
+        Fail-Smoke "native tool SHA-256 must be a 64-character digest"
+    }
+    $sourceEvidence = Get-SmokeFileEvidence "native tool" $SourcePath
+    if ($sourceEvidence.sha256 -cne $ExpectedSHA256.ToLowerInvariant()) {
+        Fail-Smoke "native tool SHA-256 is $($sourceEvidence.sha256), want $($ExpectedSHA256.ToLowerInvariant())"
+    }
+    $destination = Resolve-SmokePath $DestinationPath
+    if (Test-Path -LiteralPath $destination) {
+        Fail-Smoke "short native tool destination already exists: $destination"
+    }
+    if ($destination.Length -gt $SmokeMaximumTaskRootPathLength) {
+        Fail-Smoke "short native tool path is $($destination.Length) characters, want at most $SmokeMaximumTaskRootPathLength"
+    }
+    [void][System.IO.Directory]::CreateDirectory((Split-Path -Parent $destination))
+    Copy-Item -LiteralPath (Resolve-SmokePath $SourcePath) -Destination $destination -Force
+    $destinationEvidence = Get-SmokeFileEvidence "short native tool" $destination
+    if ($destinationEvidence.bytes -ne $sourceEvidence.bytes -or
+        $destinationEvidence.sha256 -cne $ExpectedSHA256.ToLowerInvariant()) {
+        Fail-Smoke "short native tool bytes or SHA-256 differ from the verified source"
+    }
+    return [ordered]@{
+        source = $sourceEvidence
+        destination = $destinationEvidence
+        path = $destination
+        pathLength = $destination.Length
+    }
+}
+
 function Get-SmokeDirectoryBytes {
     param([string]$Path)
     $total = [int64]0
@@ -808,7 +843,7 @@ function Invoke-LocalCandidateSmoke {
     [void][System.IO.Directory]::CreateDirectory($workDirectory)
     $checkoutPath = Join-Path $workDirectory "src"
     $extractPath = Join-Path $workDirectory "archive"
-    $environmentNames = @("GOFLAGS", "GOMAXPROCS", "GOPROXY", "GOSUMDB", "GOTOOLCHAIN", "npm_config_offline")
+    $environmentNames = @("GOFLAGS", "GOMAXPROCS", "GOPROXY", "GOSUMDB", "GOTOOLCHAIN", "npm_config_offline", "ESBUILD_BINARY_PATH")
     $originalEnvironment = @{}
     foreach ($name in $environmentNames) {
         $originalEnvironment[$name] = [System.Environment]::GetEnvironmentVariable($name, "Process")
@@ -871,13 +906,17 @@ function Invoke-LocalCandidateSmoke {
         if ($esbuildPath.Length -gt 220) {
             Fail-Smoke "staged esbuild path is $($esbuildPath.Length) characters, want at most 220"
         }
-        $esbuildResult = Invoke-CandidateCommand -FilePath $esbuildPath `
+        $esbuildOverridePath = Join-Path $workDirectory "esbuild-native.exe"
+        $esbuildOverride = Copy-SmokeNativeToolToShortPath -SourcePath $esbuildPath `
+            -DestinationPath $esbuildOverridePath -ExpectedSHA256 $EsbuildSHA256
+        $esbuildResult = Invoke-CandidateCommand -FilePath $esbuildOverridePath `
             -ArgumentList @("--version") -WorkingDirectory $checkoutPath `
             -StdoutPath (Join-Path $outputDirectory "esbuild.stdout.log") `
             -StderrPath (Join-Path $outputDirectory "esbuild.stderr.log")
         if ($esbuildResult.exitCode -ne 0 -or $esbuildResult.stdout.Trim() -cne $EsbuildVersion) {
             Fail-Smoke "esbuild sanity check failed: exit=$($esbuildResult.exitCode) version='$($esbuildResult.stdout.Trim())'"
         }
+        $env:ESBUILD_BINARY_PATH = $esbuildOverridePath
         $releaseToolEvidence = Get-SmokeFileEvidence "goreleaser" $releaseToolPath
         $releaseToolResult = Invoke-CandidateCommand -FilePath $releaseToolPath `
             -ArgumentList @("--version") -WorkingDirectory $checkoutPath `
@@ -922,8 +961,10 @@ function Invoke-LocalCandidateSmoke {
             config = Get-SmokeFileEvidence "goreleaser-config" (Join-Path $checkoutPath ".goreleaser.yml")
             bunLock = $sourceLock
             esbuild = $esbuildEvidence
+            esbuildOverride = $esbuildOverride
             esbuildVersion = $EsbuildVersion
             esbuildPathLength = $esbuildPath.Length
+            esbuildOverridePathLength = $esbuildOverride.pathLength
             workBytes = $workBytes
             maximumWorkBytes = $MaximumWorkBytes
             environment = [ordered]@{
@@ -933,6 +974,7 @@ function Invoke-LocalCandidateSmoke {
                 GOSUMDB = $env:GOSUMDB
                 GOTOOLCHAIN = $env:GOTOOLCHAIN
                 npm_config_offline = $env:npm_config_offline
+                ESBUILD_BINARY_PATH = $env:ESBUILD_BINARY_PATH
             }
         }
         if ($releaseResult.exitCode -ne 0) {

--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -1,1674 +1,708 @@
+<#
+.SYNOPSIS
+Smoke-tests a hosted release or builds and installs one local Windows candidate.
+
+.DESCRIPTION
+Candidate mode takes the source commit, repository, cached UI dependency tree,
+and native tool hashes as arguments. A new candidate identity does not require
+editing this script. The work directory must be short, absent or empty, and
+separate from the retained output and clean install directories.
+#>
 param(
     [string]$InstallScriptUrl,
     [string]$InstallVersion,
     [Parameter(Mandatory = $true)]
     [string]$InstallDir,
     [string]$BinaryName = "you.exe",
-    [string]$CandidateManifestPath,
-    [string]$ReportPath,
-    [switch]$ObserverFixture,
-    [switch]$ObserverIdentityFixture,
-    [string]$ObserverReportPath,
-    [string]$ObserverRootCommand,
-    [string[]]$ObserverRootArgumentList,
-    [string]$ObserverRootWorkingDirectory,
-    [string]$ObserverRootStdoutPath,
-    [string]$ObserverRootStderrPath,
-    [int]$ObserverRootOutputMaximumBytes = 1048576,
-    [int]$ObserverRootExitCode = 0,
-    [switch]$StageDependencyClosure,
-    [switch]$VerifyDependencyClosure,
-    [string]$DependencySourceRoot,
-    [string]$DependencyStageRoot,
-    [string]$DependencySourceManifestPath,
-    [string]$DependencyStageManifestPath,
-    [string]$DependencyExpectedManifestPath,
-    [string]$DependencyPostBuildManifestPath,
-    [string]$DependencySourceAfterManifestPath,
-    [string]$DependencyReportPath,
-    [string]$DependencyExpectedLockSHA256 = "45ca702f71dbd8fbf47855dcf8cdb86b13785a009b2c107153ba52e0b20157ad",
-    [string]$DependencyExpectedLockBlob = "d6e4b715db635497bfcac0db085163ea719d21ab",
-    [string]$ObserverReleaseCheckoutPath,
-    [switch]$PrepareReleaseCheckout,
-    [string]$ReleaseCheckoutPath,
-    [string]$ReleaseCheckoutReportPath,
-    [int]$ObserverTimeoutSeconds = 20
+    [string]$CandidateSourcePath,
+    [string]$CandidateSourceCommit,
+    [string]$CandidateSourceRepository,
+    [string]$CandidateDependencySourcePath,
+    [string]$CandidateOutputDir,
+    [string]$CandidateWorkDir,
+    [string]$GoReleaserPath,
+    [string]$ExpectedGoReleaserVersion,
+    [string]$ExpectedEsbuildVersion,
+    [string]$ExpectedEsbuildSHA256,
+    [int64]$CandidateMaximumWorkBytes = 4294967296,
+    [string]$ReportPath
 )
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
-
-$expectedCandidateCycle = "070"
-$expectedCandidateGoVersion = "go1.26.8"
-$expectedObserverQueryMode = "one-full-TCP-table-query-per-interval-filtered-to-owned-process-identities"
-$expectedProcessNetworkGapMilliseconds = 2000
-$expectedDiskGapMilliseconds = 2000
-$expectedDescendantMaximum = 36
-$expectedTemporaryDiskBytesMaximum = [int64]4294967296
-$expectedCandidateSourceRepository = "https://github.com/portpowered/you-agent-factory"
-$expectedCandidateSourceCommit = "059474b2c00915865306a33ca5e3d02b618bb6f0"
-$expectedCandidateSourceTree = "ae5d9c87fbc99a898ad2c11e1409105d78e4a094"
-$expectedDependencyLockSHA256 = "45ca702f71dbd8fbf47855dcf8cdb86b13785a009b2c107153ba52e0b20157ad"
-$expectedDependencyLockBlob = "d6e4b715db635497bfcac0db085163ea719d21ab"
-
-$observerIdentityFunctionSource = @'
-function Register-ObserverIdentities {
-    param(
-        [object]$Snapshot,
-        [hashtable]$IdentityByPid,
-        [hashtable]$OwnedIdentityToPid,
-        [hashtable]$State
-    )
-
-    foreach ($record in @($Snapshot.ownedRecords)) {
-        if ($null -eq $record) { continue }
-        $processId = [int]$record.processId
-        $identity = [string]$record.identity
-        if ($IdentityByPid.ContainsKey($processId) -and [string]$IdentityByPid[$processId] -cne $identity) {
-            throw "owned process PID $processId changed identity from $($IdentityByPid[$processId]) to $identity"
-        }
-        if ($OwnedIdentityToPid.ContainsKey($identity) -and [int]$OwnedIdentityToPid[$identity] -ne $processId) {
-            throw "owned process identity $identity is ambiguous across PIDs"
-        }
-        $IdentityByPid[$processId] = $identity
-        $OwnedIdentityToPid[$identity] = $processId
-    }
-    if ($Snapshot.rootPresent) {
-        $identity = [string]$Snapshot.root.identity
-        if ($null -eq $State["rootIdentity"]) {
-            $State["rootIdentity"] = $identity
-        } elseif ([string]$State["rootIdentity"] -cne $identity) {
-            throw "owned root identity changed from $($State['rootIdentity']) to $identity"
-        }
-    }
-}
-
-function Remove-ObserverInactivePidIdentities {
-    param(
-        [object]$Snapshot,
-        [hashtable]$IdentityByPid
-    )
-
-    # A PID may be reused after its prior owned process has disappeared
-    # between intervals. Retire both an absent PID and a PID whose current
-    # creation identity differs, but retain every identity in the historical
-    # OwnedIdentityToPid ledger. Register-ObserverIdentities still compares
-    # the before/after pair without retirement, so reuse during one TCP query
-    # remains fail closed.
-    $activeIdentities = @{}
-    foreach ($record in @($Snapshot.ownedRecords)) {
-        if ($null -ne $record) {
-            $activeIdentities[[int]$record.processId] = [string]$record.identity
-        }
-    }
-    foreach ($processId in @($IdentityByPid.Keys)) {
-        $processId = [int]$processId
-        if (-not $activeIdentities.ContainsKey($processId) -or [string]$IdentityByPid[$processId] -cne [string]$activeIdentities[$processId]) {
-            [void]$IdentityByPid.Remove($processId)
-        }
-    }
-}
-
-function Get-ObserverConnectionTable {
-    param([scriptblock]$Query)
-
-    if ($null -eq $Query) {
-        throw "TCP-table query is missing"
-    }
-    try {
-        return @(& $Query)
-    } catch {
-        throw "TCP-table query failed: $($_.Exception.Message)"
-    }
-}
-
-function Get-ObserverGitStatus {
-    param([string]$CheckoutPath)
-
-    if ([string]::IsNullOrWhiteSpace($CheckoutPath)) {
-        return ""
-    }
-    $output = @(& git.exe -C $CheckoutPath status --porcelain=v1 --untracked-files=all 2>&1)
-    if ($LASTEXITCODE -ne 0) {
-        throw "release checkout Git status failed: $($output -join ' ')"
-    }
-    return (($output | ForEach-Object { [string]$_ }) -join "`n").Trim()
-}
-'@
-
-function Get-ObserverGitStatus {
-    param([string]$CheckoutPath)
-
-    if ([string]::IsNullOrWhiteSpace($CheckoutPath)) {
-        return ""
-    }
-    $output = @(& git.exe -C $CheckoutPath status --porcelain=v1 --untracked-files=all 2>&1)
-    if ($LASTEXITCODE -ne 0) {
-        throw "release checkout Git status failed: $($output -join ' ')"
-    }
-    return (($output | ForEach-Object { [string]$_ }) -join "`n").Trim()
-}
 
 function Fail-Smoke {
     param([string]$Message)
     throw "install smoke: $Message"
 }
 
-function Get-SmokeRootOutputEvidence {
-    param(
-        [string]$RawPath,
-        [string]$RetainedPath,
-        [int]$MaximumBytes
-    )
-
-    if ($MaximumBytes -le 0) {
-        Fail-Smoke "root output maximum must be positive"
-    }
-    Ensure-SmokeFileHashCommand
-    $rawItem = Get-Item -LiteralPath $RawPath -Force -ErrorAction SilentlyContinue
-    if ($null -eq $rawItem -or $rawItem.PSIsContainer -or (($rawItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
-        Fail-Smoke "root output evidence is missing or not a regular file: $RawPath"
-    }
-    $retainedPath = Resolve-SmokeAbsolutePath $RetainedPath
-    $retainedParent = Split-Path -Parent $retainedPath
-    if (-not (Test-Path -LiteralPath $retainedParent -PathType Container)) {
-        Fail-Smoke "root output evidence parent does not exist: $retainedParent"
-    }
-    $rawBytes = [System.IO.File]::ReadAllBytes($RawPath)
-    $totalBytes = [int64]$rawBytes.Length
-    $capturedByteCount = [int][Math]::Min([int64]$MaximumBytes, $totalBytes)
-    $capturedBytes = New-Object byte[] $capturedByteCount
-    if ($capturedByteCount -gt 0) {
-        [System.Array]::Copy($rawBytes, $capturedBytes, $capturedByteCount)
-    }
-    $text = [System.Text.Encoding]::UTF8.GetString($capturedBytes)
-    $redactionPattern = '(?i)(token|password|secret|api[_-]?key|authorization)\s*([:=])\s*[^\s,;]+'
-    $redactedBytes = [int64]0
-    foreach ($match in [System.Text.RegularExpressions.Regex]::Matches($text, $redactionPattern)) {
-        $value = [string]$match.Value
-        $separatorIndex = $value.IndexOfAny([char[]]@(':', '='))
-        if ($separatorIndex -ge 0 -and $separatorIndex + 1 -lt $value.Length) {
-            $redactedValue = $value.Substring($separatorIndex + 1).Trim()
-            $redactedBytes += [int64][System.Text.Encoding]::UTF8.GetByteCount($redactedValue)
-        }
-    }
-    $redactedText = [System.Text.RegularExpressions.Regex]::Replace($text, $redactionPattern, '$1$2<redacted>')
-    [System.IO.File]::WriteAllText($retainedPath, $redactedText, [System.Text.UTF8Encoding]::new($false))
-    $retainedItem = Get-Item -LiteralPath $retainedPath -Force -ErrorAction Stop
-    if ($retainedItem.PSIsContainer -or (($retainedItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
-        Fail-Smoke "retained root output evidence is not a regular file: $retainedPath"
-    }
-    try {
-        Remove-Item -LiteralPath $RawPath -Force -ErrorAction Stop
-    } catch {
-        Fail-Smoke "unredacted root output evidence could not be removed: $RawPath; $($_.Exception.Message)"
-    }
-    return [ordered]@{
-        status = "PASS"
-        path = $retainedPath
-        present = $true
-        totalBytes = $totalBytes
-        capturedBytes = [int64]$capturedByteCount
-        truncated = ($totalBytes -gt $MaximumBytes)
-        redactedBytes = $redactedBytes
-        sha256 = ((Get-FileHash -LiteralPath $retainedPath -Algorithm SHA256).Hash.ToLowerInvariant())
-    }
+function Resolve-SmokePath {
+    param([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path)) { Fail-Smoke "path is required" }
+    if ([System.IO.Path]::IsPathRooted($Path)) { return [System.IO.Path]::GetFullPath($Path) }
+    return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
 }
 
-function Ensure-SmokeFileHashCommand {
-    if ($null -ne (Get-Command Get-FileHash -ErrorAction SilentlyContinue)) {
-        return
-    }
-
-    function global:Get-FileHash {
-        param(
-            [string[]]$Path,
-            [string[]]$LiteralPath,
-            [string]$Algorithm = "SHA256"
-        )
-
-        $paths = if ($null -ne $LiteralPath -and $LiteralPath.Count -ne 0) {
-            $LiteralPath
-        } else {
-            @(Resolve-Path -Path $Path | ForEach-Object { $_.ProviderPath })
-        }
-        foreach ($filePath in $paths) {
-            $hasher = [System.Security.Cryptography.HashAlgorithm]::Create($Algorithm)
-            $stream = [System.IO.File]::OpenRead($filePath)
-            try {
-                $digest = $hasher.ComputeHash($stream)
-            } finally {
-                $stream.Dispose()
-                $hasher.Dispose()
-            }
-            [pscustomobject]@{
-                Algorithm = $Algorithm.ToUpperInvariant()
-                Hash = [System.BitConverter]::ToString($digest).Replace("-", "")
-                Path = $filePath
-            }
-        }
-    }
-
-    if ($null -eq (Get-Command Get-FileHash -ErrorAction SilentlyContinue)) {
-        Fail-Smoke "candidate mode could not establish the SHA-256 file-hash observer"
-    }
-}
-
-function Resolve-SmokeAbsolutePath {
-    param([string]$Value)
-
-    if ([string]::IsNullOrWhiteSpace($Value)) {
-        Fail-Smoke "path is required"
-    }
-    if ([System.IO.Path]::IsPathRooted($Value)) {
-        return [System.IO.Path]::GetFullPath($Value)
-    }
-    return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Value))
-}
-
-function Invoke-SmokeGit {
-    param(
-        [string]$CheckoutPath,
-        [string[]]$ArgumentList
-    )
-
-    $output = @(& git.exe -C $CheckoutPath @ArgumentList 2>&1)
-    if ($LASTEXITCODE -ne 0) {
-        Fail-Smoke "git -C $CheckoutPath $($ArgumentList -join ' ') failed: $($output -join ' ')"
-    }
-    return @($output | ForEach-Object { [string]$_ })
-}
-
-function Assert-SmokeReleaseCheckout {
-    param(
-        [string]$RequestedCheckoutPath,
-        [switch]$PrepareDistExclude,
-        [switch]$RequireDistExclude
-    )
-
-    $checkoutPath = Resolve-SmokeAbsolutePath $RequestedCheckoutPath
-    $gitPath = Join-Path $checkoutPath ".git"
-    $gitItem = Get-Item -LiteralPath $gitPath -Force -ErrorAction SilentlyContinue
-    if ($null -eq $gitItem -or -not $gitItem.PSIsContainer) {
-        Fail-Smoke "release checkout .git is not a real directory: $gitPath"
-    }
-    $topLevel = (Invoke-SmokeGit $checkoutPath @("rev-parse", "--show-toplevel") | Select-Object -Last 1).Trim()
-    if ([System.IO.Path]::GetFullPath($topLevel) -ne $checkoutPath) {
-        Fail-Smoke "release checkout top-level = $topLevel, want $checkoutPath"
-    }
-    $head = (Invoke-SmokeGit $checkoutPath @("rev-parse", "HEAD") | Select-Object -Last 1).Trim()
-    if ($head -cne $expectedCandidateSourceCommit) {
-        Fail-Smoke "release checkout HEAD = $head, want $expectedCandidateSourceCommit"
-    }
-    $tree = (Invoke-SmokeGit $checkoutPath @("rev-parse", "HEAD^{tree}") | Select-Object -Last 1).Trim()
-    if ($tree -cne $expectedCandidateSourceTree) {
-        Fail-Smoke "release checkout tree = $tree, want $expectedCandidateSourceTree"
-    }
-    $branch = (Invoke-SmokeGit $checkoutPath @("rev-parse", "--abbrev-ref", "HEAD") | Select-Object -Last 1).Trim()
-    if ($branch -cne "HEAD") {
-        Fail-Smoke "release checkout is not detached: branch=$branch"
-    }
-    $origin = (Invoke-SmokeGit $checkoutPath @("remote", "get-url", "origin") | Select-Object -Last 1).Trim()
-    if ($origin -match "^(https?|ssh)://" -or $origin -match "^git@") {
-        Fail-Smoke "release checkout origin is not local-filesystem-only: $origin"
-    }
-    $statusBefore = Get-ObserverGitStatus $checkoutPath
-    if ($statusBefore -ne "") {
-        Fail-Smoke "release checkout is dirty before output production: $statusBefore"
-    }
-    $excludePath = Join-Path $gitPath "info\exclude"
-    if (-not (Test-Path -LiteralPath $excludePath -PathType Leaf)) {
-        Fail-Smoke "release checkout private exclude is missing: $excludePath"
-    }
-    $beforeLines = @([System.IO.File]::ReadAllLines($excludePath))
-    $beforeDistCount = @($beforeLines | Where-Object { $_ -ceq "/dist/" }).Count
-    if ($PrepareDistExclude) {
-        if ($beforeDistCount -ne 0) {
-            Fail-Smoke "release checkout private exclude already contains /dist/"
-        }
-        $existingText = [System.IO.File]::ReadAllText($excludePath)
-        $separator = if ($existingText.EndsWith("`n") -or $existingText.EndsWith("`r") -or $existingText.Length -eq 0) { "" } else { [Environment]::NewLine }
-        [System.IO.File]::AppendAllText($excludePath, $separator + "/dist/" + [Environment]::NewLine, [System.Text.UTF8Encoding]::new($false))
-    }
-    $afterLines = @([System.IO.File]::ReadAllLines($excludePath))
-    $afterDistCount = @($afterLines | Where-Object { $_ -ceq "/dist/" }).Count
-    if ($RequireDistExclude -and $afterDistCount -ne 1) {
-        Fail-Smoke "release checkout private exclude must contain exactly one /dist/ entry, found $afterDistCount"
-    }
-    if ($PrepareDistExclude) {
-        if ($afterLines.Count -ne $beforeLines.Count + 1 -or $afterLines[$afterLines.Count - 1] -cne "/dist/") {
-            Fail-Smoke "release checkout private exclude changed by more than the exact /dist/ addition"
-        }
-        for ($index = 0; $index -lt $beforeLines.Count; $index++) {
-            if ($afterLines[$index] -cne $beforeLines[$index]) {
-                Fail-Smoke "release checkout private exclude changed before the exact /dist/ addition"
-            }
-        }
-    }
-    $statusAfter = Get-ObserverGitStatus $checkoutPath
-    if ($statusAfter -ne "") {
-        Fail-Smoke "release checkout is dirty after private exclude preparation: $statusAfter"
-    }
-    $privateExcludeAdded = New-Object 'System.Collections.Generic.List[string]'
-    if ($PrepareDistExclude) {
-        [void]$privateExcludeAdded.Add("/dist/")
-    }
-    return [ordered]@{
-        status = "PASS"
-        gitDirIsDirectory = $true
-        checkoutPath = $checkoutPath
-        detachedHead = $true
-        head = $head
-        tree = $tree
-        origin = $origin
-        privateExcludePath = $excludePath
-        privateExcludeBefore = $beforeLines
-        privateExcludeAfter = $afterLines
-        privateExcludeAdded = $privateExcludeAdded
-        statusCleanBefore = ($statusBefore -eq "")
-        statusCleanAfterPreparation = ($statusAfter -eq "")
-    }
-}
-
-function Assert-SmokeDisposableRoot {
-    param(
-        [string]$Name,
-        [string]$Path
-    )
-
-    if (-not [System.IO.Path]::IsPathRooted($Path)) {
-        Fail-Smoke "declared root '$Name' is not absolute: $Path"
-    }
-
+function Assert-SmokeEmptyRoot {
+    param([string]$Name, [string]$Path)
     $item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
-    if ($null -eq $item) {
-        return
+    if ($null -eq $item) { return }
+    if (-not $item.PSIsContainer -or (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+        Fail-Smoke "$Name must be absent or an empty regular directory: $Path"
     }
-    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
-        Fail-Smoke "declared root '$Name' is a reparse point; it must be absent or empty"
-    }
-    if (-not $item.PSIsContainer) {
-        Fail-Smoke "declared root '$Name' is a file; it must be absent or an empty directory"
-    }
-
-    $entries = @(Get-ChildItem -LiteralPath $Path -Force -ErrorAction Stop)
-    if ($entries.Count -ne 0) {
-        Fail-Smoke "declared root '$Name' is not empty: $((($entries | ForEach-Object Name) -join ', '))"
-    }
+    if (@(Get-ChildItem -LiteralPath $Path -Force -ErrorAction Stop).Count -ne 0) { Fail-Smoke "$Name must be empty: $Path" }
 }
 
-function Assert-SmokeNewEvidenceFile {
-    param(
-        [string]$Name,
-        [string]$RequestedPath
-    )
-
-    $path = Resolve-SmokeAbsolutePath $RequestedPath
-    $parent = Split-Path -Parent $path
-    if (-not (Test-Path -LiteralPath $parent -PathType Container)) {
-        Fail-Smoke "$Name parent does not exist: $parent"
+function Assert-SmokeRegularFile {
+    param([string]$Name, [string]$Path)
+    $item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+    if ($null -eq $item -or $item.PSIsContainer -or (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+        Fail-Smoke "$Name is missing or is not a regular file: $Path"
     }
-    $item = Get-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
-    if ($null -ne $item) {
-        Fail-Smoke "$Name already exists; prior evidence cannot be reused: $path"
-    }
-    return $path
+    return $item
 }
 
-function Get-SmokeSHA256 {
-    param([string]$Path)
-
+function Get-SmokeFileEvidence {
+    param([string]$Role, [string]$Path)
+    $item = Assert-SmokeRegularFile $Role $Path
     $hasher = [System.Security.Cryptography.SHA256]::Create()
-    $stream = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    $stream = [System.IO.File]::OpenRead($item.FullName)
     try {
         $digest = $hasher.ComputeHash($stream)
     } finally {
         $stream.Dispose()
         $hasher.Dispose()
     }
-    return ([System.BitConverter]::ToString($digest).Replace("-", "").ToLowerInvariant())
-}
-
-function Get-SmokeRelativePath {
-    param(
-        [string]$RootPath,
-        [string]$CandidatePath,
-        [string]$Role = "path"
-    )
-
-    $root = [System.IO.Path]::GetFullPath($RootPath).TrimEnd([char[]]"\/")
-    $candidate = [System.IO.Path]::GetFullPath($CandidatePath)
-    if ($candidate.Equals($root, [System.StringComparison]::OrdinalIgnoreCase)) {
-        return "."
-    }
-    $prefix = $root + [System.IO.Path]::DirectorySeparatorChar
-    if (-not $candidate.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
-        Fail-Smoke "$Role resolves outside the contained root: $candidate"
-    }
-    return $candidate.Substring($prefix.Length).Replace([System.IO.Path]::DirectorySeparatorChar, '/')
-}
-
-function Get-SmokeDependencyLinkTarget {
-    param(
-        [object]$Item,
-        [string]$ContainmentRoot
-    )
-
-    $targetProperty = $Item.PSObject.Properties["Target"]
-    $targets = @(
-        if ($null -eq $targetProperty) { @() } else { @($targetProperty.Value) }
-    )
-    if ($targets.Count -ne 1 -or [string]::IsNullOrWhiteSpace([string]$targets[0])) {
-        Fail-Smoke "dependency link has ambiguous or missing target: $($Item.FullName)"
-    }
-    $target = [string]$targets[0]
-    if (-not [System.IO.Path]::IsPathRooted($target)) {
-        $target = Join-Path (Split-Path -Parent $Item.FullName) $target
-    }
-    $target = [System.IO.Path]::GetFullPath($target)
-    $targetItem = Get-Item -LiteralPath $target -Force -ErrorAction SilentlyContinue
-    if ($null -eq $targetItem) {
-        Fail-Smoke "dependency link target is missing: $($Item.FullName) -> $target"
-    }
-    $targetRelative = Get-SmokeRelativePath -RootPath $ContainmentRoot -CandidatePath $target -Role "dependency link target"
-    return [pscustomobject]@{
-        absolute = $target
-        relative = $targetRelative
-    }
-}
-
-function Get-SmokeDependencyLinkItems {
-    param([string]$RootPath)
-
-    $rootItem = Get-Item -LiteralPath $RootPath -Force -ErrorAction Stop
-    $pending = New-Object 'System.Collections.Generic.Queue[string]'
-    $links = New-Object 'System.Collections.Generic.List[object]'
-    $pending.Enqueue($rootItem.FullName)
-    while ($pending.Count -gt 0) {
-        $directory = $pending.Dequeue()
-        foreach ($item in @(Get-ChildItem -LiteralPath $directory -Force -ErrorAction Stop)) {
-            $isReparse = (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)
-            if ($isReparse) {
-                [void]$links.Add($item)
-                continue
-            }
-            if ($item.PSIsContainer) {
-                $pending.Enqueue($item.FullName)
-            }
-        }
-    }
-    return @($links.ToArray())
-}
-
-function Get-SmokeDependencyEntries {
-    param(
-        [string]$RootPath,
-        [string]$ContainmentRoot
-    )
-
-    $rootItem = Get-Item -LiteralPath $RootPath -Force -ErrorAction Stop
-    if (-not $rootItem.PSIsContainer -or (($rootItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
-        Fail-Smoke "dependency root is not a regular directory: $RootPath"
-    }
-    $rootFullPath = [System.IO.Path]::GetFullPath($rootItem.FullName)
-    $containmentFullPath = [System.IO.Path]::GetFullPath($ContainmentRoot)
-    $entries = New-Object 'System.Collections.Generic.List[object]'
-    [void]$entries.Add([ordered]@{
-            path = "."
-            type = "directory"
-            bytes = [int64]0
-            sha256 = ""
-            target = $null
-        })
-    $pending = New-Object 'System.Collections.Generic.Queue[string]'
-    $pending.Enqueue($rootFullPath)
-    while ($pending.Count -gt 0) {
-        $directory = $pending.Dequeue()
-        foreach ($item in @(Get-ChildItem -LiteralPath $directory -Force -ErrorAction Stop)) {
-            $relative = Get-SmokeRelativePath -RootPath $rootFullPath -CandidatePath $item.FullName -Role "dependency entry"
-            $isReparse = (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)
-            if ($isReparse) {
-                $linkTypeProperty = $item.PSObject.Properties["LinkType"]
-                $linkType = if ($null -eq $linkTypeProperty) { "" } else { [string]$linkTypeProperty.Value }
-                $link = Get-SmokeDependencyLinkTarget -Item $item -ContainmentRoot $containmentFullPath
-                $type = if ($linkType -eq "Junction") { "junction" } elseif ($linkType -eq "SymbolicLink") { "symlink" } else { "" }
-                if ([string]::IsNullOrWhiteSpace($type)) {
-                    Fail-Smoke "dependency entry has unsupported link type '$linkType': $($item.FullName)"
-                }
-                [void]$entries.Add([ordered]@{
-                        path = $relative
-                        type = $type
-                        bytes = [int64]0
-                        sha256 = ""
-                        target = $link.relative
-                    })
-                continue
-            }
-            if ($item.PSIsContainer) {
-                [void]$entries.Add([ordered]@{
-                        path = $relative
-                        type = "directory"
-                        bytes = [int64]0
-                        sha256 = ""
-                        target = $null
-                    })
-                $pending.Enqueue($item.FullName)
-                continue
-            }
-            $fileBytes = [int64]$item.Length
-            [void]$entries.Add([ordered]@{
-                    path = $relative
-                    type = "file"
-                    bytes = $fileBytes
-                    sha256 = (Get-SmokeSHA256 -Path $item.FullName)
-                    target = $null
-                })
-        }
-    }
-    return @($entries.ToArray())
-}
-
-function New-SmokeDependencyManifest {
-    param(
-        [string]$RootPath,
-        [string]$ContainmentRoot,
-        [string]$ManifestPath
-    )
-
-    $manifestPath = Assert-SmokeNewEvidenceFile -Name "dependency manifest" -RequestedPath $ManifestPath
-    $entries = @(Get-SmokeDependencyEntries -RootPath $RootPath -ContainmentRoot $ContainmentRoot)
-    $sortedEntries = @($entries | Sort-Object -Property path)
-    $writer = [System.IO.StreamWriter]::new($manifestPath, $false, [System.Text.UTF8Encoding]::new($false))
-    try {
-        foreach ($entry in $sortedEntries) {
-            $writer.WriteLine(($entry | ConvertTo-Json -Compress -Depth 5))
-        }
-    } finally {
-        $writer.Dispose()
-    }
-    $fileCount = [int64]0
-    $directoryCount = [int64]0
-    $junctionCount = [int64]0
-    $symbolicLinkCount = [int64]0
-    $totalBytes = [int64]0
-    foreach ($entry in $sortedEntries) {
-        switch ([string]$entry.type) {
-            "file" { $fileCount++; $totalBytes += [int64]$entry.bytes }
-            "directory" { $directoryCount++ }
-            "junction" { $junctionCount++ }
-            "symlink" { $symbolicLinkCount++ }
-        }
-    }
-    return [ordered]@{
-        status = "PASS"
-        manifestPath = $manifestPath
-        manifestSHA256 = Get-SmokeSHA256 -Path $manifestPath
-        entryCount = [int64]$sortedEntries.Count
-        fileCount = $fileCount
-        directoryCount = $directoryCount
-        junctionCount = $junctionCount
-        symbolicLinkCount = $symbolicLinkCount
-        totalBytes = $totalBytes
-    }
-}
-
-function Read-SmokeStructuredJSON {
-    param([string]$Path)
-
-    $raw = [System.IO.File]::ReadAllText($Path)
-    $normalized = [System.Text.RegularExpressions.Regex]::Replace($raw, ',(?=\s*[}\]])', '')
-    try {
-        [void][System.Reflection.Assembly]::LoadWithPartialName("System.Web.Extensions")
-        $serializer = [System.Web.Script.Serialization.JavaScriptSerializer]::new()
-        return $serializer.DeserializeObject($normalized)
-    } catch {
-        Fail-Smoke "dependency JSON could not be parsed: $Path; $($_.Exception.Message)"
-    }
-}
-
-function Get-SmokeMapValue {
-    param(
-        [object]$Map,
-        [string]$Name
-    )
-
-    if ($null -eq $Map) { return $null }
-    if ($Map -is [System.Collections.IDictionary]) {
-        if ($Map.ContainsKey($Name)) { return $Map[$Name] }
-        return $null
-    }
-    $property = $Map.PSObject.Properties[$Name]
-    if ($null -eq $property) { return $null }
-    return $property.Value
-}
-
-function Get-SmokeMapEntries {
-    param([object]$Map)
-
-    if ($null -eq $Map -or -not ($Map -is [System.Collections.IDictionary])) { return @() }
-    return @($Map.GetEnumerator())
-}
-
-function Assert-SmokeDependencyMapsMatch {
-    param(
-        [object]$ManifestMap,
-        [object]$LockMap,
-        [string]$WorkspaceKey,
-        [string]$GroupName
-    )
-
-    $manifestEntries = @(Get-SmokeMapEntries $ManifestMap)
-    $lockEntries = @(Get-SmokeMapEntries $LockMap)
-    foreach ($entry in $manifestEntries) {
-        $lockValue = Get-SmokeMapValue -Map $LockMap -Name ([string]$entry.Key)
-        if ($null -eq $lockValue -or [string]$lockValue -cne [string]$entry.Value) {
-            Fail-Smoke "lock workspace '$WorkspaceKey' $GroupName drift for '$($entry.Key)'"
-        }
-    }
-    foreach ($entry in $lockEntries) {
-        $manifestValue = Get-SmokeMapValue -Map $ManifestMap -Name ([string]$entry.Key)
-        if ($null -eq $manifestValue) {
-            Fail-Smoke "lock workspace '$WorkspaceKey' has undeclared $GroupName dependency '$($entry.Key)'"
-        }
-    }
-}
-
-function Resolve-SmokeNodePackageManifest {
-    param(
-        [string]$DependencyName,
-        [string]$RequesterDirectory,
-        [string]$UIRoot
-    )
-
-    $current = [System.IO.Path]::GetFullPath($RequesterDirectory)
-    $uiFullPath = [System.IO.Path]::GetFullPath($UIRoot)
-    while ($true) {
-        $candidateDirectory = Join-Path (Join-Path $current "node_modules") $DependencyName
-        $candidateManifest = Join-Path $candidateDirectory "package.json"
-        $manifestItem = Get-Item -LiteralPath $candidateManifest -Force -ErrorAction SilentlyContinue
-        if ($null -ne $manifestItem -and -not $manifestItem.PSIsContainer -and (($manifestItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0)) {
-            return $manifestItem.FullName
-        }
-        if ($current.Equals($uiFullPath, [System.StringComparison]::OrdinalIgnoreCase)) { break }
-        if (-not ($current.StartsWith($uiFullPath + [System.IO.Path]::DirectorySeparatorChar, [System.StringComparison]::OrdinalIgnoreCase))) { break }
-        $parent = [System.IO.DirectoryInfo]$current
-        $parent = $parent.Parent
-        if ($null -eq $parent) { break }
-        $current = $parent.FullName
-    }
-    return $null
-}
-
-function Get-SmokeDependencyLockClosure {
-    param(
-        [string]$DependencyRoot,
-        [string]$ExpectedLockSHA256,
-        [string]$ExpectedLockBlob
-    )
-
-    $rootPath = Resolve-SmokeAbsolutePath $DependencyRoot
-    $uiRoot = Split-Path -Parent $rootPath
-    $lockPath = Join-Path $uiRoot "bun.lock"
-    $lockItem = Get-Item -LiteralPath $lockPath -Force -ErrorAction SilentlyContinue
-    if ($null -eq $lockItem -or $lockItem.PSIsContainer -or (($lockItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
-        Fail-Smoke "dependency lock is missing or not a regular file: $lockPath"
-    }
-    $lockSHA256 = Get-SmokeSHA256 -Path $lockPath
-    if ($lockSHA256 -cne $ExpectedLockSHA256.ToLowerInvariant()) {
-        Fail-Smoke "dependency lock SHA-256 = $lockSHA256, want $ExpectedLockSHA256"
-    }
-    $lockBlob = (Invoke-SmokeGit $uiRoot @("rev-parse", "HEAD:ui/bun.lock") | Select-Object -Last 1).Trim()
-    if ($lockBlob -cne $ExpectedLockBlob.ToLowerInvariant()) {
-        Fail-Smoke "dependency lock Git blob = $lockBlob, want $ExpectedLockBlob"
-    }
-    $lock = Read-SmokeStructuredJSON $lockPath
-    $lockfileVersion = Get-SmokeMapValue -Map $lock -Name "lockfileVersion"
-    if ([int]$lockfileVersion -ne 1) {
-        Fail-Smoke "dependency lockfileVersion = $lockfileVersion, want 1"
-    }
-    $workspaces = Get-SmokeMapValue -Map $lock -Name "workspaces"
-    $packages = Get-SmokeMapValue -Map $lock -Name "packages"
-    $workspaceEntries = @(Get-SmokeMapEntries $workspaces)
-    $packageEntries = @(Get-SmokeMapEntries $packages)
-    if ($workspaceEntries.Count -eq 0 -or $packageEntries.Count -eq 0) {
-        Fail-Smoke "dependency lock has no workspace/package closure"
-    }
-
-    $workspaceManifestPaths = New-Object 'System.Collections.Generic.List[string]'
-    $rootManifestPath = Join-Path $uiRoot "package.json"
-    if (-not (Test-Path -LiteralPath $rootManifestPath -PathType Leaf)) {
-        Fail-Smoke "workspace root package manifest is missing: $rootManifestPath"
-    }
-    [void]$workspaceManifestPaths.Add($rootManifestPath)
-    $workspacePackagesRoot = Join-Path $uiRoot "packages"
-    if (-not (Test-Path -LiteralPath $workspacePackagesRoot -PathType Container)) {
-        Fail-Smoke "workspace packages root is missing: $workspacePackagesRoot"
-    }
-    foreach ($workspaceDirectory in @(Get-ChildItem -LiteralPath $workspacePackagesRoot -Directory -Force -ErrorAction Stop)) {
-        $workspaceManifestPath = Join-Path $workspaceDirectory.FullName "package.json"
-        if (Test-Path -LiteralPath $workspaceManifestPath -PathType Leaf) {
-            [void]$workspaceManifestPaths.Add($workspaceManifestPath)
-        }
-    }
-    $workspaceByName = @{}
-    $workspaceByPath = @{}
-    $workspaceRecords = New-Object 'System.Collections.Generic.List[object]'
-    foreach ($workspaceManifestPath in @($workspaceManifestPaths.ToArray())) {
-        $manifest = Read-SmokeStructuredJSON $workspaceManifestPath
-        $workspaceName = [string](Get-SmokeMapValue -Map $manifest -Name "name")
-        if ([string]::IsNullOrWhiteSpace($workspaceName)) {
-            Fail-Smoke "workspace package name is missing: $workspaceManifestPath"
-        }
-        $workspaceDirectory = Split-Path -Parent $workspaceManifestPath
-        $workspaceKey = Get-SmokeRelativePath -RootPath $uiRoot -CandidatePath $workspaceDirectory -Role "workspace"
-        if ($workspaceKey -eq ".") { $workspaceKey = "" }
-        $lockWorkspace = Get-SmokeMapValue -Map $workspaces -Name $workspaceKey
-        if ($null -eq $lockWorkspace) {
-            Fail-Smoke "lock workspace '$workspaceKey' is missing"
-        }
-        foreach ($groupName in @("dependencies", "devDependencies", "optionalDependencies")) {
-            Assert-SmokeDependencyMapsMatch -ManifestMap (Get-SmokeMapValue -Map $manifest -Name $groupName) -LockMap (Get-SmokeMapValue -Map $lockWorkspace -Name $groupName) -WorkspaceKey $workspaceKey -GroupName $groupName
-        }
-        if ($workspaceByName.ContainsKey($workspaceName)) {
-            Fail-Smoke "duplicate workspace package name '$workspaceName'"
-        }
-        $workspaceByName[$workspaceName] = $workspaceManifestPath
-        $workspaceByPath[$workspaceKey] = $workspaceManifestPath
-        [void]$workspaceRecords.Add([pscustomobject]@{ key = $workspaceKey; name = $workspaceName; manifestPath = $workspaceManifestPath })
-    }
-    $expectedWorkspaceKeys = @($workspaceByPath.Keys | Sort-Object)
-    $actualWorkspaceKeys = @($workspaces.Keys | ForEach-Object { [string]$_ } | Sort-Object)
-    if (-not ([System.Linq.Enumerable]::SequenceEqual([string[]]$expectedWorkspaceKeys, [string[]]$actualWorkspaceKeys))) {
-        Fail-Smoke "lock workspace set differs from package manifests"
-    }
-
-    $queue = New-Object 'System.Collections.Generic.Queue[string]'
-    foreach ($record in @($workspaceRecords.ToArray())) { $queue.Enqueue($record.manifestPath) }
-    $visited = @{}
-    $optionalMissing = New-Object 'System.Collections.Generic.List[string]'
-    $reachablePackageCount = [int64]0
-    while ($queue.Count -gt 0) {
-        $manifestPath = $queue.Dequeue()
-        $manifestKey = [System.IO.Path]::GetFullPath($manifestPath).ToLowerInvariant()
-        if ($visited.ContainsKey($manifestKey)) { continue }
-        $visited[$manifestKey] = $true
-        $packageManifest = Read-SmokeStructuredJSON $manifestPath
-        $packageName = [string](Get-SmokeMapValue -Map $packageManifest -Name "name")
-        if ([string]::IsNullOrWhiteSpace($packageName)) {
-            Fail-Smoke "reachable package name is missing: $manifestPath"
-        }
-        $reachablePackageCount++
-        $requesterDirectory = Split-Path -Parent $manifestPath
-        foreach ($groupName in @("dependencies", "optionalDependencies", "peerDependencies")) {
-            $dependencyMap = Get-SmokeMapValue -Map $packageManifest -Name $groupName
-            foreach ($dependency in @(Get-SmokeMapEntries $dependencyMap)) {
-                $dependencyName = [string]$dependency.Key
-                $dependencySpec = [string]$dependency.Value
-                $resolvedManifest = $null
-                if ($dependencySpec -like "workspace:*") {
-                    if (-not $workspaceByName.ContainsKey($dependencyName)) {
-                        Fail-Smoke "workspace dependency '$dependencyName' from '$packageName' is not declared"
-                    }
-                    $resolvedManifest = $workspaceByName[$dependencyName]
-                } else {
-                    $resolvedManifest = Resolve-SmokeNodePackageManifest -DependencyName $dependencyName -RequesterDirectory $requesterDirectory -UIRoot $uiRoot
-                }
-                if ([string]::IsNullOrWhiteSpace([string]$resolvedManifest)) {
-                    if ($groupName -eq "optionalDependencies") {
-                        [void]$optionalMissing.Add("$packageName->$dependencyName")
-                        continue
-                    }
-                    Fail-Smoke "dependency closure is missing required package '$dependencyName' from '$packageName'"
-                }
-                $resolvedItem = Get-Item -LiteralPath $resolvedManifest -Force -ErrorAction Stop
-                [void](Get-SmokeRelativePath -RootPath $uiRoot -CandidatePath $resolvedItem.FullName -Role "resolved dependency")
-                $queue.Enqueue($resolvedItem.FullName)
-            }
-        }
-    }
-    return [ordered]@{
-        status = "PASS"
-        lockPath = $lockPath
-        lockSHA256 = $lockSHA256
-        lockBlob = $lockBlob
-        lockfileVersion = [int]$lockfileVersion
-        workspaceCount = [int64]$workspaceEntries.Count
-        lockPackageCount = [int64]$packageEntries.Count
-        reachablePackageCount = $reachablePackageCount
-        optionalMissingCount = [int64]$optionalMissing.Count
-        optionalMissing = @($optionalMissing.ToArray())
-    }
-}
-
-function Copy-SmokeDependencyTree {
-    param(
-        [string]$SourceRoot,
-        [string]$StageRoot,
-        [string]$SourceContainmentRoot,
-        [string]$StageContainmentRoot
-    )
-
-    $sourcePath = Resolve-SmokeAbsolutePath $SourceRoot
-    $stagePath = Resolve-SmokeAbsolutePath $StageRoot
-    $sourceContainmentPath = Resolve-SmokeAbsolutePath $SourceContainmentRoot
-    $stageContainmentPath = Resolve-SmokeAbsolutePath $StageContainmentRoot
-    $sourceItem = Get-Item -LiteralPath $sourcePath -Force -ErrorAction Stop
-    if (-not $sourceItem.PSIsContainer -or (($sourceItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
-        Fail-Smoke "dependency source root is not a regular directory: $sourcePath"
-    }
-    Assert-SmokeDisposableRoot -Name "dependency stage" -Path $stagePath
-    if (-not (Test-Path -LiteralPath $stagePath -PathType Container)) {
-        [void][System.IO.Directory]::CreateDirectory($stagePath)
-    }
-    $robocopyArguments = @(
-        $sourcePath, $stagePath,
-        "/E", "/XJ", "/COPY:DAT", "/DCOPY:DAT", "/R:0", "/W:0",
-        "/NFL", "/NDL", "/NJH", "/NJS", "/NP"
-    )
-    $robocopyOutput = @(& robocopy.exe @robocopyArguments 2>&1)
-    $robocopyExitCode = [int]$LASTEXITCODE
-    if ($robocopyExitCode -gt 7) {
-        $diagnostic = @($robocopyOutput | ForEach-Object { [string]$_ } | Select-Object -Last 20) -join " | "
-        Fail-Smoke "exact dependency copy failed with robocopy exit code ${robocopyExitCode}: $diagnostic"
-    }
-
-    $rewrittenLinks = [int64]0
-    foreach ($sourceLink in @(Get-SmokeDependencyLinkItems -RootPath $sourcePath)) {
-        $relative = Get-SmokeRelativePath -RootPath $sourcePath -CandidatePath $sourceLink.FullName -Role "dependency link"
-        $stageLinkPath = Join-Path $stagePath ($relative.Replace('/', [System.IO.Path]::DirectorySeparatorChar))
-        $sourceLinkTarget = Get-SmokeDependencyLinkTarget -Item $sourceLink -ContainmentRoot $sourceContainmentPath
-        $stageTargetPath = Join-Path $stageContainmentPath ($sourceLinkTarget.relative.Replace('/', [System.IO.Path]::DirectorySeparatorChar))
-        if (-not (Test-Path -LiteralPath $stageTargetPath)) {
-            Fail-Smoke "staged dependency link target is missing: $stageLinkPath -> $stageTargetPath"
-        }
-        $stageLinkItem = Get-Item -LiteralPath $stageLinkPath -Force -ErrorAction SilentlyContinue
-        if ($null -ne $stageLinkItem -and (($stageLinkItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0)) {
-            Fail-Smoke "dependency copier followed a source reparse point: $stageLinkPath"
-        }
-        if ($null -ne $stageLinkItem) {
-            Remove-Item -LiteralPath $stageLinkPath -Force -ErrorAction Stop
-        }
-        $stageLinkParent = Split-Path -Parent $stageLinkPath
-        if (-not (Test-Path -LiteralPath $stageLinkParent -PathType Container)) {
-            [void][System.IO.Directory]::CreateDirectory($stageLinkParent)
-        }
-        $linkTypeProperty = $sourceLink.PSObject.Properties["LinkType"]
-        $linkType = if ($null -eq $linkTypeProperty) { "" } else { [string]$linkTypeProperty.Value }
-        if ($linkType -eq "Junction") {
-            [void](New-Item -ItemType Junction -Path $stageLinkPath -Target $stageTargetPath -ErrorAction Stop)
-        } elseif ($linkType -eq "SymbolicLink") {
-            [void](New-Item -ItemType SymbolicLink -Path $stageLinkPath -Target $stageTargetPath -ErrorAction Stop)
-        } else {
-            Fail-Smoke "dependency copier cannot reproduce link type '$linkType': $($sourceLink.FullName)"
-        }
-        $rewrittenLinks++
-    }
-    return [ordered]@{
-        status = "PASS"
-        robocopyExitCode = $robocopyExitCode
-        rewrittenLinks = $rewrittenLinks
-        outputLineCount = [int64]$robocopyOutput.Count
-    }
-}
-
-function Write-SmokeJSONEvidence {
-    param(
-        [string]$RequestedPath,
-        [object]$Evidence
-    )
-
-    $path = Assert-SmokeNewEvidenceFile -Name "dependency report" -RequestedPath $RequestedPath
-    [System.IO.File]::WriteAllText($path, ($Evidence | ConvertTo-Json -Depth 20), [System.Text.UTF8Encoding]::new($false))
-    return $path
-}
-
-function Invoke-SmokeDependencyStage {
-    param(
-        [string]$RequestedSourceRoot,
-        [string]$RequestedStageRoot,
-        [string]$RequestedSourceManifestPath,
-        [string]$RequestedStageManifestPath,
-        [string]$RequestedReportPath,
-        [string]$ExpectedLockSHA256,
-        [string]$ExpectedLockBlob
-    )
-
-    $reportPath = Resolve-SmokeAbsolutePath $RequestedReportPath
-    $report = [ordered]@{
-        schemaVersion = "localai-windows-install-candidate-dependency-stage/v1"
-        status = "FAIL"
-        phase = "stage"
-        sourceRoot = Resolve-SmokeAbsolutePath $RequestedSourceRoot
-        stageRoot = Resolve-SmokeAbsolutePath $RequestedStageRoot
-        packageInstallation = "NOT_RUN"
-        sourceManifest = $null
-        stageManifest = $null
-        sourceLockClosure = $null
-        stageLockClosure = $null
-        copy = $null
-        equality = $null
-        error = ""
-    }
-    try {
-        $sourceRoot = $report.sourceRoot
-        $stageRoot = $report.stageRoot
-        $sourceContainmentRoot = Split-Path -Parent $sourceRoot
-        $stageContainmentRoot = Split-Path -Parent $stageRoot
-        $sourceManifestPath = Assert-SmokeNewEvidenceFile -Name "source dependency manifest" -RequestedPath $RequestedSourceManifestPath
-        $stageManifestPath = Assert-SmokeNewEvidenceFile -Name "staged dependency manifest" -RequestedPath $RequestedStageManifestPath
-        $sourceClosure = Get-SmokeDependencyLockClosure -DependencyRoot $sourceRoot -ExpectedLockSHA256 $ExpectedLockSHA256 -ExpectedLockBlob $ExpectedLockBlob
-        $sourceManifest = New-SmokeDependencyManifest -RootPath $sourceRoot -ContainmentRoot $sourceContainmentRoot -ManifestPath $sourceManifestPath
-        $copy = Copy-SmokeDependencyTree -SourceRoot $sourceRoot -StageRoot $stageRoot -SourceContainmentRoot $sourceContainmentRoot -StageContainmentRoot $stageContainmentRoot
-        $stageClosure = Get-SmokeDependencyLockClosure -DependencyRoot $stageRoot -ExpectedLockSHA256 $ExpectedLockSHA256 -ExpectedLockBlob $ExpectedLockBlob
-        $stageManifest = New-SmokeDependencyManifest -RootPath $stageRoot -ContainmentRoot $stageContainmentRoot -ManifestPath $stageManifestPath
-        $manifestEqual = $sourceManifest.manifestSHA256 -ceq $stageManifest.manifestSHA256
-        if (-not $manifestEqual) {
-            Fail-Smoke "source and staged dependency manifests differ"
-        }
-        $report.sourceLockClosure = $sourceClosure
-        $report.stageLockClosure = $stageClosure
-        $report.sourceManifest = $sourceManifest
-        $report.stageManifest = $stageManifest
-        $report.copy = $copy
-        $report.equality = [ordered]@{
-            sourceStageManifestEqual = $manifestEqual
-            sourceEntryCount = $sourceManifest.entryCount
-            stageEntryCount = $stageManifest.entryCount
-            sourceTotalBytes = $sourceManifest.totalBytes
-            stageTotalBytes = $stageManifest.totalBytes
-        }
-        $report.status = "PASS"
-    } catch {
-        $report.error = "line $($_.InvocationInfo.ScriptLineNumber): $($_.Exception.Message)"
-    }
-    Write-SmokeJSONEvidence -RequestedPath $reportPath -Evidence $report | Out-Null
-    if ($report.status -ne "PASS") {
-        throw "dependency staging failed; report=$reportPath"
-    }
-    Write-Output "dependency staging passed; report=$reportPath"
-}
-
-function Invoke-SmokeDependencyVerification {
-    param(
-        [string]$RequestedSourceRoot,
-        [string]$RequestedStageRoot,
-        [string]$RequestedExpectedManifestPath,
-        [string]$RequestedPostBuildManifestPath,
-        [string]$RequestedSourceAfterManifestPath,
-        [string]$RequestedReportPath,
-        [string]$ExpectedLockSHA256,
-        [string]$ExpectedLockBlob
-    )
-
-    $reportPath = Resolve-SmokeAbsolutePath $RequestedReportPath
-    $report = [ordered]@{
-        schemaVersion = "localai-windows-install-candidate-dependency-stage/v1"
-        status = "FAIL"
-        phase = "post-build"
-        sourceRoot = Resolve-SmokeAbsolutePath $RequestedSourceRoot
-        stageRoot = Resolve-SmokeAbsolutePath $RequestedStageRoot
-        packageInstallation = "NOT_RUN"
-        expectedManifest = $null
-        postBuildManifest = $null
-        sourceAfterBuildManifest = $null
-        sourceLockClosure = $null
-        stageLockClosure = $null
-        equality = $null
-        error = ""
-    }
-    try {
-        $sourceRoot = $report.sourceRoot
-        $stageRoot = $report.stageRoot
-        $sourceContainmentRoot = Split-Path -Parent $sourceRoot
-        $stageContainmentRoot = Split-Path -Parent $stageRoot
-        $expectedManifestPath = Resolve-SmokeAbsolutePath $RequestedExpectedManifestPath
-        if (-not (Test-Path -LiteralPath $expectedManifestPath -PathType Leaf)) {
-            Fail-Smoke "expected dependency manifest is missing: $expectedManifestPath"
-        }
-        $postBuildManifestPath = Assert-SmokeNewEvidenceFile -Name "post-build dependency manifest" -RequestedPath $RequestedPostBuildManifestPath
-        $sourceAfterManifestPath = Assert-SmokeNewEvidenceFile -Name "source-after-build dependency manifest" -RequestedPath $RequestedSourceAfterManifestPath
-        $sourceClosure = Get-SmokeDependencyLockClosure -DependencyRoot $sourceRoot -ExpectedLockSHA256 $ExpectedLockSHA256 -ExpectedLockBlob $ExpectedLockBlob
-        $stageClosure = Get-SmokeDependencyLockClosure -DependencyRoot $stageRoot -ExpectedLockSHA256 $ExpectedLockSHA256 -ExpectedLockBlob $ExpectedLockBlob
-        $postBuildManifest = New-SmokeDependencyManifest -RootPath $stageRoot -ContainmentRoot $stageContainmentRoot -ManifestPath $postBuildManifestPath
-        $sourceAfterManifest = New-SmokeDependencyManifest -RootPath $sourceRoot -ContainmentRoot $sourceContainmentRoot -ManifestPath $sourceAfterManifestPath
-        $expectedSHA256 = Get-SmokeSHA256 -Path $expectedManifestPath
-        $postBuildEqual = $expectedSHA256 -ceq $postBuildManifest.manifestSHA256
-        $sourceUnchanged = $expectedSHA256 -ceq $sourceAfterManifest.manifestSHA256
-        if (-not $postBuildEqual) { Fail-Smoke "post-build dependency manifest differs from staged manifest" }
-        if (-not $sourceUnchanged) { Fail-Smoke "source dependency manifest changed during build" }
-        $report.expectedManifest = [ordered]@{ path = $expectedManifestPath; manifestSHA256 = $expectedSHA256 }
-        $report.postBuildManifest = $postBuildManifest
-        $report.sourceAfterBuildManifest = $sourceAfterManifest
-        $report.sourceLockClosure = $sourceClosure
-        $report.stageLockClosure = $stageClosure
-        $report.equality = [ordered]@{
-            sourceStagePostBuildEqual = ($expectedSHA256 -ceq $postBuildManifest.manifestSHA256 -and $expectedSHA256 -ceq $sourceAfterManifest.manifestSHA256)
-            expectedManifestSHA256 = $expectedSHA256
-            postBuildManifestSHA256 = $postBuildManifest.manifestSHA256
-            sourceAfterBuildManifestSHA256 = $sourceAfterManifest.manifestSHA256
-        }
-        $report.status = "PASS"
-    } catch {
-        $report.error = "line $($_.InvocationInfo.ScriptLineNumber): $($_.Exception.Message)"
-    }
-    Write-SmokeJSONEvidence -RequestedPath $reportPath -Evidence $report | Out-Null
-    if ($report.status -ne "PASS") {
-        throw "dependency post-build verification failed; report=$reportPath"
-    }
-    Write-Output "dependency post-build verification passed; report=$reportPath"
-}
-
-function Test-SmokePathResolvesYou {
-    param([string]$PathValue)
-
-    if ([string]::IsNullOrWhiteSpace($PathValue)) {
-        return $false
-    }
-    foreach ($directory in $PathValue.Split([System.IO.Path]::PathSeparator, [System.StringSplitOptions]::RemoveEmptyEntries)) {
-        $trimmedDirectory = $directory.Trim()
-        if ([string]::IsNullOrWhiteSpace($trimmedDirectory)) {
-            continue
-        }
-        foreach ($executable in @("you.exe", "you.cmd", "you.bat", "you.com", "you")) {
-            $candidate = Join-Path $trimmedDirectory $executable
-            $item = Get-Item -LiteralPath $candidate -Force -ErrorAction SilentlyContinue
-            if ($null -ne $item -and -not $item.PSIsContainer -and (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0)) {
-                return $true
-            }
-        }
-    }
-    return $false
-}
-
-function Get-SmokeForbiddenProcesses {
-    $patterns = @("localai", "local-ai", "llama-server", "llama-cli", "vibevoice", "whisper", "piper")
-    $matches = @()
-    foreach ($process in @(Get-Process -ErrorAction SilentlyContinue)) {
-        $name = $process.ProcessName.ToLowerInvariant()
-        if ($patterns | Where-Object { $name -like "*$_*" }) {
-            $matches += "{0}:{1}" -f $process.Id, $process.ProcessName
-        }
-    }
-    return $matches
-}
-
-function Get-SmokeNetworkConnections {
-    param([int]$ProcessId)
-
-    if ($null -eq (Get-Command Get-NetTCPConnection -ErrorAction SilentlyContinue)) {
-        Fail-Smoke "candidate mode requires the Get-NetTCPConnection network observer"
-    }
-    try {
-        $connections = @(Get-NetTCPConnection -OwningProcess $ProcessId -ErrorAction Stop)
-    } catch {
-        if ($_.Exception.Message -like "*No MSFT_NetTCPConnection objects found*" -or $_.Exception.Message -like "*No matching MSFT_NetTCPConnection*") {
-            return @()
-        }
-        throw
-    }
-    return @($connections | ForEach-Object {
-        [ordered]@{
-            processId = $ProcessId
-            localAddress = [string]$_.LocalAddress
-            localPort = [int]$_.LocalPort
-            remoteAddress = [string]$_.RemoteAddress
-            remotePort = [int]$_.RemotePort
-            state = [string]$_.State
-        }
-    })
-}
-
-function Get-SmokeDirectoryBytes {
-    param([string]$Path)
-
-    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
-        return [int64]0
-    }
-    $total = [int64]0
-    foreach ($item in @(Get-ChildItem -LiteralPath $Path -File -Force -Recurse -ErrorAction Stop)) {
-        if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
-            Fail-Smoke "activity root contains a reparse point: $($item.FullName)"
-        }
-        $total += [int64]$item.Length
-    }
-    return $total
-}
-
-function Test-SmokeLoopbackAddress {
-    param([string]$Address)
-
-    return $Address -eq "127.0.0.1" -or $Address -eq "::1" -or $Address -eq "0:0:0:0:0:0:0:1"
-}
-
-function Get-SmokeUnexpectedConnections {
-    param(
-        [object[]]$Connections,
-        [int]$AllowedRemotePort = 0
-    )
-
-    return @($Connections | Where-Object {
-        $loopback = Test-SmokeLoopbackAddress ([string]$_.remoteAddress)
-        $allowed = $loopback -and $AllowedRemotePort -gt 0 -and [int]$_.remotePort -eq $AllowedRemotePort
-        -not $allowed
-    })
-}
-
-function Assert-SmokeCommandNetwork {
-    param(
-        [object]$Result,
-        [string]$CommandName
-    )
-
-    if ($null -eq $Result.network -or $Result.network.observerStatus -ne "PASS" -or [int]$Result.network.samples -le 0) {
-        Fail-Smoke "network observer did not produce a live sample for $CommandName"
-    }
-    if (@($Result.network.unexpectedConnections).Count -ne 0) {
-        Fail-Smoke "unexpected network connection observed for $($CommandName): $($Result.network.unexpectedConnections | ConvertTo-Json -Compress)"
-    }
-}
-
-function Record-SmokeCommandObservation {
-    param(
-        [object]$Result,
-        [System.Collections.Generic.List[object]]$NetworkObservations,
-        [System.Collections.Generic.List[string]]$ForbiddenProcessObservations
-    )
-
-    [void]$NetworkObservations.Add($Result.network)
-    foreach ($processName in @($Result.forbiddenProcesses)) {
-        [void]$ForbiddenProcessObservations.Add([string]$processName)
-    }
-}
-
-function Get-SmokeArtifactEvidence {
-    param(
-        [string]$Role,
-        [string]$Path
-    )
-
-    $item = Get-Item -LiteralPath $Path -Force -ErrorAction Stop
-    if ($item.PSIsContainer -or (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
-        Fail-Smoke "$Role is not a regular file: $Path"
-    }
-    $hasher = [System.Security.Cryptography.SHA256]::Create()
-    $stream = [System.IO.File]::OpenRead($Path)
-    try {
-        $digest = $hasher.ComputeHash($stream)
-    } finally {
-        $stream.Dispose()
-        $hasher.Dispose()
-    }
-    $hash = [System.BitConverter]::ToString($digest).Replace("-", "").ToLowerInvariant()
     return [ordered]@{
         role = $Role
         file = $item.Name
         bytes = [int64]$item.Length
-        sha256 = $hash
+        sha256 = [System.BitConverter]::ToString($digest).Replace("-", "").ToLowerInvariant()
     }
 }
 
-function Get-SmokeZipEntryEvidence {
-    param([string]$ArchivePath)
-
-    try {
-        Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
-    } catch {
+function Get-SmokeDirectoryBytes {
+    param([string]$Path)
+    $total = [int64]0
+    $pending = New-Object 'System.Collections.Generic.Stack[string]'
+    $pending.Push((Resolve-SmokePath $Path))
+    while ($pending.Count -gt 0) {
+        foreach ($item in @(Get-ChildItem -LiteralPath $pending.Pop() -Force -ErrorAction Stop)) {
+            if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) { continue }
+            if ($item.PSIsContainer) { $pending.Push($item.FullName) } else { $total += [int64]$item.Length }
+        }
     }
-
-    $archive = [System.IO.Compression.ZipFile]::OpenRead($ArchivePath)
-    try {
-        $entries = @($archive.Entries | Where-Object { $_.FullName -eq "you.exe" })
-        if ($entries.Count -ne 1 -or $entries[0].Name -ne "you.exe") {
-            Fail-Smoke "candidate archive must contain exactly one regular you.exe entry"
-        }
-
-        $entry = $entries[0]
-        $hasher = [System.Security.Cryptography.SHA256]::Create()
-        $stream = $entry.Open()
-        try {
-            $digest = $hasher.ComputeHash($stream)
-        } finally {
-            $stream.Dispose()
-            $hasher.Dispose()
-        }
-        return [ordered]@{
-            file = $entry.FullName
-            bytes = [int64]$entry.Length
-            sha256 = ([System.BitConverter]::ToString($digest).Replace("-", "").ToLowerInvariant())
-        }
-    } finally {
-        $archive.Dispose()
-    }
+    return $total
 }
 
-function Get-SmokeExecutableBuildInfo {
-    param(
-        [string]$ExecutablePath,
-        [string]$GoExecutablePath,
-        [string]$WorkingDirectory
-    )
-
-    if ([string]::IsNullOrWhiteSpace($GoExecutablePath)) {
-        Fail-Smoke "candidate mode requires the Go tool to inspect executable build info"
-    }
-    $result = Invoke-SmokeCommand -FilePath $GoExecutablePath -Arguments @("version", "-m", $ExecutablePath) -WorkingDirectory $WorkingDirectory
-    if ($result.exitCode -ne 0) {
-        Fail-Smoke "go version -m failed for candidate executable with exit code $($result.exitCode): $($result.stderr.Trim())"
-    }
-
-    $settings = @{}
-    foreach ($line in @($result.stdout -split "`r?`n")) {
-        $columns = $line -split "`t", 2
-        if ($columns.Count -ne 2 -or $columns[0] -ne "build") {
-            continue
-        }
-        $setting = $columns[1] -split "=", 2
-        if ($setting.Count -ne 2 -or $setting[0] -notin @("vcs.revision", "vcs.modified")) {
-            continue
-        }
-        $key = [string]$setting[0]
-        if ($settings.ContainsKey($key)) {
-            Fail-Smoke "candidate executable build info contains duplicate '$key' settings"
-        }
-        $settings[$key] = [string]$setting[1].Trim()
-    }
-
-    foreach ($key in @("vcs.revision", "vcs.modified")) {
-        if (-not $settings.ContainsKey($key) -or [string]::IsNullOrWhiteSpace([string]$settings[$key])) {
-            Fail-Smoke "candidate executable build info $key is missing"
-        }
-    }
-    if ([string]$settings["vcs.revision"] -cne $expectedCandidateSourceCommit) {
-        Fail-Smoke "candidate executable build info vcs.revision = $($settings['vcs.revision']), want $expectedCandidateSourceCommit"
-    }
-    if ([string]$settings["vcs.modified"] -cne "false") {
-        Fail-Smoke "candidate executable build info vcs.modified = $($settings['vcs.modified']), want false"
-    }
-
-    return [pscustomobject]@{
-        sourceRevision = [string]$settings["vcs.revision"]
-        vcsModified = $false
-        result = $result
-    }
-}
-
-function Invoke-SmokeCommand {
-    param(
-        [string]$FilePath,
-        [string[]]$Arguments,
-        [string]$WorkingDirectory,
-        [int]$TimeoutMilliseconds = 60000,
-        [int]$NetworkObserverSampleMilliseconds = 50
-    )
-
-    $startInfo = New-SmokeProcessStartInfo -FilePath $FilePath -Arguments $Arguments -WorkingDirectory $WorkingDirectory
-
-    $process = [System.Diagnostics.Process]::new()
-    $process.StartInfo = $startInfo
-    $networkSamples = New-Object 'System.Collections.Generic.List[object]'
-    $forbiddenProcessSamples = New-Object 'System.Collections.Generic.List[string]'
-    $observerErrors = New-Object 'System.Collections.Generic.List[string]'
-    $networkSampleCount = 0
-    try {
-        if (-not $process.Start()) {
-            Fail-Smoke "could not start $FilePath"
-        }
-        $stdoutTask = $process.StandardOutput.ReadToEndAsync()
-        $stderrTask = $process.StandardError.ReadToEndAsync()
-        $startedAt = [DateTime]::UtcNow
-        $deadline = $startedAt.AddMilliseconds($TimeoutMilliseconds)
-        try {
-            $networkSampleCount++
-            foreach ($connection in @(Get-SmokeNetworkConnections -ProcessId $process.Id)) {
-                [void]$networkSamples.Add($connection)
-            }
-            foreach ($processName in @(Get-SmokeForbiddenProcesses)) {
-                [void]$forbiddenProcessSamples.Add($processName)
-            }
-        } catch {
-            [void]$observerErrors.Add($_.Exception.Message)
-        }
-        while (-not $process.HasExited) {
-            try {
-                $networkSampleCount++
-                foreach ($connection in @(Get-SmokeNetworkConnections -ProcessId $process.Id)) {
-                    [void]$networkSamples.Add($connection)
-                }
-                foreach ($processName in @(Get-SmokeForbiddenProcesses)) {
-                    [void]$forbiddenProcessSamples.Add($processName)
-                }
-            } catch {
-                [void]$observerErrors.Add($_.Exception.Message)
-                break
-            }
-            if ([DateTime]::UtcNow -ge $deadline) {
-                try {
-                    $process.Kill($true)
-                } catch {
-                    try { $process.Kill() } catch { }
-                }
-                Fail-Smoke "$FilePath $([string]::Join(' ', $Arguments)) exceeded ${TimeoutMilliseconds}ms"
-            }
-            if ($process.WaitForExit($NetworkObserverSampleMilliseconds)) {
-                break
-            }
-        }
-        $process.WaitForExit()
-        if ($observerErrors.Count -ne 0) {
-            Fail-Smoke "network/process observer failed for $FilePath`: $($observerErrors -join '; ')"
-        }
-        $unexpectedConnections = @(Get-SmokeUnexpectedConnections -Connections $networkSamples.ToArray())
-        $port7437Connections = @($networkSamples.ToArray() | Where-Object { [int]$_.remotePort -eq 7437 })
-        return [pscustomobject]@{
-            exitCode = $process.ExitCode
-            stdout = $stdoutTask.GetAwaiter().GetResult()
-            stderr = $stderrTask.GetAwaiter().GetResult()
-            network = [ordered]@{
-                observerStatus = "PASS"
-                sampler = "Get-NetTCPConnection"
-                sampleIntervalMilliseconds = $NetworkObserverSampleMilliseconds
-                samples = [int]$networkSampleCount
-                connections = $networkSamples.ToArray()
-                unexpectedConnections = $unexpectedConnections
-                port7437Connections = $port7437Connections
-            }
-            forbiddenProcesses = @($forbiddenProcessSamples | Sort-Object -Unique)
-        }
-    } finally {
-        $process.Dispose()
-    }
-}
-
-function Convert-SmokeProcessArgumentListToCommandLine {
-    param([string[]]$Arguments)
-
-    $quotedArguments = New-Object 'System.Collections.Generic.List[string]'
-    foreach ($argument in @($Arguments)) {
-        $value = if ($null -eq $argument) { "" } else { [string]$argument }
-        $builder = [System.Text.StringBuilder]::new()
-        [void]$builder.Append('"')
-        $backslashCount = 0
-        foreach ($character in $value.ToCharArray()) {
-            if ($character -eq '\') {
-                $backslashCount++
-                continue
-            }
-            if ($character -eq '"') {
-                if ($backslashCount -gt 0) { [void]$builder.Append(('\' * ($backslashCount * 2))) }
-                [void]$builder.Append('\"')
-                $backslashCount = 0
-                continue
-            }
-            if ($backslashCount -gt 0) { [void]$builder.Append(('\' * $backslashCount)); $backslashCount = 0 }
-            [void]$builder.Append($character)
-        }
-        if ($backslashCount -gt 0) { [void]$builder.Append(('\' * ($backslashCount * 2))) }
-        [void]$builder.Append('"')
-        [void]$quotedArguments.Add($builder.ToString())
-    }
-    return [string]::Join(" ", $quotedArguments.ToArray())
-}
-
-function New-SmokeProcessStartInfo {
-    param(
-        [string]$FilePath,
-        [string[]]$Arguments,
-        [string]$WorkingDirectory
-    )
-
-    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
-    $startInfo.FileName = $FilePath
-    $argumentListProperty = $startInfo.PSObject.Properties["ArgumentList"]
-    if ($null -ne $argumentListProperty) {
-        foreach ($argument in @($Arguments)) {
-            $value = if ($null -eq $argument) { "" } else { [string]$argument }
-            [void]$startInfo.ArgumentList.Add($value)
-        }
+function Protect-SmokeOutput {
+    param([string]$Path, [int]$MaximumBytes = 1048576)
+    $bytes = [System.IO.File]::ReadAllBytes($Path)
+    $count = [Math]::Min($bytes.Length, $MaximumBytes)
+    if ($count -ge 2 -and $bytes[0] -eq 0xff -and $bytes[1] -eq 0xfe) {
+        $text = [System.Text.Encoding]::Unicode.GetString($bytes, 2, $count - 2)
+    } elseif ($count -ge 3 -and $bytes[0] -eq 0xef -and $bytes[1] -eq 0xbb -and $bytes[2] -eq 0xbf) {
+        $text = [System.Text.Encoding]::UTF8.GetString($bytes, 3, $count - 3)
     } else {
-        # Windows PowerShell 5.1 uses .NET Framework, whose ProcessStartInfo
-        # has no ArgumentList. The quoting routine preserves the same token
-        # boundary without invoking a shell or reparsing a serialized list.
-        $startInfo.Arguments = Convert-SmokeProcessArgumentListToCommandLine $Arguments
+        $text = [System.Text.Encoding]::UTF8.GetString($bytes, 0, $count)
     }
-    $startInfo.WorkingDirectory = $WorkingDirectory
-    $startInfo.UseShellExecute = $false
-    $startInfo.CreateNoWindow = $true
-    $startInfo.RedirectStandardOutput = $true
-    $startInfo.RedirectStandardError = $true
-    return $startInfo
+    $pattern = '(?i)(token|password|secret|api[_-]?key|authorization)\s*([:=])\s*[^\s,;]+'
+    $text = [System.Text.RegularExpressions.Regex]::Replace($text, $pattern, '$1$2<redacted>')
+    [System.IO.File]::WriteAllText($Path, $text, [System.Text.UTF8Encoding]::new($false))
+    $fileEvidence = Get-SmokeFileEvidence "command-output" $Path
+    $evidence = [ordered]@{
+        role = $fileEvidence.role
+        file = $fileEvidence.file
+        bytes = $fileEvidence.bytes
+        sha256 = $fileEvidence.sha256
+        totalBytes = [int64]$bytes.Length
+        truncated = $bytes.Length -gt $MaximumBytes
+    }
+    return [pscustomobject]@{ text = $text; evidence = $evidence }
 }
 
-function New-SmokeLoopbackPort {
-    $reservation = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
-    try {
-        $reservation.Start()
-        return ([System.Net.IPEndPoint]$reservation.LocalEndpoint).Port
-    } finally {
-        $reservation.Stop()
-    }
-}
-
-function Start-CandidateServer {
+function Invoke-CandidateCommand {
     param(
-        [string]$InstallerPath,
-        [string]$ArchivePath,
-        [string]$ArchiveName,
-        [string]$ArchiveSHA256,
-        [string]$Version,
-        [string]$LedgerPath
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][string[]]$ArgumentList,
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string]$StdoutPath,
+        [Parameter(Mandatory = $true)][string]$StderrPath
     )
-
-    $port = New-SmokeLoopbackPort
-    $baseUrl = "http://127.0.0.1:$port/releases"
-    $scriptRequestPath = "/releases/download/v$Version/install.ps1"
-    $archiveRequestPath = "/releases/download/v$Version/$ArchiveName"
-    $checksumName = "you_${Version}_checksums.txt"
-    $checksumRequestPath = "/releases/download/v$Version/$checksumName"
-    $expectedPaths = @($scriptRequestPath, $archiveRequestPath, $checksumRequestPath)
-    $checksumContents = "$ArchiveSHA256  $ArchiveName`n"
-    $eventName = "LocalAI-Candidate-Loopback-" + [System.Guid]::NewGuid().ToString("N")
-    $createdNew = $false
-    $readyEvent = [System.Threading.EventWaitHandle]::new(
-        $false,
-        [System.Threading.EventResetMode]::ManualReset,
-        $eventName,
-        [ref]$createdNew
-    )
-
-    $job = Start-Job -Name "localai-candidate-loopback" -ArgumentList @(
-        $port,
-        $InstallerPath,
-        $ArchivePath,
-        $LedgerPath,
-        $eventName,
-        $scriptRequestPath,
-        $archiveRequestPath,
-        $checksumRequestPath,
-        $checksumContents
-    ) -ScriptBlock {
-        param(
-            $port,
-            $scriptPath,
-            $archivePath,
-            $ledgerPath,
-            $eventName,
-            $scriptRequestPath,
-            $archiveRequestPath,
-            $checksumRequestPath,
-            $checksumContents
-        )
-
-        $server = [System.Net.HttpListener]::new()
-        [void]$server.Prefixes.Add("http://127.0.0.1:$port/")
-        $ready = [System.Threading.EventWaitHandle]::OpenExisting($eventName)
-        $servedExpected = 0
-        try {
-            [void]$server.Start()
-            [void]$ready.Set()
-            while ($servedExpected -lt 3) {
-                $context = $server.GetContext()
-                $path = $context.Request.Url.AbsolutePath
-                $status = 404
-                $contentType = "text/plain"
-                $body = [System.Text.Encoding]::UTF8.GetBytes("not found")
-                if ($path -eq $scriptRequestPath) {
-                    $status = 200
-                    $contentType = "text/plain"
-                    $body = [System.IO.File]::ReadAllBytes($scriptPath)
-                } elseif ($path -eq $archiveRequestPath) {
-                    $status = 200
-                    $contentType = "application/zip"
-                    $body = [System.IO.File]::ReadAllBytes($archivePath)
-                } elseif ($path -eq $checksumRequestPath) {
-                    $status = 200
-                    $contentType = "text/plain"
-                    $body = [System.Text.Encoding]::UTF8.GetBytes($checksumContents)
-                }
-
-                $record = [ordered]@{
-                    method = $context.Request.HttpMethod
-                    path = $path
-                    status = $status
-                    bytes = [int64]$body.Length
-                }
-                $record | ConvertTo-Json -Compress | Add-Content -LiteralPath $ledgerPath -Encoding utf8
-                $context.Response.StatusCode = $status
-                $context.Response.ContentType = $contentType
-                $context.Response.ContentLength64 = $body.LongLength
-                [void]$context.Response.OutputStream.Write($body, 0, $body.Length)
-                $context.Response.Close()
-                if ($status -eq 200 -and @($scriptRequestPath, $archiveRequestPath, $checksumRequestPath) -contains $path) {
-                    $servedExpected++
-                }
-            }
-        } catch {
-            [void]$ready.Set()
-            throw
-        } finally {
-            try {
-                if ($server.IsListening) {
-                    $server.Stop()
-                }
-            } catch {
-            }
-            try {
-                $server.Close()
-            } catch {
-            }
-            try {
-                $ready.Close()
-            } catch {
-            }
-        }
+    $workingDirectory = Resolve-SmokePath $WorkingDirectory
+    $stdoutPath = Resolve-SmokePath $StdoutPath
+    $stderrPath = Resolve-SmokePath $StderrPath
+    foreach ($parent in @((Split-Path -Parent $stdoutPath), (Split-Path -Parent $stderrPath))) {
+        [void][System.IO.Directory]::CreateDirectory($parent)
     }
-
-    if (-not $readyEvent.WaitOne(5000)) {
-        $reason = $job.ChildJobs[0].JobStateInfo.Reason
-        try { Stop-Job -Job $job -ErrorAction SilentlyContinue } catch { }
-        try { Remove-Job -Job $job -Force -ErrorAction SilentlyContinue } catch { }
-        $readyEvent.Close()
-        if ($null -ne $reason) {
-            Fail-Smoke "loopback candidate server did not become ready: $reason"
-        }
-        Fail-Smoke "loopback candidate server did not become ready"
-    }
-
-    return [pscustomobject]@{
-        baseUrl = $baseUrl
-        job = $job
-        readyEvent = $readyEvent
-        port = $port
-        ledgerPath = $LedgerPath
-        expectedPaths = $expectedPaths
-    }
-}
-
-function Stop-CandidateServer {
-    param($ServerState)
-
-    if ($null -eq $ServerState) {
-        return
-    }
-    if ($null -ne $ServerState.job) {
-        try {
-            if ($ServerState.job.State -eq "Running") {
-                Stop-Job -Job $ServerState.job -ErrorAction SilentlyContinue
-            }
-            Wait-Job -Job $ServerState.job -Timeout 5 | Out-Null
-        } catch {
-        }
-        try { Receive-Job -Job $ServerState.job -ErrorAction SilentlyContinue | Out-Null } catch { }
-        try { Remove-Job -Job $ServerState.job -Force -ErrorAction SilentlyContinue } catch { }
-    }
+    $previousLocation = Get-Location
+    $previousErrorActionPreference = $ErrorActionPreference
+    $exitCode = $null
     try {
-        if ($null -ne $ServerState.readyEvent) {
-            $ServerState.readyEvent.Close()
+        Set-Location -LiteralPath $workingDirectory
+        # Windows PowerShell promotes native stderr to ErrorRecord when the
+        # caller uses Stop. Capture it as process output and decide by exit.
+        $ErrorActionPreference = "Continue"
+        if (Test-Path Variable:\PSNativeCommandUseErrorActionPreference) { $PSNativeCommandUseErrorActionPreference = $false }
+        & $FilePath @ArgumentList 1> $stdoutPath 2> $stderrPath
+        $exitCode = [int]$LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+        Set-Location -LiteralPath $previousLocation.Path
+    }
+    $stdout = Protect-SmokeOutput $stdoutPath
+    $stderr = Protect-SmokeOutput $stderrPath
+    return [pscustomobject][ordered]@{
+        file = $FilePath
+        arguments = @($ArgumentList)
+        exitCode = $exitCode
+        stdout = $stdout.text
+        stderr = $stderr.text
+        stdoutEvidence = $stdout.evidence
+        stderrEvidence = $stderr.evidence
+    }
+}
+
+function Invoke-SmokeGit {
+    param([string[]]$ArgumentList)
+    $output = @(& git.exe @ArgumentList 2>&1 | ForEach-Object { [string]$_ })
+    if ($LASTEXITCODE -ne 0) { Fail-Smoke "git $($ArgumentList -join ' ') failed: $($output -join ' ')" }
+    return ($output -join "`n").Trim()
+}
+
+function Normalize-CandidateRepository {
+    param([string]$Repository)
+    return $Repository.Trim().TrimEnd('/').Replace('\', '/').ToLowerInvariant() -replace '\.git$', ''
+}
+
+function Get-CandidateSourceIdentity {
+    param([string]$SourcePath, [string]$Commit, [string]$Repository)
+    $sourcePath = Resolve-SmokePath $SourcePath
+    if (-not (Test-Path -LiteralPath $sourcePath -PathType Container)) { Fail-Smoke "candidate source repository is missing: $sourcePath" }
+    if ($Commit -notmatch '^[0-9a-fA-F]{40}$') { Fail-Smoke "candidate source commit must be a full Git object ID" }
+    $resolvedCommit = Invoke-SmokeGit @("-C", $sourcePath, "rev-parse", "$Commit^{commit}")
+    if ($resolvedCommit -cne $Commit.ToLowerInvariant()) { Fail-Smoke "candidate source resolved to $resolvedCommit, want $Commit" }
+    $tree = Invoke-SmokeGit @("-C", $sourcePath, "rev-parse", "$resolvedCommit^{tree}")
+    $origin = Invoke-SmokeGit @("-C", $sourcePath, "remote", "get-url", "origin")
+    if (-not [string]::IsNullOrWhiteSpace($Repository) -and (Normalize-CandidateRepository $origin) -cne (Normalize-CandidateRepository $Repository)) {
+        Fail-Smoke "candidate source origin is $origin, want $Repository"
+    }
+    return [pscustomobject][ordered]@{ repository = $origin; commit = $resolvedCommit; tree = $tree }
+}
+
+function Get-SmokeAvailablePort {
+    $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    try { $listener.Start(); return [int]$listener.LocalEndpoint.Port } finally { $listener.Stop() }
+}
+
+function Start-CandidateFileServer {
+    param([string]$InstallerPath, [string]$ArchivePath, [string]$ChecksumPath, [string]$Version, [string]$ReadyPath)
+    $port = Get-SmokeAvailablePort
+    $job = Start-Job -ScriptBlock {
+        param($Port, $InstallerPath, $ArchivePath, $ChecksumPath, $Version, $ReadyPath)
+        $ErrorActionPreference = "Stop"
+        $listener = [System.Net.HttpListener]::new()
+        $listener.Prefixes.Add("http://127.0.0.1:$Port/")
+        try {
+            $listener.Start()
+            [System.IO.File]::WriteAllText($ReadyPath, "ready")
+            $routes = @{
+                "/download/v$Version/install.ps1" = $InstallerPath
+                "/releases/download/v$Version/$([System.IO.Path]::GetFileName($ArchivePath))" = $ArchivePath
+                "/releases/download/v$Version/$([System.IO.Path]::GetFileName($ChecksumPath))" = $ChecksumPath
+            }
+            while ($true) {
+                $context = $listener.GetContext()
+                $requestPath = [System.Uri]::UnescapeDataString($context.Request.Url.AbsolutePath)
+                if ($requestPath -eq "/stop") { $context.Response.StatusCode = 204; $context.Response.Close(); break }
+                if (-not $routes.ContainsKey($requestPath)) { $context.Response.StatusCode = 404; $context.Response.Close(); continue }
+                $bytes = [System.IO.File]::ReadAllBytes([string]$routes[$requestPath])
+                $context.Response.StatusCode = 200
+                $context.Response.ContentLength64 = $bytes.Length
+                $context.Response.OutputStream.Write($bytes, 0, $bytes.Length)
+                $context.Response.Close()
+            }
+        } finally {
+            if ($listener.IsListening) { $listener.Stop() }
+            $listener.Close()
         }
+    } -ArgumentList $port, $InstallerPath, $ArchivePath, $ChecksumPath, $Version, $ReadyPath
+    $deadline = [DateTime]::UtcNow.AddSeconds(10)
+    while (-not (Test-Path -LiteralPath $ReadyPath -PathType Leaf) -and [DateTime]::UtcNow -lt $deadline) {
+        if ($job.State -in @("Failed", "Completed", "Stopped")) {
+            $details = Receive-Job -Job $job -Keep -ErrorAction SilentlyContinue | Out-String
+            Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+            Fail-Smoke "candidate file server stopped before readiness: $details"
+        }
+        Start-Sleep -Milliseconds 25
+    }
+    if (-not (Test-Path -LiteralPath $ReadyPath -PathType Leaf)) {
+        Stop-Job -Job $job -ErrorAction SilentlyContinue
+        Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+        Fail-Smoke "candidate file server did not become ready"
+    }
+    return [pscustomobject]@{ job = $job; port = $port; baseUrl = "http://127.0.0.1:$port" }
+}
+
+function Stop-CandidateFileServer {
+    param([object]$Server)
+    if ($null -eq $Server) { return }
+    try {
+        Invoke-WebRequest -Uri "$($Server.baseUrl)/stop" -UseBasicParsing | Out-Null
+        Wait-Job -Job $Server.job -Timeout 10 | Out-Null
+    } finally {
+        if ($Server.job.State -notin @("Completed", "Failed", "Stopped")) { Stop-Job -Job $Server.job -ErrorAction SilentlyContinue }
+        Remove-Job -Job $Server.job -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Invoke-InstalledCandidateSmoke {
+    param(
+        [string]$CandidateDirectory,
+        [string]$ArchivePath,
+        [string]$ChecksumPath,
+        [string]$InstallerPath,
+        [string]$ArchiveExecutablePath,
+        [string]$Version,
+        [string]$RequestedInstallDir,
+        [string]$WorkDirectory
+    )
+    $installDir = Resolve-SmokePath $RequestedInstallDir
+    Assert-SmokeEmptyRoot "install directory" $installDir
+    $smokeRoot = Join-Path $WorkDirectory "install-smoke"
+    [void][System.IO.Directory]::CreateDirectory($smokeRoot)
+    $homeRoot = Join-Path $smokeRoot "home"
+    $profileRoot = Join-Path $smokeRoot "profile"
+    $tempRoot = Join-Path $smokeRoot "temp"
+    $pathRoot = Join-Path $smokeRoot "path"
+    $modelsRoot = Join-Path $smokeRoot "models"
+    $hfRoot = Join-Path $smokeRoot "hf"
+    foreach ($path in @($homeRoot, $profileRoot, $tempRoot, $pathRoot)) {
+        [void][System.IO.Directory]::CreateDirectory($path)
+    }
+    $readyPath = Join-Path $smokeRoot "server.ready"
+    $server = $null
+    $environmentNames = @(
+        "HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH", "APPDATA", "LOCALAPPDATA",
+        "TEMP", "TMP", "PATH", "XDG_CONFIG_HOME", "XDG_CACHE_HOME",
+        "INFINITE_YOU_VERSION", "INFINITE_YOU_INSTALL_DIR", "INFINITE_YOU_INSTALL_OS",
+        "INFINITE_YOU_INSTALL_ARCH", "INFINITE_YOU_INSTALL_BASE_URL",
+        "INFINITE_YOU_OMNIVOICE_CACHE_DIR", "HUGGINGFACE_HUB_CACHE", "HF_HOME"
+    )
+    $originalEnvironment = @{}
+    foreach ($name in $environmentNames) {
+        $originalEnvironment[$name] = [System.Environment]::GetEnvironmentVariable($name, "Process")
+    }
+    $shell = (Get-Command powershell.exe -ErrorAction Stop).Source
+    $commands = New-Object 'System.Collections.Generic.List[object]'
+    try {
+        $serverArguments = @{
+            InstallerPath = $InstallerPath
+            ArchivePath = $ArchivePath
+            ChecksumPath = $ChecksumPath
+            Version = $Version
+            ReadyPath = $readyPath
+        }
+        $server = Start-CandidateFileServer @serverArguments
+        $env:HOME = $homeRoot
+        $env:USERPROFILE = $profileRoot
+        $profileDrive = [System.IO.Path]::GetPathRoot($profileRoot)
+        $env:HOMEDRIVE = $profileDrive.TrimEnd('\')
+        $env:HOMEPATH = $profileRoot.Substring($profileDrive.Length - 1)
+        $env:APPDATA = Join-Path $profileRoot "AppData\Roaming"
+        $env:LOCALAPPDATA = Join-Path $profileRoot "AppData\Local"
+        $env:TEMP = $tempRoot
+        $env:TMP = $tempRoot
+        $env:PATH = $pathRoot
+        $env:XDG_CONFIG_HOME = Join-Path $profileRoot ".you-agent-factory"
+        $env:XDG_CACHE_HOME = $env:LOCALAPPDATA
+        $env:INFINITE_YOU_VERSION = $Version
+        $env:INFINITE_YOU_INSTALL_DIR = $installDir
+        $env:INFINITE_YOU_INSTALL_OS = "windows"
+        $env:INFINITE_YOU_INSTALL_ARCH = "amd64"
+        $env:INFINITE_YOU_INSTALL_BASE_URL = "$($server.baseUrl)/releases"
+        $env:INFINITE_YOU_OMNIVOICE_CACHE_DIR = $modelsRoot
+        $env:HUGGINGFACE_HUB_CACHE = $hfRoot
+        $env:HF_HOME = $hfRoot
+        $downloadedInstaller = Join-Path $smokeRoot "install.ps1"
+        Invoke-WebRequest -Uri "$($server.baseUrl)/download/v$Version/install.ps1" -OutFile $downloadedInstaller -UseBasicParsing
+        $installerLiteral = "'" + $downloadedInstaller.Replace("'", "''") + "'"
+        $installerWrapper = Join-Path $smokeRoot "run-install.ps1"
+        $wrapperSource = @(
+            "Import-Module Microsoft.PowerShell.Utility -ErrorAction Stop"
+            "Import-Module Microsoft.PowerShell.Archive -ErrorAction Stop"
+            "& $installerLiteral"
+        ) -join "`n"
+        [System.IO.File]::WriteAllText($installerWrapper, $wrapperSource, [System.Text.UTF8Encoding]::new($false))
+        $installArguments = @{
+            FilePath = $shell
+            ArgumentList = @("-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", $installerWrapper)
+            WorkingDirectory = $smokeRoot
+            StdoutPath = Join-Path $CandidateDirectory "install.stdout.log"
+            StderrPath = Join-Path $CandidateDirectory "install.stderr.log"
+        }
+        $install = Invoke-CandidateCommand @installArguments
+        [void]$commands.Add($install)
+        if ($install.exitCode -ne 0) {
+            Fail-Smoke "public installer exited $($install.exitCode): $($install.stderr)"
+        }
+        $installedBinary = Join-Path $installDir "you.exe"
+        $installedEvidence = Get-SmokeFileEvidence "installed-executable" $installedBinary
+        $archiveEvidence = Get-SmokeFileEvidence "archive-executable" $ArchiveExecutablePath
+        if ($installedEvidence.bytes -ne $archiveEvidence.bytes -or $installedEvidence.sha256 -ne $archiveEvidence.sha256) {
+            Fail-Smoke "installed executable does not match the archive member"
+        }
+        $versionCommand = Invoke-CandidateCommand -FilePath $installedBinary `
+            -ArgumentList @("--version") -WorkingDirectory $smokeRoot `
+            -StdoutPath (Join-Path $smokeRoot "version.stdout") `
+            -StderrPath (Join-Path $smokeRoot "version.stderr")
+        [void]$commands.Add($versionCommand)
+        if ($versionCommand.exitCode -ne 0 -or $versionCommand.stdout.Trim() -cne $Version) {
+            Fail-Smoke "installed candidate version is '$($versionCommand.stdout.Trim())', want '$Version'"
+        }
+        $helpCommand = Invoke-CandidateCommand -FilePath $installedBinary `
+            -ArgumentList @("models", "--help") -WorkingDirectory $smokeRoot `
+            -StdoutPath (Join-Path $smokeRoot "models-help.stdout") `
+            -StderrPath (Join-Path $smokeRoot "models-help.stderr")
+        [void]$commands.Add($helpCommand)
+        if ($helpCommand.exitCode -ne 0) {
+            Fail-Smoke "installed candidate models help exited $($helpCommand.exitCode)"
+        }
+        foreach ($name in @("llm", "asr", "tts", "embed")) {
+            if (-not $helpCommand.stdout.Contains($name)) {
+                Fail-Smoke "installed candidate models help does not expose $name"
+            }
+            $inspect = Invoke-CandidateCommand -FilePath $installedBinary `
+                -ArgumentList @("--json", "models", "inspect", $name) `
+                -WorkingDirectory $smokeRoot `
+                -StdoutPath (Join-Path $smokeRoot "$name.stdout") `
+                -StderrPath (Join-Path $smokeRoot "$name.stderr")
+            [void]$commands.Add($inspect)
+            if ($inspect.exitCode -ne 0) {
+                Fail-Smoke "installed candidate models inspect $name exited $($inspect.exitCode)"
+            }
+            $model = $inspect.stdout | ConvertFrom-Json
+            $unexpectedState = $model.name -ne $name -or
+                $model.managedRuntime.identity -ne $name -or
+                $model.managedRuntime.readinessState -ne "MISSING" -or
+                $model.managedRuntime.lifecycleState -ne "NOT_INSTALLED" -or
+                $model.loadState -ne "UNLOADED"
+            if ($unexpectedState) {
+                Fail-Smoke "installed candidate models inspect $name performed work or returned an unexpected identity/state"
+            }
+        }
+        foreach ($path in @($modelsRoot, $hfRoot)) {
+            if ((Test-Path -LiteralPath $path) -and @(Get-ChildItem -LiteralPath $path -Force -ErrorAction Stop).Count -ne 0) {
+                Fail-Smoke "discovery wrote model or backend content under $path"
+            }
+        }
+        return [pscustomobject][ordered]@{
+            status = "PASS"
+            installedExecutable = $installedEvidence
+            commands = @($commands | ForEach-Object { $_ })
+            modelCalls = 0
+            modelBackendDownloadBytes = 0
+        }
+    } finally {
+        Stop-CandidateFileServer $server
+        foreach ($name in $environmentNames) {
+            [System.Environment]::SetEnvironmentVariable($name, $originalEnvironment[$name], "Process")
+        }
+        if (Test-Path -LiteralPath $installDir) {
+            Remove-Item -LiteralPath $installDir -Recurse -Force
+        }
+    }
+}
+
+function Invoke-LocalCandidateSmoke {
+    param(
+        [string]$SourcePath,
+        [string]$SourceCommit,
+        [string]$SourceRepository,
+        [string]$DependencySourcePath,
+        [string]$OutputDirectory,
+        [string]$WorkDirectory,
+        [string]$ReleaseToolPath,
+        [string]$ReleaseToolVersion,
+        [string]$EsbuildVersion,
+        [string]$EsbuildSHA256,
+        [int64]$MaximumWorkBytes,
+        [string]$RequestedInstallDir,
+        [string]$RequestedReportPath
+    )
+    $requiredValues = [ordered]@{
+        CandidateSourcePath = $SourcePath
+        CandidateSourceCommit = $SourceCommit
+        CandidateSourceRepository = $SourceRepository
+        CandidateDependencySourcePath = $DependencySourcePath
+        CandidateOutputDir = $OutputDirectory
+        CandidateWorkDir = $WorkDirectory
+        GoReleaserPath = $ReleaseToolPath
+        ExpectedGoReleaserVersion = $ReleaseToolVersion
+        ExpectedEsbuildVersion = $EsbuildVersion
+        ExpectedEsbuildSHA256 = $EsbuildSHA256
+        ReportPath = $RequestedReportPath
+    }
+    foreach ($required in $requiredValues.GetEnumerator()) {
+        if ([string]::IsNullOrWhiteSpace([string]$required.Value)) {
+            Fail-Smoke "$($required.Key) is required in candidate mode"
+        }
+    }
+    if ($EsbuildSHA256 -notmatch '^[0-9a-fA-F]{64}$') {
+        Fail-Smoke "ExpectedEsbuildSHA256 must be a SHA-256 digest"
+    }
+    $sourcePath = Resolve-SmokePath $SourcePath
+    $dependencySourcePath = Resolve-SmokePath $DependencySourcePath
+    $outputDirectory = Resolve-SmokePath $OutputDirectory
+    $workDirectory = Resolve-SmokePath $WorkDirectory
+    $installDirectory = Resolve-SmokePath $RequestedInstallDir
+    $reportPath = Resolve-SmokePath $RequestedReportPath
+    $releaseToolPath = Resolve-SmokePath $ReleaseToolPath
+    Assert-SmokeEmptyRoot "candidate output directory" $outputDirectory
+    Assert-SmokeEmptyRoot "candidate work directory" $workDirectory
+    Assert-SmokeEmptyRoot "install directory" $installDirectory
+    [void](Assert-SmokeRegularFile "GoReleaser" $releaseToolPath)
+    if ($workDirectory.Length -gt 80) {
+        Fail-Smoke "candidate work directory must be at most 80 characters so Windows native tools remain below path limits"
+    }
+    foreach ($pair in @(@($outputDirectory, $workDirectory), @($outputDirectory, $installDirectory), @($workDirectory, $installDirectory))) {
+        if ($pair[0].TrimEnd('\').Equals($pair[1].TrimEnd('\'), [System.StringComparison]::OrdinalIgnoreCase)) {
+            Fail-Smoke "candidate output, work, and install directories must be distinct"
+        }
+    }
+    $sourceIdentity = Get-CandidateSourceIdentity -SourcePath $sourcePath `
+        -Commit $SourceCommit -Repository $SourceRepository
+    [void][System.IO.Directory]::CreateDirectory($outputDirectory)
+    [void][System.IO.Directory]::CreateDirectory($workDirectory)
+    $checkoutPath = Join-Path $workDirectory "src"
+    $extractPath = Join-Path $workDirectory "archive"
+    $environmentNames = @("GOFLAGS", "GOMAXPROCS", "GOPROXY", "GOSUMDB", "GOTOOLCHAIN", "npm_config_offline")
+    $originalEnvironment = @{}
+    foreach ($name in $environmentNames) {
+        $originalEnvironment[$name] = [System.Environment]::GetEnvironmentVariable($name, "Process")
+    }
+    $report = [ordered]@{
+        schemaVersion = "local-windows-candidate/v1"
+        status = "FAIL"
+        source = [ordered]@{
+            repository = $SourceRepository
+            commit = $sourceIdentity.commit
+            tree = $sourceIdentity.tree
+        }
+        build = [ordered]@{}
+        artifacts = @()
+        install = [ordered]@{ status = "NOT_RUN" }
+        cleanup = [ordered]@{ status = "NOT_RUN" }
+        error = ""
+    }
+    $failure = $null
+    try {
+        $env:GOFLAGS = "-p=4"
+        $env:GOMAXPROCS = "4"
+        $env:GOPROXY = "off"
+        $env:GOSUMDB = "off"
+        $env:GOTOOLCHAIN = "local"
+        $env:npm_config_offline = "true"
+        [void](Invoke-SmokeGit @("clone", "--local", "--no-checkout", "--", $sourcePath, $checkoutPath))
+        [void](Invoke-SmokeGit @("-C", $checkoutPath, "checkout", "--detach", $sourceIdentity.commit))
+        $gitDirectory = Get-Item -LiteralPath (Join-Path $checkoutPath ".git") -Force -ErrorAction Stop
+        if (-not $gitDirectory.PSIsContainer) {
+            Fail-Smoke "candidate clone must have a real .git directory"
+        }
+        $checkoutCommit = Invoke-SmokeGit @("-C", $checkoutPath, "rev-parse", "HEAD")
+        $checkoutTree = Invoke-SmokeGit @("-C", $checkoutPath, "rev-parse", "HEAD^{tree}")
+        if ($checkoutCommit -cne $sourceIdentity.commit -or $checkoutTree -cne $sourceIdentity.tree) {
+            Fail-Smoke "candidate clone source identity changed"
+        }
+        [System.IO.File]::AppendAllText((Join-Path $checkoutPath ".git\info\exclude"), "`n/dist/`n", [System.Text.UTF8Encoding]::new($false))
+        $sourceLock = Get-SmokeFileEvidence "source-bun-lock" (Join-Path $checkoutPath "ui\bun.lock")
+        $dependencyLock = Get-SmokeFileEvidence "dependency-bun-lock" (Join-Path $dependencySourcePath "ui\bun.lock")
+        if ($sourceLock.sha256 -ne $dependencyLock.sha256) {
+            Fail-Smoke "candidate and dependency source bun.lock hashes differ"
+        }
+        $dependencyNodeModules = Join-Path $dependencySourcePath "ui\node_modules"
+        if (-not (Test-Path -LiteralPath $dependencyNodeModules -PathType Container)) {
+            Fail-Smoke "verified dependency source ui/node_modules is missing"
+        }
+        $checkoutNodeModules = Join-Path $checkoutPath "ui\node_modules"
+        if (Test-Path -LiteralPath $checkoutNodeModules) {
+            Fail-Smoke "fresh candidate clone unexpectedly contains ui/node_modules"
+        }
+        [void](New-Item -ItemType Junction -Path $checkoutNodeModules -Target $dependencyNodeModules)
+        $esbuildPath = Join-Path $checkoutNodeModules "esbuild\lib\downloaded-@esbuild-win32-x64-esbuild.exe"
+        $esbuildEvidence = Get-SmokeFileEvidence "esbuild" $esbuildPath
+        if ($esbuildEvidence.sha256 -cne $EsbuildSHA256.ToLowerInvariant()) {
+            Fail-Smoke "esbuild SHA-256 is $($esbuildEvidence.sha256), want $($EsbuildSHA256.ToLowerInvariant())"
+        }
+        if ($esbuildPath.Length -gt 220) {
+            Fail-Smoke "staged esbuild path is $($esbuildPath.Length) characters, want at most 220"
+        }
+        $esbuildResult = Invoke-CandidateCommand -FilePath $esbuildPath `
+            -ArgumentList @("--version") -WorkingDirectory $checkoutPath `
+            -StdoutPath (Join-Path $outputDirectory "esbuild.stdout.log") `
+            -StderrPath (Join-Path $outputDirectory "esbuild.stderr.log")
+        if ($esbuildResult.exitCode -ne 0 -or $esbuildResult.stdout.Trim() -cne $EsbuildVersion) {
+            Fail-Smoke "esbuild sanity check failed: exit=$($esbuildResult.exitCode) version='$($esbuildResult.stdout.Trim())'"
+        }
+        $releaseToolEvidence = Get-SmokeFileEvidence "goreleaser" $releaseToolPath
+        $releaseToolResult = Invoke-CandidateCommand -FilePath $releaseToolPath `
+            -ArgumentList @("--version") -WorkingDirectory $checkoutPath `
+            -StdoutPath (Join-Path $outputDirectory "goreleaser-version.stdout.log") `
+            -StderrPath (Join-Path $outputDirectory "goreleaser-version.stderr.log")
+        if ($releaseToolResult.exitCode -ne 0 -or -not $releaseToolResult.stdout.Contains($ReleaseToolVersion)) {
+            Fail-Smoke "GoReleaser version check failed: exit=$($releaseToolResult.exitCode) output='$($releaseToolResult.stdout.Trim())'"
+        }
+        $statusBefore = Invoke-SmokeGit @("-C", $checkoutPath, "status", "--porcelain=v1", "--untracked-files=all")
+        if ($statusBefore -ne "") {
+            Fail-Smoke "candidate clone is dirty before release"
+        }
+        $releaseArguments = @("release", "--snapshot", "--clean", "-f", ".goreleaser.yml")
+        $releaseResult = Invoke-CandidateCommand -FilePath $releaseToolPath `
+            -ArgumentList $releaseArguments -WorkingDirectory $checkoutPath `
+            -StdoutPath (Join-Path $outputDirectory "release.stdout.log") `
+            -StderrPath (Join-Path $outputDirectory "release.stderr.log")
+        $workBytes = Get-SmokeDirectoryBytes $workDirectory
+        $report.build = [ordered]@{
+            command = $releaseToolPath
+            arguments = $releaseArguments
+            exitCode = $releaseResult.exitCode
+            stdout = $releaseResult.stdoutEvidence
+            stderr = $releaseResult.stderrEvidence
+            goReleaser = $releaseToolEvidence
+            goReleaserVersion = $ReleaseToolVersion
+            config = Get-SmokeFileEvidence "goreleaser-config" (Join-Path $checkoutPath ".goreleaser.yml")
+            bunLock = $sourceLock
+            esbuild = $esbuildEvidence
+            esbuildVersion = $EsbuildVersion
+            esbuildPathLength = $esbuildPath.Length
+            workBytes = $workBytes
+            maximumWorkBytes = $MaximumWorkBytes
+            environment = [ordered]@{
+                GOFLAGS = $env:GOFLAGS
+                GOMAXPROCS = $env:GOMAXPROCS
+                GOPROXY = $env:GOPROXY
+                GOSUMDB = $env:GOSUMDB
+                GOTOOLCHAIN = $env:GOTOOLCHAIN
+                npm_config_offline = $env:npm_config_offline
+            }
+        }
+        if ($releaseResult.exitCode -ne 0) {
+            Fail-Smoke "GoReleaser exited $($releaseResult.exitCode): $($releaseResult.stderr)"
+        }
+        if ($MaximumWorkBytes -le 0 -or $workBytes -gt $MaximumWorkBytes) {
+            Fail-Smoke "candidate work directory used $workBytes bytes, limit $MaximumWorkBytes"
+        }
+        $statusAfter = Invoke-SmokeGit @("-C", $checkoutPath, "status", "--porcelain=v1", "--untracked-files=all")
+        if ($statusAfter -ne "") {
+            Fail-Smoke "candidate clone is dirty after release"
+        }
+        $archives = @(Get-ChildItem -LiteralPath (Join-Path $checkoutPath "dist") -Filter "you_*_windows_amd64.zip" -File -ErrorAction Stop)
+        if ($archives.Count -ne 1) {
+            Fail-Smoke "release produced $($archives.Count) Windows amd64 archives, want exactly one"
+        }
+        $archiveMatch = [regex]::Match($archives[0].Name, '^you_(.+)_windows_amd64\.zip$')
+        if (-not $archiveMatch.Success) {
+            Fail-Smoke "release archive name does not expose its version: $($archives[0].Name)"
+        }
+        $version = $archiveMatch.Groups[1].Value
+        $checksumSource = Join-Path $checkoutPath "dist\you_${version}_checksums.txt"
+        $installerSource = Join-Path $checkoutPath "scripts\install.ps1"
+        foreach ($source in @($archives[0].FullName, $checksumSource, $installerSource)) {
+            [void](Assert-SmokeRegularFile "candidate artifact" $source)
+            Copy-Item -LiteralPath $source -Destination $outputDirectory
+        }
+        $archivePath = Join-Path $outputDirectory $archives[0].Name
+        $checksumPath = Join-Path $outputDirectory ([System.IO.Path]::GetFileName($checksumSource))
+        $installerPath = Join-Path $outputDirectory "install.ps1"
+        [void][System.IO.Directory]::CreateDirectory($extractPath)
+        Expand-Archive -LiteralPath $archivePath -DestinationPath $extractPath -Force
+        $archiveExecutablePath = Join-Path $extractPath "you.exe"
+        [void](Assert-SmokeRegularFile "archive executable" $archiveExecutablePath)
+        $report.artifacts = @(
+            Get-SmokeFileEvidence "windows-amd64-archive" $archivePath
+            Get-SmokeFileEvidence "checksums" $checksumPath
+            Get-SmokeFileEvidence "windows-installer" $installerPath
+            Get-SmokeFileEvidence "windows-amd64-executable" $archiveExecutablePath
+        )
+        $installArguments = @{
+            CandidateDirectory = $outputDirectory
+            ArchivePath = $archivePath
+            ChecksumPath = $checksumPath
+            InstallerPath = $installerPath
+            ArchiveExecutablePath = $archiveExecutablePath
+            Version = $version
+            RequestedInstallDir = $installDirectory
+            WorkDirectory = $workDirectory
+        }
+        $report.install = Invoke-InstalledCandidateSmoke @installArguments
+        $report.status = "PASS"
     } catch {
-    }
-}
-
-function Read-CandidateRequestLedger {
-    param([string]$LedgerPath)
-
-    $records = @()
-    if (-not (Test-Path -LiteralPath $LedgerPath -PathType Leaf)) {
-        return $records
-    }
-    foreach ($line in @(Get-Content -LiteralPath $LedgerPath -ErrorAction Stop)) {
-        if (-not [string]::IsNullOrWhiteSpace($line)) {
-            $records += ($line | ConvertFrom-Json)
+        $failure = $_.Exception
+        $report.error = $failure.Message
+    } finally {
+        foreach ($name in $environmentNames) {
+            [System.Environment]::SetEnvironmentVariable($name, $originalEnvironment[$name], "Process")
         }
+        try {
+            if (Test-Path -LiteralPath $installDirectory) {
+                Remove-Item -LiteralPath $installDirectory -Recurse -Force
+            }
+            if (Test-Path -LiteralPath $workDirectory) {
+                Remove-Item -LiteralPath $workDirectory -Recurse -Force
+            }
+            $report.cleanup = [ordered]@{
+                status = "PASS"
+                workDirectoryRemoved = -not (Test-Path -LiteralPath $workDirectory)
+                installDirectoryRemoved = -not (Test-Path -LiteralPath $installDirectory)
+            }
+        } catch {
+            $report.cleanup = [ordered]@{ status = "FAIL"; error = $_.Exception.Message }
+            if ($null -eq $failure) { $failure = $_.Exception }
+            $report.status = "FAIL"
+        }
+        [void][System.IO.Directory]::CreateDirectory((Split-Path -Parent $reportPath))
+        $report | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $reportPath -Encoding UTF8
+        $reportEvidence = Get-SmokeFileEvidence "candidate-report" $reportPath
+        $reportDigestPath = Join-Path $outputDirectory "candidate-report.sha256"
+        $reportDigest = "$($reportEvidence.sha256)  $([System.IO.Path]::GetFileName($reportPath))`n"
+        [System.IO.File]::WriteAllText($reportDigestPath, $reportDigest, [System.Text.UTF8Encoding]::new($false))
     }
-    return $records
+    if ($null -ne $failure) {
+        throw $failure
+    }
+    Write-Output "local candidate build and install smoke passed for $($sourceIdentity.commit); report: $reportPath"
 }
 
-function Invoke-LegacyHostedSmoke {
+function Invoke-HostedInstallSmoke {
     param(
         [string]$ScriptUrl,
         [string]$Version,
         [string]$RequestedInstallDir,
         [string]$RequestedBinaryName
     )
-
     if ([string]::IsNullOrWhiteSpace($ScriptUrl) -or [string]::IsNullOrWhiteSpace($Version)) {
         Fail-Smoke "InstallScriptUrl and InstallVersion are required outside candidate mode"
     }
-
     $tempHome = Join-Path ([System.IO.Path]::GetTempPath()) ("infinite-you-install-smoke-" + [System.Guid]::NewGuid().ToString("N"))
     try {
-        [void](New-Item -ItemType Directory -Path $tempHome -Force)
-        [void](New-Item -ItemType Directory -Path $RequestedInstallDir -Force)
-
+        New-Item -ItemType Directory -Path $tempHome -Force | Out-Null
+        New-Item -ItemType Directory -Path $RequestedInstallDir -Force | Out-Null
         $scriptPath = Join-Path $tempHome "install.ps1"
         Invoke-WebRequest -Uri $ScriptUrl -OutFile $scriptPath
-
         $env:HOME = $tempHome
-        $env:USERPROFILE = $tempHome
         $env:INFINITE_YOU_VERSION = $Version
         $env:INFINITE_YOU_INSTALL_DIR = $RequestedInstallDir
-
-        $downloadMarker = "/download/"
-        $downloadIndex = $ScriptUrl.IndexOf($downloadMarker, [System.StringComparison]::OrdinalIgnoreCase)
-        if ($downloadIndex -gt 0) {
-            $env:INFINITE_YOU_INSTALL_BASE_URL = $ScriptUrl.Substring(0, $downloadIndex)
-        }
-
         & $scriptPath
-
         $binaryPath = Join-Path $RequestedInstallDir $RequestedBinaryName
         if (-not (Test-Path -LiteralPath $binaryPath -PathType Leaf)) {
             Fail-Smoke "installed binary missing: $binaryPath"
         }
-
         & $binaryPath --help | Out-Null
         & $binaryPath --json factory list --dir (Join-Path $tempHome ".you-agent-factory" "factories") | Out-Null
-
-        $configPath = Join-Path $tempHome ".you-agent-factory" "config.json"
+        $configPath = Join-Path $tempHome ".you-agent-factory\config.json"
         if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
             Fail-Smoke "normal initializer did not create operator config at $configPath"
         }
-
         Write-Output "hosted install smoke passed for $binaryPath via $ScriptUrl"
     } finally {
         if (Test-Path -LiteralPath $tempHome) {
@@ -1677,1460 +711,30 @@ function Invoke-LegacyHostedSmoke {
     }
 }
 
-function Invoke-CandidateSmoke {
-    param(
-        [string]$RequestedManifestPath,
-        [string]$RequestedInstallDir,
-        [string]$RequestedReportPath
-    )
-
-    $report = [ordered]@{
-        schemaVersion = "localai-windows-install-candidate-install/v1"
-        status = "FAIL"
-        property = "public-install-identity-discovery-zero-model-backend-activity-cleanup"
-        run = [ordered]@{
-            schemaVersion = "localai-windows-install-candidate-run/v1"
-            status = "NOT_STARTED"
-            startedAt = $null
-            endedAt = $null
-            durationMilliseconds = $null
-            platform = [ordered]@{
-                os = "windows"
-                architecture = "amd64"
-                powershell = [string]$PSVersionTable.PSVersion
-                edition = [string]$PSVersionTable.PSEdition
-            }
-            artifact = [ordered]@{}
-            isolation = [ordered]@{}
-            timeouts = [ordered]@{
-                commandMilliseconds = 60000
-                loopbackServerReadyMilliseconds = 5000
-                loopbackCompletionMilliseconds = 15000
-                networkObserverSampleMilliseconds = 50
-            }
-            processLifetime = [ordered]@{
-                command = "observed from process start until exit or command timeout"
-                descendantPolicy = "candidate smoke owns and cleans the loopback server job and installed CLI processes"
-            }
-            networkPolicy = [ordered]@{
-                allowed = "installer loopback requests recorded by the task server"
-                unexpected = "any non-loopback or unexpected loopback connection observed for the installed CLI fails the smoke"
-                port7437 = "must remain unobserved"
-                observer = "Get-NetTCPConnection by installed CLI process id"
-            }
-            budgets = [ordered]@{}
-            observed = [ordered]@{}
-        }
-        preconditions = [ordered]@{}
-        identity = [ordered]@{}
-        installer = [ordered]@{}
-        commands = @()
-        discovery = [ordered]@{}
-        activity = [ordered]@{}
-        cleanup = [ordered]@{ status = "NOT_RUN" }
-        postCleanup = [ordered]@{}
+if ($MyInvocation.InvocationName -eq ".") { return }
+if (-not [string]::IsNullOrWhiteSpace($CandidateSourcePath)) {
+    $candidateArguments = @{
+        SourcePath = $CandidateSourcePath
+        SourceCommit = $CandidateSourceCommit
+        SourceRepository = $CandidateSourceRepository
+        DependencySourcePath = $CandidateDependencySourcePath
+        OutputDirectory = $CandidateOutputDir
+        WorkDirectory = $CandidateWorkDir
+        ReleaseToolPath = $GoReleaserPath
+        ReleaseToolVersion = $ExpectedGoReleaserVersion
+        EsbuildVersion = $ExpectedEsbuildVersion
+        EsbuildSHA256 = $ExpectedEsbuildSHA256
+        MaximumWorkBytes = $CandidateMaximumWorkBytes
+        RequestedInstallDir = $InstallDir
+        RequestedReportPath = $ReportPath
     }
-    $failure = $null
-    $serverState = $null
-    $taskRoot = $null
-    $installRootSafe = $false
-    $manifestPath = $null
-    $candidateDirectory = $null
-    $installDirectory = $null
-    $reportPath = $null
-    $archivePath = $null
-    $installerPath = $null
-    $executablePath = $null
-    $digestPath = $null
-    $archiveEvidence = $null
-    $installerEvidence = $null
-    $executableEvidence = $null
-    $manifestEvidence = $null
-    $goExecutablePath = $null
-    $commandEvidence = @()
-    $originalEnvironment = @{}
-    $runStartedAt = [DateTime]::UtcNow
-    $networkObservations = New-Object 'System.Collections.Generic.List[object]'
-    $forbiddenProcessObservations = New-Object 'System.Collections.Generic.List[string]'
-    $report.run.startedAt = $runStartedAt.ToString("o")
-    $report.run.status = "RUNNING"
-    $environmentNames = @(
-        "HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH", "PATH", "TEMP", "TMP",
-        "APPDATA", "LOCALAPPDATA", "XDG_CONFIG_HOME", "XDG_CACHE_HOME",
-        "INFINITE_YOU_VERSION", "INFINITE_YOU_INSTALL_BASE_URL", "INFINITE_YOU_INSTALL_DIR",
-        "INFINITE_YOU_INSTALL_OS", "INFINITE_YOU_INSTALL_ARCH", "INFINITE_YOU_OMNIVOICE_CACHE_DIR",
-        "HUGGINGFACE_HUB_CACHE", "HF_HOME"
-    )
-
-    try {
-        Ensure-SmokeFileHashCommand
-        $goCommand = Get-Command go.exe -CommandType Application -ErrorAction SilentlyContinue
-        if ($null -eq $goCommand) {
-            Fail-Smoke "candidate mode requires Go to inspect executable build info"
-        }
-        $goExecutablePath = [System.IO.Path]::GetFullPath($goCommand.Source)
-        $manifestPath = Resolve-SmokeAbsolutePath $RequestedManifestPath
-        $candidateDirectory = Split-Path -Parent $manifestPath
-        $installDirectory = Resolve-SmokeAbsolutePath $RequestedInstallDir
-        $reportPath = if ([string]::IsNullOrWhiteSpace($RequestedReportPath)) {
-            Join-Path $candidateDirectory "install-validation-report.json"
-        } else {
-            Resolve-SmokeAbsolutePath $RequestedReportPath
-        }
-        $report.manifestPath = $manifestPath
-        $report.reportPath = $reportPath
-
-        $manifestBytes = [System.IO.File]::ReadAllBytes($manifestPath)
-        $manifest = [System.Text.Encoding]::UTF8.GetString($manifestBytes) | ConvertFrom-Json
-        if ($manifest.schemaVersion -ne "localai-windows-install-candidate/v1") {
-            Fail-Smoke "candidate schemaVersion is not localai-windows-install-candidate/v1"
-        }
-        if ($manifest.project -ne "localai" -or $manifest.cycle -ne $expectedCandidateCycle) {
-            Fail-Smoke "candidate project/cycle does not identify LocalAI cycle $expectedCandidateCycle"
-        }
-        if ([string]$manifest.source.repository -cne $expectedCandidateSourceRepository -or [string]$manifest.source.commit -cne $expectedCandidateSourceCommit -or [string]$manifest.source.tree -cne $expectedCandidateSourceTree) {
-            Fail-Smoke "candidate source identity = repository=$($manifest.source.repository) commit=$($manifest.source.commit) tree=$($manifest.source.tree), want repository=$expectedCandidateSourceRepository commit=$expectedCandidateSourceCommit tree=$expectedCandidateSourceTree"
-        }
-        $version = [string]$manifest.build.candidateVersion
-        if ([string]::IsNullOrWhiteSpace($version) -or $version -match '[\\/:*?"<>|\s]') {
-            Fail-Smoke "candidate version is not a usable release version: $version"
-        }
-        if ([string]::IsNullOrWhiteSpace([string]$manifest.build.cliVersion) -or $manifest.build.goVersion -ne $expectedCandidateGoVersion -or [string]$manifest.build.goreleaserConfigSha256 -notmatch '^[0-9a-f]{64}$' -or $manifest.build.goreleaserVersion -ne "v2.12.7" -or $manifest.build.target.goos -ne "windows" -or $manifest.build.target.goarch -ne "amd64" -or $manifest.build.target.cgoEnabled -ne $false) {
-            Fail-Smoke "candidate build identity is not Go $expectedCandidateGoVersion with GoReleaser v2.12.7, windows/amd64 and cgo disabled"
-        }
-        $requiredEnvironment = [ordered]@{
-            GOSUMDB = "off"
-            GOTOOLCHAIN = "go1.26.8"
-            npm_config_offline = "true"
-            GOFLAGS = "-p=4"
-            GOMAXPROCS = "4"
-        }
-        foreach ($environment in $requiredEnvironment.GetEnumerator()) {
-            if ([string]$manifest.build.environment.($environment.Key) -ne [string]$environment.Value) {
-                Fail-Smoke "candidate build environment $($environment.Key) = $($manifest.build.environment.($environment.Key)), want $($environment.Value)"
-            }
-        }
-        if ([string]$manifest.build.environment.GOPROXY -notmatch '^file://') {
-            Fail-Smoke "candidate build environment GOPROXY must be a file URL"
-        }
-        $requiredLimits = [ordered]@{
-            temporaryDiskBytesMaximum = 4294967296
-            ordinaryToolDownloadBytesMaximum = 0
-            modelBackendDownloadBytesMaximum = 0
-            modelCallsMaximum = 0
-            paidUSDMaximum = 0
-            descendantMaximum = 36
-            packagingOrSmokeRerunsMaximum = 1
-        }
-        foreach ($limit in $requiredLimits.GetEnumerator()) {
-            $actualLimit = $manifest.limits.($limit.Key)
-            if ($null -eq $actualLimit -or [int64]$actualLimit -ne [int64]$limit.Value) {
-                Fail-Smoke "candidate limit $($limit.Key) = $actualLimit, want $($limit.Value)"
-            }
-        }
-        $requiredControls = [ordered]@{
-            goflags = "-p=4"
-            gomaxprocs = "4"
-        }
-        foreach ($control in $requiredControls.GetEnumerator()) {
-            $actualControl = [string]$manifest.limits.($control.Key)
-            if ($actualControl -ne [string]$control.Value) {
-                Fail-Smoke "candidate control $($control.Key) = $actualControl, want $($control.Value)"
-            }
-        }
-        $expectedPriorCycles = @("030", "040", "042", "045", "048", "050", "063", "067", "068")
-        $actualPriorCycles = @($manifest.attempts.priorCycles | ForEach-Object { [string]$_ })
-        if ($actualPriorCycles.Count -ne $expectedPriorCycles.Count -or (Compare-Object -ReferenceObject $expectedPriorCycles -DifferenceObject $actualPriorCycles)) {
-            Fail-Smoke "candidate attempts priorCycles = $($actualPriorCycles -join ', '), want $($expectedPriorCycles -join ', ')"
-        }
-        if ([int]$manifest.attempts.cycle063BuildMaximum -ne 1 -or [int]$manifest.attempts.cycle063BuildUsed -ne 1) {
-            Fail-Smoke "candidate attempts must record cycle063BuildMaximum=1 and cycle063BuildUsed=1"
-        }
-        if ([int]$manifest.attempts.cycle067BuildMaximum -ne 2 -or [int]$manifest.attempts.cycle067BuildUsed -ne 2) {
-            Fail-Smoke "candidate attempts must record cycle067BuildMaximum=2 and cycle067BuildUsed=2"
-        }
-        if ([int]$manifest.attempts.cycle068BuildMaximum -ne 1 -or [int]$manifest.attempts.cycle068BuildUsed -ne 1) {
-            Fail-Smoke "candidate attempts must record cycle068BuildMaximum=1 and cycle068BuildUsed=1"
-        }
-        if ([int]$manifest.attempts.cycle070BuildMaximum -ne 1 -or [int]$manifest.attempts.cycle070BuildUsed -ne 1) {
-            Fail-Smoke "candidate attempts must record cycle070BuildMaximum=1 and cycle070BuildUsed=1"
-        }
-        $archiveArtifacts = @($manifest.artifacts | Where-Object { $_.role -eq "windows-amd64-archive" })
-        $installerArtifacts = @($manifest.artifacts | Where-Object { $_.role -eq "windows-installer" })
-        $executableArtifacts = @($manifest.artifacts | Where-Object { $_.role -eq "windows-amd64-executable" })
-        if (@($manifest.artifacts).Count -ne 3 -or $archiveArtifacts.Count -ne 1 -or $installerArtifacts.Count -ne 1 -or $executableArtifacts.Count -ne 1) {
-            Fail-Smoke "candidate manifest must contain one archive, one executable, and one installer artifact"
-        }
-        $archiveArtifact = $archiveArtifacts[0]
-        $installerArtifact = $installerArtifacts[0]
-        $executableArtifact = $executableArtifacts[0]
-        $archiveName = "you_${version}_windows_amd64.zip"
-        if ($archiveArtifact.file -ne $archiveName -or $installerArtifact.file -ne "install.ps1" -or $executableArtifact.file -ne "you.exe") {
-            Fail-Smoke "candidate artifact filenames do not match the declared version and executable identity"
-        }
-        foreach ($artifact in @($archiveArtifact, $installerArtifact, $executableArtifact)) {
-            if ([System.IO.Path]::GetFileName([string]$artifact.file) -ne [string]$artifact.file -or [int64]$artifact.bytes -le 0 -or [string]$artifact.sha256 -notmatch '^[0-9a-f]{64}$') {
-                Fail-Smoke "candidate artifact $($artifact.role) is incomplete or unsafe"
-            }
-        }
-
-        $archivePath = Join-Path $candidateDirectory $archiveArtifact.file
-        $installerPath = Join-Path $candidateDirectory $installerArtifact.file
-        $executablePath = Join-Path $candidateDirectory $executableArtifact.file
-        $archiveEvidence = Get-SmokeArtifactEvidence "windows-amd64-archive" $archivePath
-        $installerEvidence = Get-SmokeArtifactEvidence "windows-installer" $installerPath
-        $executableEvidence = Get-SmokeArtifactEvidence "windows-amd64-executable" $executablePath
-        if ($archiveEvidence.bytes -ne [int64]$archiveArtifact.bytes -or $archiveEvidence.sha256 -ne [string]$archiveArtifact.sha256) {
-            Fail-Smoke "candidate archive bytes or SHA-256 do not match the manifest"
-        }
-        if ($installerEvidence.bytes -ne [int64]$installerArtifact.bytes -or $installerEvidence.sha256 -ne [string]$installerArtifact.sha256) {
-            Fail-Smoke "candidate installer bytes or SHA-256 do not match the manifest"
-        }
-        if ($executableEvidence.bytes -ne [int64]$executableArtifact.bytes -or $executableEvidence.sha256 -ne [string]$executableArtifact.sha256) {
-            Fail-Smoke "candidate executable bytes or SHA-256 do not match the manifest"
-        }
-        $archiveCandidates = @(Get-ChildItem -LiteralPath $candidateDirectory -File -Force | Where-Object { $_.Name -match '^you_.+_windows_amd64\.zip$' })
-        if ($archiveCandidates.Count -ne 1 -or $archiveCandidates[0].Name -ne $archiveName) {
-            Fail-Smoke "candidate directory must retain exactly one archive named $archiveName"
-        }
-        $manifestEvidence = Get-SmokeArtifactEvidence "candidate-manifest" $manifestPath
-        $digestPath = Join-Path $candidateDirectory "candidate-manifest.sha256"
-        $digestFields = ([System.IO.File]::ReadAllText($digestPath)).Trim() -split '\s+'
-        if (($digestFields.Count -ne 1 -and $digestFields.Count -ne 2) -or $digestFields[0] -ne $manifestEvidence.sha256 -or ($digestFields.Count -eq 2 -and [System.IO.Path]::GetFileName($digestFields[1]) -ne "candidate-manifest.json")) {
-            Fail-Smoke "detached candidate manifest digest does not match the manifest"
-        }
-        $zipEntryEvidence = Get-SmokeZipEntryEvidence $archivePath
-        if ($executableEvidence.bytes -ne $zipEntryEvidence.bytes -or $executableEvidence.sha256 -ne $zipEntryEvidence.sha256) {
-            Fail-Smoke "candidate executable does not match the you.exe member in the declared archive"
-        }
-        $buildInfoEvidence = Get-SmokeExecutableBuildInfo -ExecutablePath $executablePath -GoExecutablePath $goExecutablePath -WorkingDirectory $candidateDirectory
-        Record-SmokeCommandObservation -Result $buildInfoEvidence.result -NetworkObservations $networkObservations -ForbiddenProcessObservations $forbiddenProcessObservations
-        Assert-SmokeCommandNetwork -Result $buildInfoEvidence.result -CommandName "go version -m candidate executable"
-        $commandEvidence += [ordered]@{
-            command = "go version -m $executablePath"
-            exitCode = $buildInfoEvidence.result.exitCode
-            stdout = $buildInfoEvidence.result.stdout
-            stderr = $buildInfoEvidence.result.stderr
-            network = $buildInfoEvidence.result.network
-            forbiddenProcesses = $buildInfoEvidence.result.forbiddenProcesses
-        }
-        $report.identity = [ordered]@{
-            schemaVersion = $manifest.schemaVersion
-            sourceCommit = $manifest.source.commit
-            sourceTree = $manifest.source.tree
-            embeddedSourceRevision = $buildInfoEvidence.sourceRevision
-            embeddedVCSModified = $buildInfoEvidence.vcsModified
-            candidateVersion = $version
-            cliVersion = [string]$manifest.build.cliVersion
-            target = "$($manifest.build.target.goos)/$($manifest.build.target.goarch)"
-            archive = $archiveEvidence
-            archiveYouEntry = $zipEntryEvidence
-            executable = $executableEvidence
-            installer = $installerEvidence
-            manifest = $manifestEvidence
-            detachedManifestDigest = $digestFields[0]
-        }
-        $report.run.status = "RUNNING"
-        $report.run.startedAt = $runStartedAt.ToString("o")
-        $report.run.artifact = [ordered]@{
-            candidateVersion = $version
-            cliVersion = [string]$manifest.build.cliVersion
-            sourceCommit = [string]$manifest.source.commit
-            sourceTree = [string]$manifest.source.tree
-            embeddedSourceRevision = $buildInfoEvidence.sourceRevision
-            embeddedVCSModified = $buildInfoEvidence.vcsModified
-            manifest = $manifestEvidence
-            archive = $archiveEvidence
-            installer = $installerEvidence
-        }
-        $report.run.budgets = [ordered]@{
-            temporaryDiskBytesMaximum = [int64]$manifest.limits.temporaryDiskBytesMaximum
-            ordinaryToolDownloadBytesMaximum = [int64]$manifest.limits.ordinaryToolDownloadBytesMaximum
-            modelBackendDownloadBytesMaximum = [int64]$manifest.limits.modelBackendDownloadBytesMaximum
-            modelCallsMaximum = [int64]$manifest.limits.modelCallsMaximum
-            paidUSDMaximum = [int64]$manifest.limits.paidUSDMaximum
-            descendantMaximum = [int64]$manifest.limits.descendantMaximum
-            packagingOrSmokeRerunsMaximum = [int64]$manifest.limits.packagingOrSmokeRerunsMaximum
-            goflags = [string]$manifest.limits.goflags
-            gomaxprocs = [string]$manifest.limits.gomaxprocs
-        }
-        $report.installer.archiveName = $archiveName
-        $report.installer.checksumName = "you_${version}_checksums.txt"
-
-        $taskRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("infinite-you-install-candidate-" + [System.Guid]::NewGuid().ToString("N"))
-        Assert-SmokeDisposableRoot "task" $taskRoot
-        [void](New-Item -ItemType Directory -Path $taskRoot -Force)
-        $homeRoot = Join-Path $taskRoot "home"
-        $profileRoot = Join-Path $taskRoot "profile"
-        $pathRoot = Join-Path $taskRoot "path"
-        $tempRoot = Join-Path $taskRoot "temp"
-        $modelsRoot = Join-Path $taskRoot "models"
-        $backendRoot = Join-Path $modelsRoot "backend-artifacts"
-        $hfRoot = Join-Path $taskRoot "hf"
-        $appDataRoot = Join-Path $profileRoot "AppData\Roaming"
-        $localAppDataRoot = Join-Path $profileRoot "AppData\Local"
-        $configRoot = Join-Path $profileRoot ".you-agent-factory"
-        $stateRoot = Join-Path $configRoot "recordings"
-        $roots = @(
-            [pscustomobject]@{ name = "HOME"; path = $homeRoot },
-            [pscustomobject]@{ name = "USERPROFILE"; path = $profileRoot },
-            [pscustomobject]@{ name = "APPDATA"; path = $appDataRoot },
-            [pscustomobject]@{ name = "LOCALAPPDATA"; path = $localAppDataRoot },
-            [pscustomobject]@{ name = "install"; path = $installDirectory },
-            [pscustomobject]@{ name = "config"; path = $configRoot },
-            [pscustomobject]@{ name = "state"; path = $stateRoot },
-            [pscustomobject]@{ name = "models"; path = $modelsRoot },
-            [pscustomobject]@{ name = "backend"; path = $backendRoot },
-            [pscustomobject]@{ name = "HF"; path = $hfRoot },
-            [pscustomobject]@{ name = "temporary"; path = $tempRoot }
-        )
-        $seenRoots = @{}
-        foreach ($root in $roots) {
-            $normalizedRoot = [System.IO.Path]::GetFullPath($root.path).TrimEnd('\\').ToLowerInvariant()
-            if ($seenRoots.ContainsKey($normalizedRoot)) {
-                Fail-Smoke "declared roots '$($seenRoots[$normalizedRoot])' and '$($root.name)' overlap"
-            }
-            $seenRoots[$normalizedRoot] = $root.name
-            Assert-SmokeDisposableRoot $root.name $root.path
-        }
-        $installRootSafe = $true
-        Import-Module Microsoft.PowerShell.Utility -Global -ErrorAction Stop
-        if ($installDirectory.StartsWith($candidateDirectory.TrimEnd('\\') + '\\', [System.StringComparison]::OrdinalIgnoreCase) -or $installDirectory.TrimEnd('\\').Equals($candidateDirectory.TrimEnd('\\'), [System.StringComparison]::OrdinalIgnoreCase)) {
-            Fail-Smoke "install directory must not be inside the retained candidate directory"
-        }
-        if (Test-SmokePathResolvesYou $pathRoot) {
-            Fail-Smoke "task PATH already resolves you before installation"
-        }
-        $forbiddenBefore = @(Get-SmokeForbiddenProcesses)
-        if ($forbiddenBefore.Count -ne 0) {
-            Fail-Smoke "model/backend processes already exist before installation: $($forbiddenBefore -join ', ')"
-        }
-        $report.preconditions = [ordered]@{
-            taskPath = $pathRoot
-            pathResolvesYouBefore = $false
-            roots = @($roots | ForEach-Object { [ordered]@{ name = $_.name; path = $_.path; state = "ABSENT_OR_EMPTY" } })
-            forbiddenProcessesBefore = $forbiddenBefore
-            network = "loopback candidate listener only; no model/backend operation is admitted"
-            modelBackendDownloadBytesMaximum = 0
-            modelCallsMaximum = 0
-        }
-
-        foreach ($name in $environmentNames) {
-            $originalEnvironment[$name] = [System.Environment]::GetEnvironmentVariable($name, "Process")
-        }
-        $env:HOME = $homeRoot
-        $env:USERPROFILE = $profileRoot
-        $profileDrive = [System.IO.Path]::GetPathRoot($profileRoot)
-        if ([string]::IsNullOrWhiteSpace($profileDrive) -or $profileRoot.Length -lt $profileDrive.Length - 1) {
-            Fail-Smoke "could not derive an isolated HOMEDRIVE/HOMEPATH from $profileRoot"
-        }
-        $env:HOMEDRIVE = $profileDrive.TrimEnd('\\')
-        $env:HOMEPATH = $profileRoot.Substring($profileDrive.Length - 1)
-        $env:PATH = $pathRoot
-        $env:TEMP = $tempRoot
-        $env:TMP = $tempRoot
-        $env:APPDATA = $appDataRoot
-        $env:LOCALAPPDATA = $localAppDataRoot
-        $env:XDG_CONFIG_HOME = $configRoot
-        $env:XDG_CACHE_HOME = $localAppDataRoot
-        $env:INFINITE_YOU_VERSION = $version
-        $env:INFINITE_YOU_INSTALL_DIR = $installDirectory
-        $env:INFINITE_YOU_INSTALL_OS = "windows"
-        $env:INFINITE_YOU_INSTALL_ARCH = "amd64"
-        $env:INFINITE_YOU_OMNIVOICE_CACHE_DIR = $modelsRoot
-        $env:HUGGINGFACE_HUB_CACHE = $hfRoot
-        $env:HF_HOME = $hfRoot
-
-        [void](New-Item -ItemType Directory -Path $tempRoot -Force)
-        $baselineNetworkConnections = @(Get-SmokeNetworkConnections -ProcessId $PID)
-        foreach ($processName in $forbiddenBefore) {
-            [void]$forbiddenProcessObservations.Add($processName)
-        }
-        $activityBytesBefore = [int64](Get-SmokeDirectoryBytes -Path $modelsRoot) + [int64](Get-SmokeDirectoryBytes -Path $hfRoot)
-        $report.run.isolation = [ordered]@{
-            manifest = $manifestPath
-            candidateDirectory = $candidateDirectory
-            taskRoot = $taskRoot
-            installDirectory = $installDirectory
-            home = $homeRoot
-            userProfile = $profileRoot
-            temporary = $tempRoot
-            models = $modelsRoot
-            backend = $backendRoot
-            huggingFace = $hfRoot
-        }
-        $report.run.observer = [ordered]@{
-            status = "PASS"
-            startedBeforeInstaller = $true
-            networkSampler = "Get-NetTCPConnection"
-            baselineSamples = 1
-            baselineConnections = $baselineNetworkConnections
-            processSampler = "Get-Process forbidden-name scan"
-            errors = @()
-        }
-        $ledgerPath = Join-Path $tempRoot "installer-request-ledger.jsonl"
-        $serverState = Start-CandidateServer -InstallerPath $installerPath -ArchivePath $archivePath -ArchiveName $archiveName -ArchiveSHA256 $archiveEvidence.sha256 -Version $version -LedgerPath $ledgerPath
-        $env:INFINITE_YOU_INSTALL_BASE_URL = $serverState.baseUrl
-        $scriptUrl = "$($serverState.baseUrl)/download/v$version/install.ps1"
-        $report.installer.baseUrl = $serverState.baseUrl
-        $report.installer.scriptUrl = $scriptUrl
-        $report.installer.requestLedger = $ledgerPath
-
-        # Keep the fetched public script outside the installer-owned temp
-        # directory. The installer is responsible for removing its own
-        # temporary extraction directory before this smoke cleans the task.
-        $downloadedScriptPath = Join-Path $taskRoot "downloaded-install.ps1"
-        Invoke-WebRequest -Uri $scriptUrl -OutFile $downloadedScriptPath
-        $installerOutput = @(& $downloadedScriptPath 2>&1 | ForEach-Object { $_.ToString() })
-        $report.installer.output = $installerOutput
-
-        $installedBinaryPath = Join-Path $installDirectory $BinaryName
-        if (-not (Test-Path -LiteralPath $installedBinaryPath -PathType Leaf)) {
-            Fail-Smoke "installed binary missing: $installedBinaryPath"
-        }
-        $installedEvidence = Get-SmokeArtifactEvidence "installed-binary" $installedBinaryPath
-        if ($installedEvidence.bytes -ne $zipEntryEvidence.bytes -or $installedEvidence.sha256 -ne $zipEntryEvidence.sha256) {
-            Fail-Smoke "installed binary does not match the you.exe member in the declared archive"
-        }
-        $env:PATH = $installDirectory
-        $resolvedCommand = Get-Command -Name $BinaryName -CommandType Application -ErrorAction Stop
-        $resolvedPath = [System.IO.Path]::GetFullPath($resolvedCommand.Source)
-        if (-not $resolvedPath.Equals([System.IO.Path]::GetFullPath($installedBinaryPath), [System.StringComparison]::OrdinalIgnoreCase)) {
-            Fail-Smoke "PATH resolved $resolvedPath instead of the installed candidate $installedBinaryPath"
-        }
-        $report.identity.installedBinary = $installedEvidence
-        $report.identity.pathResolvedBinary = $resolvedPath
-
-        $versionResult = Invoke-SmokeCommand -FilePath $resolvedPath -Arguments @("--version") -WorkingDirectory $tempRoot
-        Record-SmokeCommandObservation -Result $versionResult -NetworkObservations $networkObservations -ForbiddenProcessObservations $forbiddenProcessObservations
-        Assert-SmokeCommandNetwork -Result $versionResult -CommandName "you --version"
-        $commandEvidence += [ordered]@{ command = "you --version"; exitCode = $versionResult.exitCode; stdout = $versionResult.stdout; stderr = $versionResult.stderr; network = $versionResult.network; forbiddenProcesses = $versionResult.forbiddenProcesses }
-        if ($versionResult.exitCode -ne 0 -or $versionResult.stdout.Trim() -ne [string]$manifest.build.cliVersion) {
-            Fail-Smoke "installed you --version was '$($versionResult.stdout.Trim())', want '$($manifest.build.cliVersion)'"
-        }
-        if (@(Get-SmokeForbiddenProcesses).Count -ne 0) {
-            Fail-Smoke "model/backend process observed after version command"
-        }
-
-        $helpResult = Invoke-SmokeCommand -FilePath $resolvedPath -Arguments @("models", "--help") -WorkingDirectory $tempRoot
-        Record-SmokeCommandObservation -Result $helpResult -NetworkObservations $networkObservations -ForbiddenProcessObservations $forbiddenProcessObservations
-        Assert-SmokeCommandNetwork -Result $helpResult -CommandName "you models --help"
-        $commandEvidence += [ordered]@{ command = "you models --help"; exitCode = $helpResult.exitCode; stdout = $helpResult.stdout; stderr = $helpResult.stderr; network = $helpResult.network; forbiddenProcesses = $helpResult.forbiddenProcesses }
-        if ($helpResult.exitCode -ne 0) {
-            Fail-Smoke "you models --help failed with exit code $($helpResult.exitCode)"
-        }
-        foreach ($modelName in @("llm", "asr", "tts", "embed")) {
-            if (-not $helpResult.stdout.Contains($modelName)) {
-                Fail-Smoke "you models --help did not expose built-in model '$modelName'"
-            }
-        }
-        if (@(Get-SmokeForbiddenProcesses).Count -ne 0) {
-            Fail-Smoke "model/backend process observed after models help"
-        }
-
-        $inspectionEvidence = @()
-        foreach ($modelName in @("llm", "asr", "tts", "embed")) {
-            $inspectResult = Invoke-SmokeCommand -FilePath $resolvedPath -Arguments @("--json", "models", "inspect", $modelName) -WorkingDirectory $tempRoot
-            Record-SmokeCommandObservation -Result $inspectResult -NetworkObservations $networkObservations -ForbiddenProcessObservations $forbiddenProcessObservations
-            Assert-SmokeCommandNetwork -Result $inspectResult -CommandName "you --json models inspect $modelName"
-            $commandEvidence += [ordered]@{ command = "you --json models inspect $modelName"; exitCode = $inspectResult.exitCode; stdout = $inspectResult.stdout; stderr = $inspectResult.stderr; network = $inspectResult.network; forbiddenProcesses = $inspectResult.forbiddenProcesses }
-            if ($inspectResult.exitCode -ne 0) {
-                Fail-Smoke "you --json models inspect $modelName failed with exit code $($inspectResult.exitCode)"
-            }
-            $inspection = $inspectResult.stdout | ConvertFrom-Json
-            if ($inspection.name -ne $modelName -or $inspection.managedRuntime.identity -ne $modelName) {
-                Fail-Smoke "models inspect $modelName returned an unexpected public name"
-            }
-            if ($inspection.managedRuntime.readinessState -ne "MISSING" -or $inspection.managedRuntime.lifecycleState -ne "NOT_INSTALLED" -or $inspection.loadState -ne "UNLOADED") {
-                Fail-Smoke "models inspect $modelName did not remain discovery-only (readiness=$($inspection.managedRuntime.readinessState), lifecycle=$($inspection.managedRuntime.lifecycleState), load=$($inspection.loadState))"
-            }
-            $inspectionEvidence += [ordered]@{
-                name = $inspection.name
-                readinessState = $inspection.managedRuntime.readinessState
-                lifecycleState = $inspection.managedRuntime.lifecycleState
-                loadState = $inspection.loadState
-            }
-            if (@(Get-SmokeForbiddenProcesses).Count -ne 0) {
-                Fail-Smoke "model/backend process observed after models inspect $modelName"
-            }
-        }
-        $report.commands = $commandEvidence
-        $report.discovery = [ordered]@{
-            help = "PASS"
-            inspections = $inspectionEvidence
-            modelNames = @("llm", "asr", "tts", "embed")
-            operation = "discovery-only"
-        }
-
-        $forbiddenAfter = @(Get-SmokeForbiddenProcesses)
-        foreach ($processName in $forbiddenAfter) {
-            [void]$forbiddenProcessObservations.Add($processName)
-        }
-        $nonEmptyActivityRoots = @()
-        foreach ($root in @(
-            [pscustomobject]@{ name = "models"; path = $modelsRoot },
-            [pscustomobject]@{ name = "backend"; path = $backendRoot },
-            [pscustomobject]@{ name = "HF"; path = $hfRoot }
-        )) {
-            $rootItem = Get-Item -LiteralPath $root.path -Force -ErrorAction SilentlyContinue
-            if ($null -ne $rootItem -and $rootItem.PSIsContainer -and @(Get-ChildItem -LiteralPath $root.path -Force -ErrorAction Stop).Count -ne 0) {
-                $nonEmptyActivityRoots += $root.name
-            }
-        }
-        if ($nonEmptyActivityRoots.Count -ne 0) {
-            Fail-Smoke "discovery created model/backend activity in: $($nonEmptyActivityRoots -join ', ')"
-        }
-        if ($forbiddenAfter.Count -ne 0) {
-            Fail-Smoke "model/backend processes remained after discovery: $($forbiddenAfter -join ', ')"
-        }
-        $allObservedConnections = New-Object 'System.Collections.Generic.List[object]'
-        $allUnexpectedConnections = New-Object 'System.Collections.Generic.List[object]'
-        $allPort7437Connections = New-Object 'System.Collections.Generic.List[object]'
-        $networkSampleCount = 0
-        foreach ($observation in $networkObservations) {
-            $networkSampleCount += [int]$observation.samples
-            foreach ($connection in @($observation.connections)) {
-                [void]$allObservedConnections.Add($connection)
-            }
-            foreach ($connection in @($observation.unexpectedConnections)) {
-                [void]$allUnexpectedConnections.Add($connection)
-            }
-            foreach ($connection in @($observation.port7437Connections)) {
-                [void]$allPort7437Connections.Add($connection)
-            }
-        }
-        if ($allUnexpectedConnections.Count -ne 0) {
-            Fail-Smoke "unexpected network activity was observed: $($allUnexpectedConnections | ConvertTo-Json -Compress)"
-        }
-        $activityBytesAfter = [int64](Get-SmokeDirectoryBytes -Path $modelsRoot) + [int64](Get-SmokeDirectoryBytes -Path $hfRoot)
-        $modelBackendDownloadBytes = [int64]$activityBytesAfter - [int64]$activityBytesBefore
-        if ($modelBackendDownloadBytes -lt 0) {
-            Fail-Smoke "model/backend activity byte observation moved backwards"
-        }
-        $observedForbiddenProcesses = @($forbiddenProcessObservations | Sort-Object -Unique)
-        $networkObserverEvidence = [ordered]@{
-            status = "PASS"
-            sampler = "Get-NetTCPConnection"
-            samples = $networkSampleCount
-            commandObservations = $networkObservations.ToArray()
-            connectionsObserved = $allObservedConnections.ToArray()
-            unexpectedConnectionsObserved = $allUnexpectedConnections.ToArray()
-            port7437ConnectionsObserved = $allPort7437Connections.ToArray()
-        }
-        $report.activity = [ordered]@{
-            modelBackendProcesses = $observedForbiddenProcesses
-            modelBackendActivityRoots = $nonEmptyActivityRoots
-            modelBackendDownloadBytes = $modelBackendDownloadBytes
-            modelCalls = [int]$allObservedConnections.Count
-            backendRequestsObserved = [int]$allPort7437Connections.Count
-            unexpectedNetworkConnectionsObserved = $allUnexpectedConnections.ToArray()
-            networkObserver = $networkObserverEvidence
-            conclusion = "PASS from live installed-CLI process/network observations and task-owned activity roots"
-        }
-        $report.run.observed = [ordered]@{
-            networkSamples = $networkSampleCount
-            connections = [int]$allObservedConnections.Count
-            unexpectedConnections = [int]$allUnexpectedConnections.Count
-            port7437Connections = [int]$allPort7437Connections.Count
-            forbiddenProcesses = $observedForbiddenProcesses
-            modelBackendDownloadBytes = $modelBackendDownloadBytes
-            modelCalls = [int]$allObservedConnections.Count
-        }
-
-        $completed = Wait-Job -Job $serverState.job -Timeout 15
-        if ($null -eq $completed -or $serverState.job.State -ne "Completed") {
-            Fail-Smoke "loopback candidate server did not finish its three expected installer requests"
-        }
-        $records = Read-CandidateRequestLedger $ledgerPath
-        $actualPaths = @($records | ForEach-Object { [string]$_.path } | Sort-Object)
-        $expectedPaths = @($serverState.expectedPaths | Sort-Object)
-        if ($records.Count -ne 3 -or (($actualPaths -join "`n") -ne ($expectedPaths -join "`n"))) {
-            Fail-Smoke "installer request ledger did not contain exactly the script, archive, and checksum paths: $($actualPaths -join ', ')"
-        }
-        foreach ($record in $records) {
-            if ($record.method -ne "GET" -or [int]$record.status -ne 200) {
-                Fail-Smoke "installer request ledger contains a non-success request: $($record | ConvertTo-Json -Compress)"
-            }
-        }
-        $report.installer.requests = $records
-        $report.status = "PASS"
-    } catch {
-        $failure = $_.Exception
-        $report.error = $failure.ToString()
-        $report.errorType = $failure.GetType().FullName
-        $report.errorInvocation = $_.InvocationInfo.PositionMessage
-    } finally {
-        try {
-            Stop-CandidateServer $serverState
-            $report.cleanup.listener = "STOPPED"
-        } catch {
-            $report.cleanup.listener = "ERROR: $($_.Exception.Message)"
-            if ($null -eq $failure) { $failure = $_.Exception }
-        }
-
-        $cleanupErrors = @()
-        if ($installRootSafe) {
-            try {
-                if (Test-Path -LiteralPath $installDirectory) {
-                    Remove-Item -LiteralPath $installDirectory -Recurse -Force -ErrorAction Stop
-                }
-            } catch {
-                $cleanupErrors += "install: $($_.Exception.Message)"
-            }
-        }
-        if ($null -ne $taskRoot) {
-            try {
-                if (Test-Path -LiteralPath $taskRoot) {
-                    Remove-Item -LiteralPath $taskRoot -Recurse -Force -ErrorAction Stop
-                }
-            } catch {
-                $cleanupErrors += "task: $($_.Exception.Message)"
-            }
-        }
-        $remainingPaths = @()
-        $preservedPreexistingPaths = @()
-        $cleanupPaths = @($taskRoot)
-        if ($installRootSafe) {
-            $cleanupPaths += $installDirectory
-        } elseif (-not [string]::IsNullOrWhiteSpace($installDirectory) -and (Test-Path -LiteralPath $installDirectory)) {
-            $preservedPreexistingPaths += $installDirectory
-        }
-        foreach ($path in $cleanupPaths) {
-            if (-not [string]::IsNullOrWhiteSpace($path) -and (Test-Path -LiteralPath $path)) {
-                $remainingPaths += $path
-            }
-        }
-        $report.cleanup.remainingTaskPaths = $remainingPaths
-        $report.cleanup.preservedPreexistingPaths = $preservedPreexistingPaths
-        $report.cleanup.errors = $cleanupErrors
-        if ($cleanupErrors.Count -ne 0 -or $remainingPaths.Count -ne 0) {
-            $report.cleanup.status = "FAIL"
-            if ($null -eq $failure) {
-                $failure = [System.Exception]::new("candidate cleanup left task-owned paths or reported errors")
-            }
-        } else {
-            $report.cleanup.status = "PASS"
-        }
-
-        try {
-            if ($originalEnvironment.Count -ne 0) {
-                foreach ($name in $environmentNames) {
-                    $value = $originalEnvironment[$name]
-                    if ($null -eq $value) {
-                        Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
-                    } else {
-                        [System.Environment]::SetEnvironmentVariable($name, $value, "Process")
-                    }
-                }
-            }
-        } catch {
-            $report.cleanup.environmentRestore = "ERROR: $($_.Exception.Message)"
-            if ($null -eq $failure) { $failure = $_.Exception }
-        }
-
-        try {
-            if ($null -ne $archiveEvidence -and $null -ne $installerEvidence -and $null -ne $executableEvidence -and $null -ne $manifestEvidence) {
-                $postArchive = Get-SmokeArtifactEvidence "windows-amd64-archive" $archivePath
-                $postInstaller = Get-SmokeArtifactEvidence "windows-installer" $installerPath
-                $postExecutable = Get-SmokeArtifactEvidence "windows-amd64-executable" $executablePath
-                $postManifest = Get-SmokeArtifactEvidence "candidate-manifest" $manifestPath
-                $postDigest = (([System.IO.File]::ReadAllText($digestPath)).Trim() -split '\s+')[0]
-                $report.postCleanup = [ordered]@{
-                    archive = $postArchive
-                    executable = $postExecutable
-                    installer = $postInstaller
-                    manifest = $postManifest
-                    detachedManifestDigest = $postDigest
-                    candidateHashesStable = ($postArchive.sha256 -eq $archiveEvidence.sha256 -and $postExecutable.sha256 -eq $executableEvidence.sha256 -and $postInstaller.sha256 -eq $installerEvidence.sha256 -and $postManifest.sha256 -eq $manifestEvidence.sha256 -and $postDigest -eq $manifestEvidence.sha256)
-                }
-                if (-not $report.postCleanup.candidateHashesStable) {
-                    if ($null -eq $failure) { $failure = [System.Exception]::new("candidate hashes changed during install smoke cleanup") }
-                    $report.cleanup.status = "FAIL"
-                }
-            } else {
-                $report.postCleanup = [ordered]@{ status = "NOT_AVAILABLE"; reason = "candidate artifacts were not fully validated" }
-            }
-        } catch {
-            $report.postCleanup = [ordered]@{ status = "ERROR"; error = $_.Exception.Message }
-            if ($null -eq $failure) { $failure = $_.Exception }
-        }
-        $runEndedAt = [DateTime]::UtcNow
-        $report.run.endedAt = $runEndedAt.ToString("o")
-        $report.run.durationMilliseconds = [int64]($runEndedAt - $runStartedAt).TotalMilliseconds
-        $report.run.status = if ($null -eq $failure) { "PASS" } else { "FAIL" }
-    }
-
-    if ($null -ne $failure) {
-        $report.status = "FAIL"
-    }
-    return [pscustomobject]@{
-        report = $report
-        error = $failure
-    }
+    Invoke-LocalCandidateSmoke @candidateArguments
+    exit 0
 }
-
-function Invoke-ObserverIdentityFixture {
-    param(
-        [string]$RequestedInstallDir,
-        [string]$RequestedReportPath
-    )
-
-    $reportPath = if ([string]::IsNullOrWhiteSpace($RequestedReportPath)) {
-        Join-Path (Resolve-SmokeAbsolutePath $RequestedInstallDir) "observer-identity-report.json"
-    } else {
-        Resolve-SmokeAbsolutePath $RequestedReportPath
-    }
-    $job = Start-Job -ScriptBlock {
-        param($IdentityFunctionSource, $CandidateCycle)
-        $ErrorActionPreference = "Stop"
-        Invoke-Expression $IdentityFunctionSource
-
-        function New-ObserverSyntheticSnapshot {
-            param([string]$Identity)
-
-            $root = [pscustomobject]@{ processId = 100; identity = "100/root"; name = "powershell" }
-            $descendant = [pscustomobject]@{ processId = 42; identity = $Identity; name = "powershell" }
-            return [pscustomobject]@{
-                rootPresent = $true
-                root = $root
-                descendants = @($descendant)
-                ownedRecords = @($root, $descendant)
-            }
-        }
-
-        $crossActive = @{}
-        $crossHistory = @{}
-        $crossState = @{ rootIdentity = $null }
-        Register-ObserverIdentities (New-ObserverSyntheticSnapshot "42/A") $crossActive $crossHistory $crossState
-        $emptyRows = @(Get-ObserverConnectionTable { @() })
-        Remove-ObserverInactivePidIdentities (New-ObserverSyntheticSnapshot "42/B") $crossActive
-        Register-ObserverIdentities (New-ObserverSyntheticSnapshot "42/B") $crossActive $crossHistory $crossState
-        Register-ObserverIdentities (New-ObserverSyntheticSnapshot "42/B") $crossActive $crossHistory $crossState
-        $crossPass = [string]$crossActive[42] -ceq "42/B" -and $crossHistory.ContainsKey("42/A") -and $crossHistory.ContainsKey("42/B") -and $emptyRows.Count -eq 0
-
-        $withinActive = @{}
-        $withinHistory = @{}
-        $withinState = @{ rootIdentity = $null }
-        Register-ObserverIdentities (New-ObserverSyntheticSnapshot "42/A") $withinActive $withinHistory $withinState
-        $withinRejected = $false
-        $withinError = ""
-        try {
-            [void](Get-ObserverConnectionTable { @() })
-            Register-ObserverIdentities (New-ObserverSyntheticSnapshot "42/B") $withinActive $withinHistory $withinState
-        } catch {
-            $withinRejected = $true
-            $withinError = $_.Exception.Message
-        }
-
-        $queryErrorPreserved = $false
-        $queryError = ""
-        try {
-            [void](Get-ObserverConnectionTable { throw "synthetic query error" })
-        } catch {
-            $queryError = $_.Exception.Message
-            $queryErrorPreserved = $queryError -like "*synthetic query error*"
-        }
-        [ordered]@{
-            schemaVersion = "localai-windows-install-candidate-observer-identity/v1"
-            status = if ($crossPass -and $withinRejected -and $queryErrorPreserved) { "PASS" } else { "FAIL" }
-            cycle = $CandidateCycle
-            releaseStatus = "observer-identity-fixture"
-            crossInterval = [ordered]@{
-                status = if ($crossPass) { "PASS" } else { "FAIL" }
-                activeIdentity = [string]$crossActive[42]
-                historicalIdentities = @($crossHistory.Keys | Sort-Object)
-                continued = $crossPass
-            }
-            withinSample = [ordered]@{
-                status = if ($withinRejected) { "PASS" } else { "FAIL" }
-                rejected = $withinRejected
-                error = $withinError
-            }
-            emptyTCP = [ordered]@{
-                status = if ($emptyRows.Count -eq 0) { "PASS" } else { "FAIL" }
-                rowCount = $emptyRows.Count
-            }
-            queryError = [ordered]@{
-                status = if ($queryErrorPreserved) { "PASS" } else { "FAIL" }
-                error = $queryError
-            }
-        } | ConvertTo-Json -Depth 12
-    } -ArgumentList $observerIdentityFunctionSource, $expectedCandidateCycle
-    $report = $null
-    $failure = $null
-    try {
-        $completed = Wait-Job -Job $job -Timeout 10
-        if ($null -eq $completed -or $job.State -ne "Completed") {
-            throw "observer identity fixture did not complete"
-        }
-        $results = @(Receive-Job -Job $job -ErrorAction Stop)
-        if ($results.Count -eq 0) {
-            throw "observer identity fixture returned no report"
-        }
-        $report = [string]$results[$results.Count - 1] | ConvertFrom-Json
-    } catch {
-        $failure = $_.Exception
-    } finally {
-        try { Remove-Job -Job $job -Force -ErrorAction Stop } catch { }
-    }
-    if ($null -eq $report) {
-        $report = [ordered]@{
-            schemaVersion = "localai-windows-install-candidate-observer-identity/v1"
-            status = "FAIL"
-            cycle = $expectedCandidateCycle
-            releaseStatus = "observer-identity-fixture"
-            error = if ($null -eq $failure) { "observer identity fixture returned no report" } else { $failure.Message }
-        }
-    }
-    $reportParent = Split-Path -Parent $reportPath
-    if (-not (Test-Path -LiteralPath $reportParent -PathType Container)) {
-        Fail-Smoke "observer identity report parent does not exist: $reportParent"
-    }
-    [System.IO.File]::WriteAllText($reportPath, ($report | ConvertTo-Json -Depth 12))
-    if ($report.status -ne "PASS") {
-        throw "observer identity fixture failed; report=$reportPath"
-    }
-    Write-Output "observer identity fixture passed; report=$reportPath"
+$hostedArguments = @{
+    ScriptUrl = $InstallScriptUrl
+    Version = $InstallVersion
+    RequestedInstallDir = $InstallDir
+    RequestedBinaryName = $BinaryName
 }
-
-function Invoke-ObserverFixture {
-    param(
-        [string]$RequestedInstallDir,
-        [string]$RequestedReportPath,
-        [string]$RootCommand,
-        [string[]]$RootArgumentList,
-        [string]$RootWorkingDirectory,
-        [string]$RootStdoutPath,
-        [string]$RootStderrPath,
-        [int]$RootOutputMaximumBytes = 1048576,
-        [int]$RequestedRootExitCode = 0,
-        [string]$ObserverReleaseCheckoutPath,
-        [int]$TimeoutSeconds = 20
-    )
-
-    $externalRoot = -not [string]::IsNullOrWhiteSpace($RootCommand)
-    if ($TimeoutSeconds -le 0) {
-        Fail-Smoke "observer timeout must be positive"
-    }
-    $resolvedRootWorkingDirectory = $null
-    if ($externalRoot) {
-        $resolvedRootWorkingDirectory = if ([string]::IsNullOrWhiteSpace($RootWorkingDirectory)) {
-            (Get-Location).Path
-        } else {
-            Resolve-SmokeAbsolutePath $RootWorkingDirectory
-        }
-        if (-not (Test-Path -LiteralPath $resolvedRootWorkingDirectory -PathType Container)) {
-            Fail-Smoke "observer root working directory does not exist: $resolvedRootWorkingDirectory"
-        }
-    }
-    $reportPath = if ([string]::IsNullOrWhiteSpace($RequestedReportPath)) {
-        Join-Path (Resolve-SmokeAbsolutePath $RequestedInstallDir) "observer-report.json"
-    } else {
-        Resolve-SmokeAbsolutePath $RequestedReportPath
-    }
-    $fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("infinite-you-observer-" + [System.Guid]::NewGuid().ToString("N"))
-    [void][System.IO.Directory]::CreateDirectory($fixtureRoot)
-    $observationRoot = if ($externalRoot) {
-        Resolve-SmokeAbsolutePath $RequestedInstallDir
-    } else {
-        $fixtureRoot
-    }
-    if (-not (Test-Path -LiteralPath $observationRoot -PathType Container)) {
-        Fail-Smoke "observer observation root does not exist: $observationRoot"
-    }
-    $releaseCheckoutEvidence = $null
-    if (-not [string]::IsNullOrWhiteSpace($ObserverReleaseCheckoutPath)) {
-        $releaseCheckoutEvidence = Assert-SmokeReleaseCheckout -RequestedCheckoutPath $ObserverReleaseCheckoutPath -RequireDistExclude
-        $releaseCheckoutEvidence.statusCleanDuringOutput = $false
-        $releaseCheckoutEvidence.statusCleanAfterOutput = $false
-        $releaseCheckoutEvidence.statusChecks = 0
-    }
-    $processReadyPath = Join-Path $fixtureRoot "process-ready"
-    $diskReadyPath = Join-Path $fixtureRoot "disk-ready"
-    $pidPath = Join-Path $fixtureRoot "root.pid"
-    $donePath = Join-Path $fixtureRoot "root.done"
-    $rootStdoutPath = if ([string]::IsNullOrWhiteSpace($RootStdoutPath)) {
-        Join-Path (Split-Path -Parent $reportPath) "observer-root.stdout.txt"
-    } else {
-        Resolve-SmokeAbsolutePath $RootStdoutPath
-    }
-    $rootStderrPath = if ([string]::IsNullOrWhiteSpace($RootStderrPath)) {
-        Join-Path (Split-Path -Parent $reportPath) "observer-root.stderr.txt"
-    } else {
-        Resolve-SmokeAbsolutePath $RootStderrPath
-    }
-    if ($RootOutputMaximumBytes -le 0) {
-        Fail-Smoke "observer root output maximum must be positive"
-    }
-    foreach ($retainedPath in @($rootStdoutPath, $rootStderrPath)) {
-        $retainedParent = Split-Path -Parent $retainedPath
-        if (-not (Test-Path -LiteralPath $retainedParent -PathType Container)) {
-            Fail-Smoke "observer root output parent does not exist: $retainedParent"
-        }
-        if (Test-Path -LiteralPath $retainedPath -PathType Leaf) {
-            Fail-Smoke "observer root output evidence already exists: $retainedPath"
-        }
-        if (Test-Path -LiteralPath $retainedPath -PathType Container) {
-            Fail-Smoke "observer root output evidence path is a directory: $retainedPath"
-        }
-    }
-    $rootStdoutCapturePath = $rootStdoutPath + ".capture"
-    $rootStderrCapturePath = $rootStderrPath + ".capture"
-    foreach ($capturePath in @($rootStdoutCapturePath, $rootStderrCapturePath)) {
-        if (Test-Path -LiteralPath $capturePath) {
-            Fail-Smoke "observer root output capture already exists: $capturePath"
-        }
-    }
-    $processJob = $null
-    $diskJob = $null
-    $rootProcess = $null
-    $rootExitCode = $null
-    $rootOutput = [ordered]@{
-        status = "FAIL"
-        maximumBytes = [int64]$RootOutputMaximumBytes
-        stdout = [ordered]@{ status = "FAIL"; path = $rootStdoutPath; present = $false; totalBytes = [int64]0; capturedBytes = [int64]0; truncated = $false; redactedBytes = [int64]0; sha256 = "" }
-        stderr = [ordered]@{ status = "FAIL"; path = $rootStderrPath; present = $false; totalBytes = [int64]0; capturedBytes = [int64]0; truncated = $false; redactedBytes = [int64]0; sha256 = "" }
-    }
-    $failure = $null
-    $cleanupErrors = New-Object 'System.Collections.Generic.List[string]'
-    $remainingTaskPaths = @()
-    $processObservation = [pscustomobject]@{
-        status = "FAIL"; startedBeforeRoot = $false; continuedThroughDescendantExit = $false
-        maximumGapMilliseconds = [int64]0; nonLoopbackConnections = 0; externalTransferBytes = [int64]0; descendantHighWater = [int64]0
-        sampleCount = 0; tcpTableQueries = 0; zeroConnectionSamples = 0; ownedConnectionMatches = 0
-        ownedProcessIdentityCount = 0; queryMode = $expectedObserverQueryMode; forbiddenProcesses = @(); error = ""
-        releaseStatusCleanBeforeRoot = $false; releaseStatusCleanDuringRoot = $false; releaseStatusCleanAfterOutput = $false; releaseStatusChecks = 0
-    }
-    $diskObservation = [pscustomobject]@{
-        status = "FAIL"; independent = $false; startPeriodicFinal = $false
-        maximumGapMilliseconds = [int64]0; peakDeltaBytes = [int64]0; error = ""
-    }
-    $goEnvironment = [ordered]@{
-        GOFLAGS = [string]$env:GOFLAGS
-        GOMAXPROCS = [string]$env:GOMAXPROCS
-    }
-
-    try {
-        $processJob = Start-Job -ScriptBlock {
-            param($ReadyPath, $PidPath, $DonePath, $TimeoutSeconds, $IdentityFunctionSource, $ReleaseCheckoutPath)
-            $ErrorActionPreference = "Stop"
-            Invoke-Expression $IdentityFunctionSource
-            $processNetworkGapMaximumMilliseconds = [int64]2000
-            $descendantMaximum = [int64]36
-            $queryMode = "one-full-TCP-table-query-per-interval-filtered-to-owned-process-identities"
-            $forbiddenNamePatterns = @("localai", "local-ai", "llama-server", "llama-cli", "vibevoice", "whisper", "piper")
-            $releaseStatusCleanBeforeRoot = $false
-            $releaseStatusCleanDuringRoot = $false
-            $releaseStatusCleanAfterOutput = $false
-            $releaseStatusChecks = 0
-            if (-not [string]::IsNullOrWhiteSpace($ReleaseCheckoutPath)) {
-                if ((Get-ObserverGitStatus $ReleaseCheckoutPath) -ne "") {
-                    throw "release checkout is dirty before root start"
-                }
-                $releaseStatusChecks++
-                $releaseStatusCleanBeforeRoot = $true
-            }
-            [System.IO.File]::WriteAllText($ReadyPath, "ready")
-            function Convert-ObserverCreationTimeTicks {
-                param($Value)
-
-                if ($Value -is [DateTime]) {
-                    return [int64]$Value.ToUniversalTime().Ticks
-                }
-                try {
-                    $date = [System.Management.ManagementDateTimeConverter]::ToDateTime([string]$Value)
-                } catch {
-                    throw "process creation time is not readable: $Value"
-                }
-                return [int64]$date.ToUniversalTime().Ticks
-            }
-            function Get-ObserverProcessSnapshot {
-                param([int]$RootId)
-                $all = @(Get-CimInstance -ClassName Win32_Process -ErrorAction Stop)
-                $byId = @{}
-                $children = @{}
-                foreach ($item in $all) {
-                    $processId = [int]$item.ProcessId
-                    if ($byId.ContainsKey($processId)) {
-                        throw "process identity is ambiguous for PID $processId"
-                    }
-                    $creationTicks = Convert-ObserverCreationTimeTicks $item.CreationDate
-                    $record = [pscustomobject]@{
-                        processId = $processId
-                        parentProcessId = [int]$item.ParentProcessId
-                        identity = "$processId/$creationTicks"
-                        name = [string]$item.Name
-                    }
-                    $byId[$processId] = $record
-                    $parent = [int]$item.ParentProcessId
-                    if (-not $children.ContainsKey($parent)) { $children[$parent] = @() }
-                    $children[$parent] = @($children[$parent]) + $processId
-                }
-                if (-not $byId.ContainsKey($RootId)) {
-                    return [pscustomobject]@{
-                        rootPresent = $false
-                        root = $null
-                        descendants = @()
-                        ownedRecords = @()
-                    }
-                }
-                $pending = [System.Collections.Generic.Queue[int]]::new()
-                $visited = @{$RootId = $true}
-                $descendants = New-Object 'System.Collections.Generic.List[object]'
-                $ownedRecords = New-Object 'System.Collections.Generic.List[object]'
-                $root = $byId[$RootId]
-                [void]$ownedRecords.Add($root)
-                $pending.Enqueue($RootId)
-                while ($pending.Count -gt 0) {
-                    $parent = $pending.Dequeue()
-                    if (-not $children.ContainsKey($parent)) { continue }
-                    foreach ($childId in @($children[$parent])) {
-                        $childId = [int]$childId
-                        if ($visited.ContainsKey($childId)) {
-                            throw "owned process tree is ambiguous at PID $childId"
-                        }
-                        if (-not $byId.ContainsKey($childId)) {
-                            throw "owned process tree lost PID $childId during enumeration"
-                        }
-                        $visited[$childId] = $true
-                        $child = $byId[$childId]
-                        [void]$descendants.Add($child)
-                        [void]$ownedRecords.Add($child)
-                        $pending.Enqueue($childId)
-                    }
-                }
-                if ($descendants.Count -gt $descendantMaximum) {
-                    throw "owned descendant count $($descendants.Count) exceeds $descendantMaximum"
-                }
-                [pscustomobject]@{
-                    rootPresent = $true
-                    root = $root
-                    descendants = $descendants.ToArray()
-                    ownedRecords = $ownedRecords.ToArray()
-                }
-            }
-            function Test-ObserverLoopbackAddress {
-                param([string]$Address)
-
-                return $Address.Trim().ToLowerInvariant() -in @("127.0.0.1", "::1", "0:0:0:0:0:0:0:1", "::ffff:127.0.0.1")
-            }
-            function Get-ObserverSample {
-                param(
-                    [int]$RootId,
-                    [hashtable]$IdentityByPid,
-                    [hashtable]$OwnedIdentityToPid,
-                    [hashtable]$State
-                )
-                if ($null -eq (Get-Command Get-NetTCPConnection -ErrorAction SilentlyContinue)) {
-                    throw "Get-NetTCPConnection is unavailable"
-                }
-                $before = Get-ObserverProcessSnapshot $RootId
-                Remove-ObserverInactivePidIdentities $before $IdentityByPid
-                Register-ObserverIdentities $before $IdentityByPid $OwnedIdentityToPid $State
-                # One complete TCP-table query is deliberately shared by every
-                # owned process in this interval; an empty table is a valid sample.
-                $connections = @(Get-ObserverConnectionTable { Get-NetTCPConnection -ErrorAction Stop })
-                $after = Get-ObserverProcessSnapshot $RootId
-                Register-ObserverIdentities $after $IdentityByPid $OwnedIdentityToPid $State
-                $ownedPids = @{}
-                foreach ($record in @($before.ownedRecords) + @($after.ownedRecords)) {
-                    $ownedPids[[int]$record.processId] = [string]$record.identity
-                }
-                $nonLoopback = 0
-                $ownedMatches = 0
-                foreach ($connection in @($connections)) {
-                    if ($null -eq $connection.OwningProcess) {
-                        throw "TCP-table row has no owning process identity"
-                    }
-                    $processId = [int]$connection.OwningProcess
-                    if (-not $ownedPids.ContainsKey($processId)) {
-                        continue
-                    }
-                    $ownedMatches++
-                    if ([string]$connection.State -ne "Listen" -and -not (Test-ObserverLoopbackAddress ([string]$connection.RemoteAddress))) {
-                        $nonLoopback++
-                    }
-                }
-                $forbiddenProcesses = @($before.ownedRecords + $after.ownedRecords | Where-Object {
-                    $name = ([string]$_.name).ToLowerInvariant()
-                    $forbiddenNamePatterns | Where-Object { $name -like "*$_*" }
-                } | ForEach-Object { "{0}:{1}" -f $_.processId, $_.name } | Sort-Object -Unique)
-                if ($forbiddenProcesses.Count -ne 0) {
-                    throw "forbidden owned process observed: $($forbiddenProcesses -join ', ')"
-                }
-                if ($nonLoopback -ne 0) {
-                    throw "non-loopback connection observed in owned TCP sample"
-                }
-                [pscustomobject]@{
-                    rootPresent = [bool]$after.rootPresent
-                    descendantCount = [int]$after.descendants.Count
-                    nonLoopbackConnections = [int]$nonLoopback
-                    ownedConnectionMatches = [int]$ownedMatches
-                    tcpRows = [int]$connections.Count
-                    tcpTableQueries = 1
-                    ownedProcessIdentityCount = [int]$OwnedIdentityToPid.Count
-                    forbiddenProcesses = $forbiddenProcesses
-                }
-            }
-            $identityByPid = @{}
-            $ownedIdentityToPid = @{}
-            $observerState = @{rootIdentity = $null}
-            $maximumGap = [int64]0
-            $samples = 0
-            $descendantHighWater = [int64]0
-            $nonLoopbackConnections = 0
-            $tcpTableQueries = 0
-            $zeroConnectionSamples = 0
-            $ownedConnectionMatches = 0
-            try {
-                $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
-                while (-not (Test-Path -LiteralPath $PidPath) -and [DateTime]::UtcNow -lt $deadline) { Start-Sleep -Milliseconds 25 }
-                if (-not (Test-Path -LiteralPath $PidPath)) { throw "root PID was not published" }
-                $rootId = [int]([System.IO.File]::ReadAllText($PidPath)).Trim()
-                $previous = $null
-                $rootExited = $false
-                $continuedThroughExit = $false
-                while ([DateTime]::UtcNow -lt $deadline) {
-                    $sample = Get-ObserverSample $rootId $identityByPid $ownedIdentityToPid $observerState
-                    $now = [DateTime]::UtcNow
-                    if ($null -ne $previous) {
-                        $gap = [int64]($now - $previous).TotalMilliseconds
-                        if ($gap -gt $maximumGap) { $maximumGap = $gap }
-                        if ($gap -gt $processNetworkGapMaximumMilliseconds) {
-                            throw "process/network observer gap $gap ms exceeds $processNetworkGapMaximumMilliseconds ms"
-                        }
-                    }
-                    $previous = $now
-                    $samples++
-                    if ($sample.descendantCount -gt $descendantHighWater) { $descendantHighWater = $sample.descendantCount }
-                    if ($sample.descendantCount -gt $descendantMaximum) { throw "owned descendant count $($sample.descendantCount) exceeds $descendantMaximum" }
-                    $nonLoopbackConnections += [int]$sample.nonLoopbackConnections
-                    $tcpTableQueries += [int]$sample.tcpTableQueries
-                    $ownedConnectionMatches += [int]$sample.ownedConnectionMatches
-                    if ([int]$sample.ownedConnectionMatches -eq 0) { $zeroConnectionSamples++ }
-                    if ([int]$sample.nonLoopbackConnections -ne 0) { throw "non-loopback connection observed in owned TCP sample" }
-                    if (Test-Path -LiteralPath $DonePath) { $rootExited = $true }
-                    if (-not [string]::IsNullOrWhiteSpace($ReleaseCheckoutPath)) {
-                        if ((Get-ObserverGitStatus $ReleaseCheckoutPath) -ne "") {
-                            throw "release checkout became dirty during output production"
-                        }
-                        $releaseStatusChecks++
-                        $releaseStatusCleanDuringRoot = $true
-                        if ($rootExited) { $releaseStatusCleanAfterOutput = $true }
-                    }
-                    if ($rootExited -and -not $sample.rootPresent -and $sample.descendantCount -eq 0) {
-                        if ($null -eq $observerState["rootIdentity"]) { throw "root exited before its owned process identity was captured" }
-                        $continuedThroughExit = $true
-                        break
-                    }
-                    # This is the measurement cadence, not a completion wait;
-                    # completion is decided from the next process/TCP sample.
-                    Start-Sleep -Milliseconds 100
-                }
-                if (-not $continuedThroughExit) { throw "observer did not reach root and descendant exit" }
-                [pscustomobject]@{
-                    status = "PASS"; startedBeforeRoot = $true; continuedThroughDescendantExit = $continuedThroughExit
-                    maximumGapMilliseconds = $maximumGap; nonLoopbackConnections = $nonLoopbackConnections
-                    externalTransferBytes = [int64]0; descendantHighWater = $descendantHighWater
-                    sampleCount = $samples; tcpTableQueries = $tcpTableQueries
-                    zeroConnectionSamples = $zeroConnectionSamples; ownedConnectionMatches = $ownedConnectionMatches
-                    ownedProcessIdentityCount = [int64]$ownedIdentityToPid.Count; queryMode = $queryMode
-                    forbiddenProcesses = @(); error = ""
-                    releaseStatusCleanBeforeRoot = $releaseStatusCleanBeforeRoot; releaseStatusCleanDuringRoot = $releaseStatusCleanDuringRoot; releaseStatusCleanAfterOutput = $releaseStatusCleanAfterOutput; releaseStatusChecks = $releaseStatusChecks
-                }
-            } catch {
-                [pscustomobject]@{
-                    status = "FAIL"; startedBeforeRoot = $true; continuedThroughDescendantExit = $false
-                    maximumGapMilliseconds = $maximumGap; nonLoopbackConnections = $nonLoopbackConnections; externalTransferBytes = [int64]0
-                    descendantHighWater = $descendantHighWater; sampleCount = $samples; tcpTableQueries = $tcpTableQueries
-                    zeroConnectionSamples = $zeroConnectionSamples; ownedConnectionMatches = $ownedConnectionMatches
-                    ownedProcessIdentityCount = [int64]$ownedIdentityToPid.Count; queryMode = $queryMode
-                    forbiddenProcesses = @(); error = $_.Exception.Message
-                    releaseStatusCleanBeforeRoot = $releaseStatusCleanBeforeRoot; releaseStatusCleanDuringRoot = $releaseStatusCleanDuringRoot; releaseStatusCleanAfterOutput = $releaseStatusCleanAfterOutput; releaseStatusChecks = $releaseStatusChecks
-                }
-            }
-        } -ArgumentList $processReadyPath, $pidPath, $donePath, $TimeoutSeconds, $observerIdentityFunctionSource, $ObserverReleaseCheckoutPath
-
-        $diskJob = Start-Job -ScriptBlock {
-            param($RootPath, $ReadyPath, $DonePath, $TimeoutSeconds)
-            $ErrorActionPreference = "Stop"
-            $diskGapMaximumMilliseconds = [int64]2000
-            $temporaryDiskMaximum = [int64]4294967296
-            function Get-ObserverDirectoryBytes {
-                $total = [int64]0
-                if (-not (Test-Path -LiteralPath $RootPath -PathType Container)) { return $total }
-                foreach ($item in @(Get-ChildItem -LiteralPath $RootPath -File -Force -Recurse -ErrorAction Stop)) {
-                    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) { throw "observer fixture saw a reparse point" }
-                    $total += [int64]$item.Length
-                }
-                return $total
-            }
-            $maximumGap = [int64]0
-            $peakBytes = [int64]0
-            $samples = 0
-            try {
-                $startedAt = [DateTime]::UtcNow
-                [System.IO.File]::WriteAllText($ReadyPath, "ready")
-                $previous = $null
-                $initialBytes = $null
-                $finalSample = $false
-                $deadline = $startedAt.AddSeconds($TimeoutSeconds)
-                while ([DateTime]::UtcNow -lt $deadline) {
-                    $bytes = [int64](Get-ObserverDirectoryBytes)
-                    $now = [DateTime]::UtcNow
-                    if ($null -ne $previous) {
-                        $gap = [int64]($now - $previous).TotalMilliseconds
-                        if ($gap -gt $maximumGap) { $maximumGap = $gap }
-                        if ($gap -gt $diskGapMaximumMilliseconds) {
-                            throw "disk observer gap $gap ms exceeds $diskGapMaximumMilliseconds ms"
-                        }
-                    }
-                    $previous = $now
-                    if ($null -eq $initialBytes) { $initialBytes = $bytes }
-                    if ($bytes -gt $peakBytes) { $peakBytes = $bytes }
-                    if ($peakBytes - $initialBytes -gt $temporaryDiskMaximum) {
-                        throw "disk observer delta $($peakBytes - $initialBytes) exceeds $temporaryDiskMaximum bytes"
-                    }
-                    $samples++
-                    if (Test-Path -LiteralPath $DonePath) {
-                        $bytes = [int64](Get-ObserverDirectoryBytes)
-                        $now = [DateTime]::UtcNow
-                        $gap = [int64]($now - $previous).TotalMilliseconds
-                        if ($gap -gt $maximumGap) { $maximumGap = $gap }
-                        if ($gap -gt $diskGapMaximumMilliseconds) {
-                            throw "disk observer final gap $gap ms exceeds $diskGapMaximumMilliseconds ms"
-                        }
-                        if ($bytes -gt $peakBytes) { $peakBytes = $bytes }
-                        if ($peakBytes - $initialBytes -gt $temporaryDiskMaximum) {
-                            throw "disk observer delta $($peakBytes - $initialBytes) exceeds $temporaryDiskMaximum bytes"
-                        }
-                        $samples++
-                        $finalSample = $true
-                        break
-                    }
-                    # This is the disk measurement cadence; completion is
-                    # decided from the observed done marker and final sample.
-                    Start-Sleep -Milliseconds 100
-                }
-                if ($null -eq $initialBytes -or -not $finalSample) { throw "disk observer did not produce periodic and final samples" }
-                [pscustomobject]@{
-                    status = "PASS"; independent = $true; startPeriodicFinal = ($samples -ge 3 -and $finalSample)
-                    maximumGapMilliseconds = $maximumGap; peakDeltaBytes = [int64]($peakBytes - $initialBytes); samples = $samples; error = ""
-                }
-            } catch {
-                [pscustomobject]@{
-                    status = "FAIL"; independent = $true; startPeriodicFinal = $false
-                    maximumGapMilliseconds = $maximumGap; peakDeltaBytes = [int64]$peakBytes; error = $_.Exception.Message
-                }
-            }
-        } -ArgumentList $observationRoot, $diskReadyPath, $donePath, $TimeoutSeconds
-
-        $readyDeadline = [DateTime]::UtcNow.AddSeconds(10)
-        # Readiness is polled only until both independent observer jobs publish
-        # their ready markers; sampling cadence remains inside each observer.
-        while ((-not (Test-Path -LiteralPath $processReadyPath) -or -not (Test-Path -LiteralPath $diskReadyPath)) -and [DateTime]::UtcNow -lt $readyDeadline) { Start-Sleep -Milliseconds 25 }
-        if (-not (Test-Path -LiteralPath $processReadyPath) -or -not (Test-Path -LiteralPath $diskReadyPath)) { throw "observers did not start before root" }
-
-        if ($externalRoot) {
-            $rootFilePath = $RootCommand
-            $rootArguments = @($RootArgumentList)
-        } else {
-        $childOne = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("Start-Sleep -Milliseconds 2500"))
-        $childTwo = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("Start-Sleep -Milliseconds 3000"))
-        $fixtureFile = (Join-Path $fixtureRoot "fixture.txt").Replace("'", "''")
-        if ($RequestedRootExitCode -lt 0 -or $RequestedRootExitCode -gt 255) { throw "observer root exit code must be between 0 and 255" }
-        $rootExitCommand = "exit " + ([int]$RequestedRootExitCode)
-        $rootScript = "`$ErrorActionPreference = 'Stop'; Set-Content -LiteralPath '$fixtureFile' -Value ('fixture' * 64); Write-Output 'root stdout token=observer-secret'; [Console]::Error.WriteLine('root stderr api_key=observer-secret'); `$one = Start-Process -FilePath 'powershell.exe' -WindowStyle Hidden -ArgumentList @('-NoProfile','-NonInteractive','-EncodedCommand','$childOne') -PassThru; `$two = Start-Process -FilePath 'powershell.exe' -WindowStyle Hidden -ArgumentList @('-NoProfile','-NonInteractive','-EncodedCommand','$childTwo') -PassThru; Wait-Process -Id @(`$one.Id, `$two.Id); $rootExitCommand"
-        $rootEncoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($rootScript))
-        $rootFilePath = "powershell.exe"
-        $rootArguments = @("-NoProfile", "-NonInteractive", "-EncodedCommand", $rootEncoded)
-        }
-        $rootWorkingDirectory = if ($externalRoot) { $resolvedRootWorkingDirectory } else { $fixtureRoot }
-        $rootStartInfo = New-SmokeProcessStartInfo -FilePath $rootFilePath -Arguments $rootArguments -WorkingDirectory $rootWorkingDirectory
-        $rootProcess = [System.Diagnostics.Process]::new()
-        $rootProcess.StartInfo = $rootStartInfo
-        if (-not $rootProcess.Start()) { throw "observer root could not start: $rootFilePath" }
-        $rootStdoutTask = $rootProcess.StandardOutput.ReadToEndAsync()
-        $rootStderrTask = $rootProcess.StandardError.ReadToEndAsync()
-        [System.IO.File]::WriteAllText($pidPath, [string]$rootProcess.Id)
-        $waitMilliseconds = [int][Math]::Min([int64]2147483647, [int64]$TimeoutSeconds * 1000)
-        if (-not $rootProcess.WaitForExit($waitMilliseconds)) { throw "observer root timed out" }
-        $rootProcess.Refresh()
-        $rootExitCode = [int64]$rootProcess.ExitCode
-        [System.IO.File]::WriteAllText($rootStdoutCapturePath, $rootStdoutTask.GetAwaiter().GetResult(), [System.Text.UTF8Encoding]::new($false))
-        [System.IO.File]::WriteAllText($rootStderrCapturePath, $rootStderrTask.GetAwaiter().GetResult(), [System.Text.UTF8Encoding]::new($false))
-        $rootOutput.stdout = Get-SmokeRootOutputEvidence -RawPath $rootStdoutCapturePath -RetainedPath $rootStdoutPath -MaximumBytes $RootOutputMaximumBytes
-        $rootOutput.stderr = Get-SmokeRootOutputEvidence -RawPath $rootStderrCapturePath -RetainedPath $rootStderrPath -MaximumBytes $RootOutputMaximumBytes
-        $rootOutput.status = if ($rootOutput.stdout.status -eq "PASS" -and $rootOutput.stderr.status -eq "PASS") { "PASS" } else { "FAIL" }
-        [System.IO.File]::WriteAllText($donePath, "done")
-        $completedJobs = @(Wait-Job -Job @($processJob, $diskJob) -Timeout 25)
-        if ($completedJobs.Count -ne 2) { throw "observers did not complete after root exit" }
-        $processResults = @(Receive-Job -Job $processJob -ErrorAction Stop)
-        $diskResults = @(Receive-Job -Job $diskJob -ErrorAction Stop)
-        if ($processResults.Count -eq 0 -or $diskResults.Count -eq 0) { throw "observers returned no result" }
-        $processObservation = $processResults[$processResults.Count - 1]
-        $diskObservation = $diskResults[$diskResults.Count - 1]
-        if (-not [string]::IsNullOrWhiteSpace($ObserverReleaseCheckoutPath)) {
-            $finalCheckoutEvidence = Assert-SmokeReleaseCheckout -RequestedCheckoutPath $ObserverReleaseCheckoutPath -RequireDistExclude
-            $releaseCheckoutEvidence.statusCleanDuringOutput = [bool]$processObservation.releaseStatusCleanDuringRoot
-            $releaseCheckoutEvidence.statusCleanAfterOutput = [bool]$finalCheckoutEvidence.statusCleanAfterPreparation
-            $releaseCheckoutEvidence.statusChecks = [int]$processObservation.releaseStatusChecks
-        }
-    } catch {
-        $failure = $_.Exception
-        if ($processObservation.error -eq "") { $processObservation.error = $failure.Message }
-        $jobStates = @($processJob, $diskJob) | Where-Object { $null -ne $_ } | ForEach-Object { "$($_.Name)=$($_.State)" }
-        if ($jobStates.Count -ne 0) { $failure = [System.Exception]::new("$($failure.Message); observer jobs: $($jobStates -join ', ')") }
-    } finally {
-        if ($null -ne $rootProcess) {
-            try {
-                if (-not $rootProcess.HasExited) { & taskkill.exe /PID $rootProcess.Id /T /F | Out-Null }
-                if (-not $rootProcess.HasExited) { [void]$cleanupErrors.Add("root process $($rootProcess.Id) remained running") }
-            } catch {
-                [void]$cleanupErrors.Add("root process cleanup: $($_.Exception.Message)")
-            }
-            try { $rootProcess.Dispose() } catch { }
-        }
-        foreach ($job in @($processJob, $diskJob)) {
-            if ($null -ne $job) {
-                try { if ($job.State -eq "Running") { Stop-Job -Job $job -ErrorAction Stop } } catch { [void]$cleanupErrors.Add("observer job stop: $($_.Exception.Message)") }
-                try {
-                    Wait-Job -Job $job -Timeout 5 -ErrorAction Stop | Out-Null
-                    if ($job.State -in @("Running", "NotStarted")) { [void]$cleanupErrors.Add("observer job $($job.Name) remained $($job.State)") }
-                } catch { [void]$cleanupErrors.Add("observer job wait: $($_.Exception.Message)") }
-                try { Remove-Job -Job $job -Force -ErrorAction Stop } catch { [void]$cleanupErrors.Add("observer job removal: $($_.Exception.Message)") }
-            }
-        }
-        try {
-            if (Test-Path -LiteralPath $fixtureRoot) { Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction Stop }
-        } catch { [void]$cleanupErrors.Add("fixture root cleanup: $($_.Exception.Message)") }
-        foreach ($capturePath in @($rootStdoutCapturePath, $rootStderrCapturePath)) {
-            try {
-                if (Test-Path -LiteralPath $capturePath) { Remove-Item -LiteralPath $capturePath -Force -ErrorAction Stop }
-            } catch { [void]$cleanupErrors.Add("root output capture cleanup: $($_.Exception.Message)") }
-        }
-        if (Test-Path -LiteralPath $fixtureRoot) { $remainingTaskPaths += $fixtureRoot }
-    }
-
-    if ($cleanupErrors.Count -ne 0 -and $processObservation.error -eq "") {
-        $processObservation.error = $cleanupErrors -join "; "
-    }
-    $checkoutPass = [string]::IsNullOrWhiteSpace($ObserverReleaseCheckoutPath) -or ($null -ne $releaseCheckoutEvidence -and [bool]$processObservation.releaseStatusCleanBeforeRoot -and [bool]$processObservation.releaseStatusCleanDuringRoot -and [bool]$processObservation.releaseStatusCleanAfterOutput -and [bool]$releaseCheckoutEvidence.statusCleanAfterOutput)
-    $rootOutputPass = $rootOutput.status -eq "PASS" -and $rootOutput.stdout.present -and $rootOutput.stderr.present -and $rootOutput.stdout.capturedBytes -le $RootOutputMaximumBytes -and $rootOutput.stderr.capturedBytes -le $RootOutputMaximumBytes
-    $observerPass = $goEnvironment.GOFLAGS -eq "-p=4" -and $goEnvironment.GOMAXPROCS -eq "4" -and $processObservation.status -eq "PASS" -and $processObservation.sampleCount -gt 0 -and $processObservation.tcpTableQueries -eq $processObservation.sampleCount -and $processObservation.zeroConnectionSamples -gt 0 -and $processObservation.ownedProcessIdentityCount -gt 0 -and $processObservation.queryMode -eq $expectedObserverQueryMode -and $diskObservation.status -eq "PASS" -and [bool]$diskObservation.startPeriodicFinal -and $processObservation.maximumGapMilliseconds -le $expectedProcessNetworkGapMilliseconds -and $diskObservation.maximumGapMilliseconds -le $expectedDiskGapMilliseconds -and $diskObservation.peakDeltaBytes -le $expectedTemporaryDiskBytesMaximum -and $rootOutputPass -and $checkoutPass -and $cleanupErrors.Count -eq 0 -and $remainingTaskPaths.Count -eq 0
-    $report = [ordered]@{
-        schemaVersion = "localai-windows-install-candidate-observer/v1"
-        status = if ($null -eq $failure -and $rootExitCode -eq 0 -and $observerPass) { "PASS" } else { "FAIL" }
-        cycle = $expectedCandidateCycle
-        releaseStatus = if ($externalRoot) { "observed-command" } else { "observer-fixture" }
-        observation = [ordered]@{
-            environment = $goEnvironment
-            processNetworkObserver = [ordered]@{
-                startedBeforeRoot = [bool]$processObservation.startedBeforeRoot
-                continuedThroughDescendantExit = [bool]$processObservation.continuedThroughDescendantExit
-                maximumGapMilliseconds = [int64]$processObservation.maximumGapMilliseconds
-                status = [string]$processObservation.status
-                nonLoopbackConnections = [int]$processObservation.nonLoopbackConnections
-                externalTransferBytes = [int64]$processObservation.externalTransferBytes
-                sampleCount = [int]$processObservation.sampleCount
-                tcpTableQueries = [int]$processObservation.tcpTableQueries
-                zeroConnectionSamples = [int]$processObservation.zeroConnectionSamples
-                ownedConnectionMatches = [int]$processObservation.ownedConnectionMatches
-                ownedProcessIdentityCount = [int]$processObservation.ownedProcessIdentityCount
-                queryMode = [string]$processObservation.queryMode
-                forbiddenProcesses = @($processObservation.forbiddenProcesses)
-                error = [string]$processObservation.error
-                releaseStatusCleanBeforeRoot = [bool]$processObservation.releaseStatusCleanBeforeRoot
-                releaseStatusCleanDuringRoot = [bool]$processObservation.releaseStatusCleanDuringRoot
-                releaseStatusCleanAfterOutput = [bool]$processObservation.releaseStatusCleanAfterOutput
-                releaseStatusChecks = [int]$processObservation.releaseStatusChecks
-            }
-            diskObserver = [ordered]@{
-                independent = [bool]$diskObservation.independent
-                startPeriodicFinal = [bool]$diskObservation.startPeriodicFinal
-                maximumGapMilliseconds = [int64]$diskObservation.maximumGapMilliseconds
-                status = [string]$diskObservation.status
-                peakDeltaBytes = [int64]$diskObservation.peakDeltaBytes
-                error = [string]$diskObservation.error
-            }
-            descendantMaximum = $expectedDescendantMaximum
-            descendantHighWater = [int64]$processObservation.descendantHighWater
-            rootExitCode = $rootExitCode
-            rootOutput = $rootOutput
-            failurePropagation = if ($null -eq $failure -and $rootExitCode -eq 0 -and $observerPass) { "PASS" } else { "FAIL" }
-            modelBackendBytes = [int64]0
-            modelBackendCalls = [int64]0
-        }
-        cleanup = [ordered]@{
-            status = if ($cleanupErrors.Count -eq 0 -and $remainingTaskPaths.Count -eq 0) { "PASS" } else { "FAIL" }
-            remainingTaskPaths = $remainingTaskPaths
-            errors = $cleanupErrors.ToArray()
-        }
-        releaseCheckout = $releaseCheckoutEvidence
-    }
-    $reportParent = Split-Path -Parent $reportPath
-    if (-not (Test-Path -LiteralPath $reportParent -PathType Container)) { Fail-Smoke "observer report parent does not exist: $reportParent" }
-    [System.IO.File]::WriteAllText($reportPath, ($report | ConvertTo-Json -Depth 12))
-    if ($report.status -ne "PASS") { throw "observer fixture failed; report=$reportPath" }
-    Write-Output "observer fixture passed; report=$reportPath"
-}
-
-if ($StageDependencyClosure) {
-    Invoke-SmokeDependencyStage -RequestedSourceRoot $DependencySourceRoot -RequestedStageRoot $DependencyStageRoot -RequestedSourceManifestPath $DependencySourceManifestPath -RequestedStageManifestPath $DependencyStageManifestPath -RequestedReportPath $DependencyReportPath -ExpectedLockSHA256 $DependencyExpectedLockSHA256 -ExpectedLockBlob $DependencyExpectedLockBlob
-    return
-}
-
-if ($VerifyDependencyClosure) {
-    Invoke-SmokeDependencyVerification -RequestedSourceRoot $DependencySourceRoot -RequestedStageRoot $DependencyStageRoot -RequestedExpectedManifestPath $DependencyExpectedManifestPath -RequestedPostBuildManifestPath $DependencyPostBuildManifestPath -RequestedSourceAfterManifestPath $DependencySourceAfterManifestPath -RequestedReportPath $DependencyReportPath -ExpectedLockSHA256 $DependencyExpectedLockSHA256 -ExpectedLockBlob $DependencyExpectedLockBlob
-    return
-}
-
-if ($PrepareReleaseCheckout) {
-    if ([string]::IsNullOrWhiteSpace($ReleaseCheckoutPath)) {
-        Fail-Smoke "release checkout path is required for private exclude preparation"
-    }
-    $releaseCheckoutEvidence = Assert-SmokeReleaseCheckout -RequestedCheckoutPath $ReleaseCheckoutPath -PrepareDistExclude -RequireDistExclude
-    $releaseCheckoutReportPath = if ([string]::IsNullOrWhiteSpace($ReleaseCheckoutReportPath)) {
-        Join-Path (Resolve-SmokeAbsolutePath $InstallDir) "release-checkout-report.json"
-    } else {
-        Resolve-SmokeAbsolutePath $ReleaseCheckoutReportPath
-    }
-    $releaseCheckoutReportParent = Split-Path -Parent $releaseCheckoutReportPath
-    if (-not (Test-Path -LiteralPath $releaseCheckoutReportParent -PathType Container)) {
-        Fail-Smoke "release checkout report parent does not exist: $releaseCheckoutReportParent"
-    }
-    [System.IO.File]::WriteAllText($releaseCheckoutReportPath, ($releaseCheckoutEvidence | ConvertTo-Json -Depth 12))
-    Write-Output "release checkout prepared; report=$releaseCheckoutReportPath"
-    return
-}
-
-if ($ObserverIdentityFixture) {
-    Invoke-ObserverIdentityFixture -RequestedInstallDir $InstallDir -RequestedReportPath $ObserverReportPath
-    return
-}
-
-if ($ObserverFixture) {
-    Invoke-ObserverFixture -RequestedInstallDir $InstallDir -RequestedReportPath $ObserverReportPath -RootCommand $ObserverRootCommand -RootArgumentList $ObserverRootArgumentList -RootWorkingDirectory $ObserverRootWorkingDirectory -RootStdoutPath $ObserverRootStdoutPath -RootStderrPath $ObserverRootStderrPath -RootOutputMaximumBytes $ObserverRootOutputMaximumBytes -RequestedRootExitCode $ObserverRootExitCode -ObserverReleaseCheckoutPath $ObserverReleaseCheckoutPath -TimeoutSeconds $ObserverTimeoutSeconds
-    return
-}
-
-if ([string]::IsNullOrWhiteSpace($CandidateManifestPath)) {
-    Invoke-LegacyHostedSmoke -ScriptUrl $InstallScriptUrl -Version $InstallVersion -RequestedInstallDir $InstallDir -RequestedBinaryName $BinaryName
-    return
-}
-
-$candidateResult = Invoke-CandidateSmoke -RequestedManifestPath $CandidateManifestPath -RequestedInstallDir $InstallDir -RequestedReportPath $ReportPath
-$candidateReportPath = if ([string]::IsNullOrWhiteSpace($ReportPath)) {
-    Join-Path (Split-Path -Parent (Resolve-SmokeAbsolutePath $CandidateManifestPath)) "install-validation-report.json"
-} else {
-    Resolve-SmokeAbsolutePath $ReportPath
-}
-$reportParent = Split-Path -Parent $candidateReportPath
-if (-not (Test-Path -LiteralPath $reportParent -PathType Container)) {
-    Fail-Smoke "report parent does not exist: $reportParent"
-}
-[System.IO.File]::WriteAllText($candidateReportPath, ($candidateResult.report | ConvertTo-Json -Depth 12))
-if ($null -ne $candidateResult.error) {
-    throw $candidateResult.error
-}
-Write-Output "candidate install smoke passed for $InstallDir; report=$candidateReportPath"
+Invoke-HostedInstallSmoke @hostedArguments

--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -13,9 +13,10 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
+$expectedCandidateCycle = "067"
 $expectedCandidateSourceRepository = "https://github.com/portpowered/you-agent-factory"
-$expectedCandidateSourceCommit = "f0092a8bebfb50d70fa2dff7dbb6d720eb28e3bc"
-$expectedCandidateSourceTree = "2c00a0d213fbf878402b66895466053a832a9583"
+$expectedCandidateSourceCommit = "059474b2c00915865306a33ca5e3d02b618bb6f0"
+$expectedCandidateSourceTree = "ae5d9c87fbc99a898ad2c11e1409105d78e4a094"
 
 function Fail-Smoke {
     param([string]$Message)
@@ -280,6 +281,58 @@ function Get-SmokeZipEntryEvidence {
         }
     } finally {
         $archive.Dispose()
+    }
+}
+
+function Get-SmokeExecutableBuildInfo {
+    param(
+        [string]$ExecutablePath,
+        [string]$GoExecutablePath,
+        [string]$WorkingDirectory
+    )
+
+    if ([string]::IsNullOrWhiteSpace($GoExecutablePath)) {
+        Fail-Smoke "candidate mode requires the Go tool to inspect executable build info"
+    }
+    $quotedExecutablePath = '"' + $ExecutablePath.Replace('"', '\"') + '"'
+    $result = Invoke-SmokeCommand -FilePath $GoExecutablePath -Arguments @("version", "-m", $quotedExecutablePath) -WorkingDirectory $WorkingDirectory
+    if ($result.exitCode -ne 0) {
+        Fail-Smoke "go version -m failed for candidate executable with exit code $($result.exitCode): $($result.stderr.Trim())"
+    }
+
+    $settings = @{}
+    foreach ($line in @($result.stdout -split "`r?`n")) {
+        $columns = $line -split "`t", 2
+        if ($columns.Count -ne 2 -or $columns[0] -ne "build") {
+            continue
+        }
+        $setting = $columns[1] -split "=", 2
+        if ($setting.Count -ne 2 -or $setting[0] -notin @("vcs.revision", "vcs.modified")) {
+            continue
+        }
+        $key = [string]$setting[0]
+        if ($settings.ContainsKey($key)) {
+            Fail-Smoke "candidate executable build info contains duplicate '$key' settings"
+        }
+        $settings[$key] = [string]$setting[1].Trim()
+    }
+
+    foreach ($key in @("vcs.revision", "vcs.modified")) {
+        if (-not $settings.ContainsKey($key) -or [string]::IsNullOrWhiteSpace([string]$settings[$key])) {
+            Fail-Smoke "candidate executable build info $key is missing"
+        }
+    }
+    if ([string]$settings["vcs.revision"] -cne $expectedCandidateSourceCommit) {
+        Fail-Smoke "candidate executable build info vcs.revision = $($settings['vcs.revision']), want $expectedCandidateSourceCommit"
+    }
+    if ([string]$settings["vcs.modified"] -cne "false") {
+        Fail-Smoke "candidate executable build info vcs.modified = $($settings['vcs.modified']), want false"
+    }
+
+    return [pscustomobject]@{
+        sourceRevision = [string]$settings["vcs.revision"]
+        vcsModified = $false
+        result = $result
     }
 }
 
@@ -685,6 +738,8 @@ function Invoke-CandidateSmoke {
     $installerEvidence = $null
     $executableEvidence = $null
     $manifestEvidence = $null
+    $goExecutablePath = $null
+    $commandEvidence = @()
     $originalEnvironment = @{}
     $runStartedAt = [DateTime]::UtcNow
     $networkObservations = New-Object 'System.Collections.Generic.List[object]'
@@ -701,6 +756,11 @@ function Invoke-CandidateSmoke {
 
     try {
         Ensure-SmokeFileHashCommand
+        $goCommand = Get-Command go.exe -CommandType Application -ErrorAction SilentlyContinue
+        if ($null -eq $goCommand) {
+            Fail-Smoke "candidate mode requires Go to inspect executable build info"
+        }
+        $goExecutablePath = [System.IO.Path]::GetFullPath($goCommand.Source)
         $manifestPath = Resolve-SmokeAbsolutePath $RequestedManifestPath
         $candidateDirectory = Split-Path -Parent $manifestPath
         $installDirectory = Resolve-SmokeAbsolutePath $RequestedInstallDir
@@ -717,8 +777,8 @@ function Invoke-CandidateSmoke {
         if ($manifest.schemaVersion -ne "localai-windows-install-candidate/v1") {
             Fail-Smoke "candidate schemaVersion is not localai-windows-install-candidate/v1"
         }
-        if ($manifest.project -ne "localai" -or $manifest.cycle -ne "063") {
-            Fail-Smoke "candidate project/cycle does not identify LocalAI cycle 063"
+        if ($manifest.project -ne "localai" -or $manifest.cycle -ne $expectedCandidateCycle) {
+            Fail-Smoke "candidate project/cycle does not identify LocalAI cycle $expectedCandidateCycle"
         }
         if ([string]$manifest.source.repository -cne $expectedCandidateSourceRepository -or [string]$manifest.source.commit -cne $expectedCandidateSourceCommit -or [string]$manifest.source.tree -cne $expectedCandidateSourceTree) {
             Fail-Smoke "candidate source identity = repository=$($manifest.source.repository) commit=$($manifest.source.commit) tree=$($manifest.source.tree), want repository=$expectedCandidateSourceRepository commit=$expectedCandidateSourceCommit tree=$expectedCandidateSourceTree"
@@ -826,10 +886,23 @@ function Invoke-CandidateSmoke {
         if ($executableEvidence.bytes -ne $zipEntryEvidence.bytes -or $executableEvidence.sha256 -ne $zipEntryEvidence.sha256) {
             Fail-Smoke "candidate executable does not match the you.exe member in the declared archive"
         }
+        $buildInfoEvidence = Get-SmokeExecutableBuildInfo -ExecutablePath $executablePath -GoExecutablePath $goExecutablePath -WorkingDirectory $candidateDirectory
+        Record-SmokeCommandObservation -Result $buildInfoEvidence.result -NetworkObservations $networkObservations -ForbiddenProcessObservations $forbiddenProcessObservations
+        Assert-SmokeCommandNetwork -Result $buildInfoEvidence.result -CommandName "go version -m candidate executable"
+        $commandEvidence += [ordered]@{
+            command = "go version -m $executablePath"
+            exitCode = $buildInfoEvidence.result.exitCode
+            stdout = $buildInfoEvidence.result.stdout
+            stderr = $buildInfoEvidence.result.stderr
+            network = $buildInfoEvidence.result.network
+            forbiddenProcesses = $buildInfoEvidence.result.forbiddenProcesses
+        }
         $report.identity = [ordered]@{
             schemaVersion = $manifest.schemaVersion
             sourceCommit = $manifest.source.commit
             sourceTree = $manifest.source.tree
+            embeddedSourceRevision = $buildInfoEvidence.sourceRevision
+            embeddedVCSModified = $buildInfoEvidence.vcsModified
             candidateVersion = $version
             cliVersion = [string]$manifest.build.cliVersion
             target = "$($manifest.build.target.goos)/$($manifest.build.target.goarch)"
@@ -847,6 +920,8 @@ function Invoke-CandidateSmoke {
             cliVersion = [string]$manifest.build.cliVersion
             sourceCommit = [string]$manifest.source.commit
             sourceTree = [string]$manifest.source.tree
+            embeddedSourceRevision = $buildInfoEvidence.sourceRevision
+            embeddedVCSModified = $buildInfoEvidence.vcsModified
             manifest = $manifestEvidence
             archive = $archiveEvidence
             installer = $installerEvidence
@@ -1009,7 +1084,6 @@ function Invoke-CandidateSmoke {
         $report.identity.installedBinary = $installedEvidence
         $report.identity.pathResolvedBinary = $resolvedPath
 
-        $commandEvidence = @()
         $versionResult = Invoke-SmokeCommand -FilePath $resolvedPath -Arguments @("--version") -WorkingDirectory $tempRoot
         Record-SmokeCommandObservation -Result $versionResult -NetworkObservations $networkObservations -ForbiddenProcessObservations $forbiddenProcessObservations
         Assert-SmokeCommandNetwork -Result $versionResult -CommandName "you --version"
@@ -1511,7 +1585,7 @@ function Invoke-ObserverFixture {
     $report = [ordered]@{
         schemaVersion = "localai-windows-install-candidate-observer/v1"
         status = if ($null -eq $failure -and $rootExitCode -eq 0 -and $observerPass) { "PASS" } else { "FAIL" }
-        cycle = "063"
+        cycle = $expectedCandidateCycle
         releaseStatus = "observer-fixture"
         observation = [ordered]@{
             environment = $goEnvironment

--- a/scripts/release/smoke-install.ps1
+++ b/scripts/release/smoke-install.ps1
@@ -775,7 +775,8 @@ function Get-SmokeModelActivity {
 
 function Assert-SmokeNoModelActivity {
     param([object]$Activity)
-    if ($null -eq $Activity -or -not [bool]$Activity.observed) {
+    if ($null -eq $Activity -or -not [bool]$Activity.observed -or
+        -not [bool]$Activity.runtimeEvidenceObserved) {
         Fail-Smoke "model activity observation was unavailable"
     }
     if ([int]$Activity.modelCalls -ne 0 -or

--- a/tests/release/localai_install_candidate_test.go
+++ b/tests/release/localai_install_candidate_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"crypto/sha256"
+	"debug/buildinfo"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -18,6 +19,8 @@ import (
 
 	"github.com/portpowered/infinite-you/internal/testutil"
 )
+
+const localAICandidateSourceCommit = "059474b2c00915865306a33ca5e3d02b618bb6f0"
 
 func TestLocalAICandidateScriptParses(t *testing.T) {
 	t.Parallel()
@@ -102,6 +105,7 @@ if ($result.exitCode -ne 23) { exit 2 }
 	}
 	var result struct {
 		ExitCode       int      `json:"exitCode"`
+		ElapsedMillis  int64    `json:"elapsedMilliseconds"`
 		Arguments      []string `json:"arguments"`
 		Stdout         string   `json:"stdout"`
 		Stderr         string   `json:"stderr"`
@@ -113,7 +117,7 @@ if ($result.exitCode -ne 23) { exit 2 }
 		} `json:"stderrEvidence"`
 	}
 	readJSONFile(t, resultPath, &result)
-	if result.ExitCode != 23 || len(result.Arguments) != len(wantArguments)+4 {
+	if result.ExitCode != 23 || result.ElapsedMillis < 0 || len(result.Arguments) != len(wantArguments)+4 {
 		t.Fatalf("command result = %#v", result)
 	}
 	if !strings.Contains(result.Stdout, "token=<redacted>") || !strings.Contains(result.Stderr, "api_key=<redacted>") {
@@ -294,6 +298,32 @@ try {
 } catch {
     if (-not $_.Exception.Message.Contains('reparse point in its ancestry')) { throw }
 }
+$longRoot = Join-Path %s ('x' * 230)
+$rootCases = @(
+    @{ Name = 'output'; OutputDirectory = $longRoot },
+    @{ Name = 'work'; WorkDirectory = $longRoot },
+    @{ Name = 'install'; InstallDirectory = $longRoot },
+    @{ Name = 'report'; ReportPath = (Join-Path $longRoot 'report.json') }
+)
+foreach ($case in $rootCases) {
+    $arguments = @{
+        SourcePath = %s
+        DependencySourcePath = %s
+        OutputDirectory = %s
+        WorkDirectory = %s
+        InstallDirectory = %s
+        ReportPath = %s
+    }
+    foreach ($key in $case.Keys) {
+        if ($key -ne 'Name') { $arguments[$key] = $case[$key] }
+    }
+    try {
+        Assert-SmokeCandidateRoots @arguments | Out-Null
+        exit 4
+    } catch {
+        if (-not $_.Exception.Message.Contains('at most 220 characters')) { throw }
+    }
+}
 `,
 		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
 		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "unused-install")),
@@ -304,6 +334,13 @@ try {
 		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "install")),
 		localAICandidatePowerShellLiteral(filepath.Join(outputDir, "report.json")),
 		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "source-link")),
+		localAICandidatePowerShellLiteral(sourceDir),
+		localAICandidatePowerShellLiteral(dependencyDir),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "output")),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "work")),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "install")),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "output", "report.json")),
+		localAICandidatePowerShellLiteral(tempDir),
 		localAICandidatePowerShellLiteral(sourceDir),
 		localAICandidatePowerShellLiteral(dependencyDir),
 		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "output")),
@@ -493,6 +530,11 @@ func TestLocalAICandidatePublicInstallUsesPrebuiltArtifact(t *testing.T) {
 	if !filepath.IsAbs(binaryPath) {
 		t.Fatalf("INFINITE_YOU_LOCALAI_PREBUILT_BINARY must be absolute: %s", binaryPath)
 	}
+	assertLocalAICandidateBuildInfo(t, binaryPath)
+	goPath, err := exec.LookPath("go.exe")
+	if err != nil {
+		t.Fatalf("locate Go for build-info inspection: %v", err)
+	}
 	versionOutput, err := exec.Command(binaryPath, "--version").CombinedOutput()
 	if err != nil {
 		t.Fatalf("read prebuilt candidate version: %v\n%s", err, versionOutput)
@@ -534,7 +576,7 @@ func TestLocalAICandidatePublicInstallUsesPrebuiltArtifact(t *testing.T) {
 	harnessPath := filepath.Join(tempDir, "install.ps1")
 	harness := fmt.Sprintf(`
 . %s -InstallDir %s
-$result = Invoke-InstalledCandidateSmoke -CandidateDirectory %s -ArchivePath %s -ChecksumPath %s -InstallerPath %s -ArchiveExecutablePath %s -Version %s -RequestedInstallDir %s -WorkDirectory %s
+$result = Invoke-InstalledCandidateSmoke -CandidateDirectory %s -ArchivePath %s -ChecksumPath %s -InstallerPath %s -ArchiveExecutablePath %s -Version %s -ExpectedSourceCommit %s -GoExecutablePath %s -RequestedInstallDir %s -WorkDirectory %s
 $result | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath %s -Encoding UTF8
 `,
 		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
@@ -545,6 +587,8 @@ $result | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath %s -Encoding UTF8
 		localAICandidatePowerShellLiteral(installerPath),
 		localAICandidatePowerShellLiteral(stagedBinary),
 		localAICandidatePowerShellLiteral(version),
+		localAICandidatePowerShellLiteral(localAICandidateSourceCommit),
+		localAICandidatePowerShellLiteral(goPath),
 		localAICandidatePowerShellLiteral(installDir),
 		localAICandidatePowerShellLiteral(workDir),
 		localAICandidatePowerShellLiteral(resultPath),
@@ -559,10 +603,48 @@ $result | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath %s -Encoding UTF8
 		Status                    string `json:"status"`
 		ModelCalls                int    `json:"modelCalls"`
 		ModelBackendDownloadBytes int64  `json:"modelBackendDownloadBytes"`
+		PathResolution            string `json:"pathResolution"`
+		ExecutableBuildInfo       struct {
+			SourceRevision string `json:"sourceRevision"`
+			VCSModified    bool   `json:"vcsModified"`
+		} `json:"executableBuildInfo"`
+		Commands []struct {
+			Arguments     []string `json:"arguments"`
+			ElapsedMillis int64    `json:"elapsedMilliseconds"`
+		} `json:"commands"`
 	}
 	readJSONFile(t, resultPath, &result)
 	if result.Status != "PASS" || result.ModelCalls != 0 || result.ModelBackendDownloadBytes != 0 {
 		t.Fatalf("public candidate install result = %#v", result)
+	}
+	if result.PathResolution == "" || !strings.EqualFold(filepath.Clean(result.PathResolution), filepath.Clean(filepath.Join(installDir, "you.exe"))) {
+		t.Fatalf("public candidate PATH resolution = %q, want installed executable", result.PathResolution)
+	}
+	if result.ExecutableBuildInfo.SourceRevision != localAICandidateSourceCommit || result.ExecutableBuildInfo.VCSModified {
+		t.Fatalf("public candidate executable build info = %#v", result.ExecutableBuildInfo)
+	}
+	wantCommands := []string{
+		"--version",
+		"--help",
+		"docs models",
+		"models list",
+		"models --help",
+		"--json models inspect llm",
+		"--json models inspect asr",
+		"--json models inspect tts",
+		"--json models inspect embed",
+	}
+	seenCommands := make(map[string]bool, len(result.Commands))
+	for _, command := range result.Commands {
+		if command.ElapsedMillis < 0 {
+			t.Fatalf("candidate command has negative elapsed time: %#v", command)
+		}
+		seenCommands[strings.Join(command.Arguments, " ")] = true
+	}
+	for _, command := range wantCommands {
+		if !seenCommands[command] {
+			t.Fatalf("candidate install did not record command %q: %#v", command, result.Commands)
+		}
 	}
 	if _, err := os.Stat(installDir); !os.IsNotExist(err) {
 		t.Fatalf("install directory remains after smoke: %v", err)
@@ -585,6 +667,24 @@ func localAICandidatePowerShell(t *testing.T) string {
 
 func localAICandidatePowerShellLiteral(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+func assertLocalAICandidateBuildInfo(t *testing.T, binaryPath string) {
+	t.Helper()
+	info, err := buildinfo.ReadFile(binaryPath)
+	if err != nil {
+		t.Fatalf("read candidate executable build info: %v", err)
+	}
+	settings := make(map[string]string, len(info.Settings))
+	for _, setting := range info.Settings {
+		if _, exists := settings[setting.Key]; exists {
+			t.Fatalf("candidate executable build info repeats %q", setting.Key)
+		}
+		settings[setting.Key] = setting.Value
+	}
+	if settings["vcs.revision"] != localAICandidateSourceCommit || settings["vcs.modified"] != "false" {
+		t.Fatalf("candidate executable build info = %#v, want revision %s and vcs.modified=false", settings, localAICandidateSourceCommit)
+	}
 }
 
 func localAICandidateGit(t *testing.T, directory string, arguments ...string) string {

--- a/tests/release/localai_install_candidate_test.go
+++ b/tests/release/localai_install_candidate_test.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"debug/buildinfo"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -19,6 +21,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"unicode/utf16"
 
 	"github.com/portpowered/infinite-you/internal/testutil"
 )
@@ -370,6 +373,17 @@ func localAICandidatePowerShellCommand(t *testing.T, arguments ...string) *exec.
 	command := exec.Command(pwsh, commandArguments...)
 	command.Dir = root
 	return command
+}
+func localAICandidatePowerShellLiteral(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+func utf16LE(value string) []byte {
+	encoded := utf16.Encode([]rune(value))
+	result := make([]byte, len(encoded)*2)
+	for index, character := range encoded {
+		binary.LittleEndian.PutUint16(result[index*2:], character)
+	}
+	return result
 }
 func localAICandidateRunGit(t *testing.T, directory string, arguments ...string) string {
 	t.Helper()
@@ -735,6 +749,131 @@ func TestLocalAICandidateObserverRootFailureRetainsOutput(t *testing.T) {
 		}
 	}
 	t.Logf("LOCALAI-OBSERVER-FAILURE status=PASS evidence=%s", raw)
+}
+func TestLocalAICandidateObserverArgumentVector(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows argument-vector fixture is only available on Windows")
+	}
+	repo := testutil.MustRepoRoot(t)
+	shell, err := exec.LookPath("pwsh.exe")
+	if err != nil {
+		shell, err = exec.LookPath("powershell.exe")
+		if err != nil {
+			t.Fatalf("argument-vector fixture requires PowerShell: %v", err)
+		}
+	}
+	recorderPath := filepath.Join(t.TempDir(), "argv-recorder.ps1")
+	recorder := `$observed = [string[]]$args
+Write-Output (ConvertTo-Json -InputObject $observed -Compress)
+[Console]::Error.WriteLine("argv-recorder stderr")
+$sleepScript = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("Start-Sleep -Milliseconds 1500"))
+$childPath = Join-Path $PSHOME "pwsh.exe"
+if (-not (Test-Path -LiteralPath $childPath)) { $childPath = Join-Path $PSHOME "powershell.exe" }
+$child = Start-Process -FilePath $childPath -WindowStyle Hidden -ArgumentList @("-NoProfile", "-NonInteractive", "-EncodedCommand", $sleepScript) -PassThru
+Wait-Process -Id $child.Id
+exit 0
+`
+	if err := os.WriteFile(recorderPath, []byte(recorder), 0o600); err != nil {
+		t.Fatalf("write argv recorder: %v", err)
+	}
+	spacedArgument := filepath.Join(t.TempDir(), "config path with spaces", ".goreleaser.yml")
+	wantArguments := []string{"release", "--snapshot", "--clean", "-f", spacedArgument}
+	collapsedArguments := "'" + strings.Join([]string{"release", "--snapshot", "--clean", "-f", spacedArgument}, "','") + "'"
+	readArguments := func(t *testing.T, reportPath string) []string {
+		t.Helper()
+		raw, err := os.ReadFile(reportPath)
+		if err != nil {
+			t.Fatalf("read argument observer report: %v", err)
+		}
+		var report localAICandidateObserverReport
+		if err := decodeLocalAICandidateJSON(raw, &report); err != nil {
+			t.Fatalf("decode argument observer report: %v", err)
+		}
+		if report.Status != "PASS" || report.Observation.RootExitCode == nil || *report.Observation.RootExitCode != 0 {
+			t.Fatalf("argument observer report = %#v, want successful observed root", report)
+		}
+		if err := validateLocalAICandidateObserverEvidence(report.Observation); err != nil {
+			t.Fatalf("argument observer evidence: %v", err)
+		}
+		stdout, err := os.ReadFile(report.Observation.RootOutput.Stdout.Path)
+		if err != nil {
+			t.Fatalf("read argument recorder stdout: %v", err)
+		}
+		stderr, err := os.ReadFile(report.Observation.RootOutput.Stderr.Path)
+		if err != nil {
+			t.Fatalf("read argument recorder stderr: %v", err)
+		}
+		if !strings.Contains(string(stderr), "argv-recorder stderr") {
+			t.Fatalf("argument recorder stderr = %q, want retained stderr", stderr)
+		}
+		var observed []string
+		if err := json.Unmarshal([]byte(strings.TrimSpace(string(stdout))), &observed); err != nil {
+			t.Fatalf("decode recorded argv %q: %v", stdout, err)
+		}
+		return observed
+	}
+	newInstallDir := filepath.Join(t.TempDir(), "install-root")
+	if err := os.MkdirAll(newInstallDir, 0o700); err != nil {
+		t.Fatalf("create direct-array install root: %v", err)
+	}
+	newReportPath := filepath.Join(t.TempDir(), "direct-array-report.json")
+	newStdoutPath := filepath.Join(filepath.Dir(newReportPath), "direct-array.stdout.txt")
+	newStderrPath := filepath.Join(filepath.Dir(newReportPath), "direct-array.stderr.txt")
+	argumentLiterals := make([]string, 0, len(wantArguments)+4)
+	for _, argument := range append([]string{"-NoProfile", "-NonInteractive", "-File", recorderPath}, wantArguments...) {
+		argumentLiterals = append(argumentLiterals, localAICandidatePowerShellLiteral(argument))
+	}
+	invocation := fmt.Sprintf(`$parameters = @{
+    InstallDir = %s
+    ObserverFixture = $true
+    ObserverReportPath = %s
+    ObserverRootCommand = %s
+    ObserverRootArgumentList = @(%s)
+    ObserverRootWorkingDirectory = %s
+    ObserverRootStdoutPath = %s
+    ObserverRootStderrPath = %s
+    ObserverRootOutputMaximumBytes = 65536
+    ObserverTimeoutSeconds = 10
+}
+& %s @parameters`, localAICandidatePowerShellLiteral(newInstallDir), localAICandidatePowerShellLiteral(newReportPath), localAICandidatePowerShellLiteral(shell), strings.Join(argumentLiterals, ", "), localAICandidatePowerShellLiteral(repo), localAICandidatePowerShellLiteral(newStdoutPath), localAICandidatePowerShellLiteral(newStderrPath), localAICandidatePowerShellLiteral(filepath.Join(repo, "scripts", "release", "smoke-install.ps1")))
+	command := exec.Command(shell, "-NoProfile", "-NonInteractive", "-EncodedCommand", base64.StdEncoding.EncodeToString(utf16LE(invocation)))
+	command.Dir = repo
+	command.Env = append(os.Environ(), "GOFLAGS="+localAICandidateGOFLAGS, "GOMAXPROCS="+localAICandidateGOMAXPROCS)
+	if output, err := command.CombinedOutput(); err != nil {
+		report, readErr := os.ReadFile(newReportPath)
+		t.Fatalf("direct argument-vector observer: %v\n%s\nreport=%s readError=%v", err, output, report, readErr)
+	}
+	observed := readArguments(t, newReportPath)
+	if !slices.Equal(observed, wantArguments) {
+		t.Fatalf("direct argument-vector recorder = %#v, want %#v", observed, wantArguments)
+	}
+	t.Logf("LOCALAI-ARGV status=PASS requested=%#v observed=%#v", wantArguments, observed)
+
+	collapsedInstallDir := filepath.Join(t.TempDir(), "install-root")
+	if err := os.MkdirAll(collapsedInstallDir, 0o700); err != nil {
+		t.Fatalf("create collapsed-array install root: %v", err)
+	}
+	collapsedReportPath := filepath.Join(t.TempDir(), "collapsed-array-report.json")
+	collapsedStdoutPath := filepath.Join(filepath.Dir(collapsedReportPath), "collapsed-array.stdout.txt")
+	collapsedStderrPath := filepath.Join(filepath.Dir(collapsedReportPath), "collapsed-array.stderr.txt")
+	collapsedCommand := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", "-File", filepath.Join(repo, "scripts", "release", "smoke-install.ps1"), "-InstallDir", collapsedInstallDir, "-ObserverFixture", "-ObserverReportPath", collapsedReportPath, "-ObserverRootCommand", shell, "-ObserverRootWorkingDirectory", repo, "-ObserverRootStdoutPath", collapsedStdoutPath, "-ObserverRootStderrPath", collapsedStderrPath, "-ObserverRootOutputMaximumBytes", "65536", "-ObserverTimeoutSeconds", "10", "-ObserverRootArgumentList", collapsedArguments)
+	collapsedCommand.Dir = repo
+	collapsedCommand.Env = append(os.Environ(), "GOFLAGS="+localAICandidateGOFLAGS, "GOMAXPROCS="+localAICandidateGOMAXPROCS)
+	if output, err := collapsedCommand.CombinedOutput(); err == nil {
+		t.Fatalf("retained collapsed argument-vector observer unexpectedly succeeded: %s", output)
+	}
+	collapsedRaw, err := os.ReadFile(collapsedReportPath)
+	if err != nil {
+		t.Fatalf("read collapsed argument observer report: %v", err)
+	}
+	var collapsedReport localAICandidateObserverReport
+	if err := decodeLocalAICandidateJSON(collapsedRaw, &collapsedReport); err != nil {
+		t.Fatalf("decode collapsed argument observer report: %v", err)
+	}
+	if collapsedReport.Status != "FAIL" || collapsedReport.Observation.RootExitCode == nil || *collapsedReport.Observation.RootExitCode == 0 || collapsedReport.Observation.RootOutput.Status != "PASS" {
+		t.Fatalf("collapsed argument observer report = %#v, want retained failure with root output", collapsedReport)
+	}
+	t.Logf("LOCALAI-ARGV-REGRESSION status=PASS retainedCollapsed=%q rootExit=%d", collapsedArguments, *collapsedReport.Observation.RootExitCode)
 }
 func TestLocalAICandidateObserverIdentityFixture(t *testing.T) {
 	if runtime.GOOS != "windows" {

--- a/tests/release/localai_install_candidate_test.go
+++ b/tests/release/localai_install_candidate_test.go
@@ -245,12 +245,13 @@ type localAICandidateObserverReport struct {
 	ReleaseCheckout *localAICandidateReleaseCheckoutEvidence `json:"releaseCheckout"`
 }
 type localAICandidateNativeToolLaunch struct {
-	Status   string `json:"status"`
-	Path     string `json:"path"`
-	ExitCode *int64 `json:"exitCode"`
-	Stdout   string `json:"stdout"`
-	Stderr   string `json:"stderr"`
-	Error    string `json:"error"`
+	Status     string `json:"status"`
+	Path       string `json:"path"`
+	PathLength int    `json:"pathLength"`
+	ExitCode   *int64 `json:"exitCode"`
+	Stdout     string `json:"stdout"`
+	Stderr     string `json:"stderr"`
+	Error      string `json:"error"`
 }
 type localAICandidateNativeToolFile struct {
 	Path       string                           `json:"path"`
@@ -265,16 +266,22 @@ type localAICandidateNativeToolReport struct {
 	Cycle         string `json:"cycle"`
 	Property      string `json:"property"`
 	ShortRoot     struct {
-		Status     string `json:"status"`
-		Path       string `json:"path"`
-		Parent     string `json:"parent"`
-		PathLength int    `json:"pathLength"`
-		Present    bool   `json:"present"`
-		Empty      bool   `json:"empty"`
+		Status       string `json:"status"`
+		Path         string `json:"path"`
+		Parent       string `json:"parent"`
+		RelativePath string `json:"relativePath"`
+		PathLength   int    `json:"pathLength"`
+		Present      bool   `json:"present"`
+		Empty        bool   `json:"empty"`
 	} `json:"shortRoot"`
+	Limits struct {
+		MaximumShortPathLength      int `json:"maximumShortPathLength"`
+		CharacterizedLongPathLength int `json:"characterizedLongPathLength"`
+	} `json:"limits"`
 	LongPath  localAICandidateNativeToolFile  `json:"longPath"`
 	ShortPath localAICandidateNativeToolFile  `json:"shortPath"`
 	Cleanup   localAICandidateObserverCleanup `json:"cleanup"`
+	Error     string                          `json:"error"`
 }
 
 func localAICandidateManifestPath(t *testing.T, purpose string) string {

--- a/tests/release/localai_install_candidate_test.go
+++ b/tests/release/localai_install_candidate_test.go
@@ -4,2009 +4,422 @@ import (
 	"archive/zip"
 	"bytes"
 	"crypto/sha256"
-	"debug/buildinfo"
-	"encoding/base64"
-	"encoding/binary"
-	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"runtime"
-	"runtime/debug"
-	"slices"
+	"strconv"
 	"strings"
 	"testing"
-	"unicode/utf16"
 
 	"github.com/portpowered/infinite-you/internal/testutil"
 )
 
-const (
-	localAICandidateManifestEnv, localAICandidateSchemaVersion, localAICandidateProject                                                                                                                                                                                                                                                  = "INFINITE_YOU_LOCALAI_CANDIDATE_MANIFEST", "localai-windows-install-candidate/v1", "localai"
-	localAICandidateCycle, localAICandidateGoVersion, localAICandidateGOFLAGS, localAICandidateGOMAXPROCS, localAICandidateObserverQueryMode                                                                                                                                                                                             = "070", "go1.26.8", "-p=4", "4", "one-full-TCP-table-query-per-interval-filtered-to-owned-process-identities"
-	localAICandidateRepository, localAICandidateSourceCommit, localAICandidateSourceTree                                                                                                                                                                                                                                                 = "https://github.com/portpowered/you-agent-factory", "059474b2c00915865306a33ca5e3d02b618bb6f0", "ae5d9c87fbc99a898ad2c11e1409105d78e4a094"
-	localAICandidateGoReleaser, localAICandidateGOOS, localAICandidateGOARCH                                                                                                                                                                                                                                                             = "v2.12.7", "windows", "amd64"
-	localAICandidateTemporaryDiskMaximum, localAICandidateToolDownloadMaximum, localAICandidateModelDownloadMaximum, localAICandidateModelCallsMaximum, localAICandidatePaidUSDMaximum, localAICandidateDescendantMaximum, localAICandidateRerunsMaximum, localAICandidateProcessNetworkGapMaximum, localAICandidateDiskGapMaximum int64 = 4294967296, 0, 0, 0, 0, 36, 1, 2000, 2000
-)
-
-var localAICandidateSHA256Pattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
-
-type localAICandidateManifest struct {
-	SchemaVersion string                     `json:"schemaVersion"`
-	Project       string                     `json:"project"`
-	Cycle         string                     `json:"cycle"`
-	Source        localAICandidateSource     `json:"source"`
-	Build         localAICandidateBuild      `json:"build"`
-	Artifacts     []localAICandidateArtifact `json:"artifacts"`
-	Limits        localAICandidateLimits     `json:"limits"`
-	Attempts      localAICandidateAttempts   `json:"attempts"`
-}
-type localAICandidateSource struct {
-	Repository string `json:"repository"`
-	Commit     string `json:"commit"`
-	Tree       string `json:"tree"`
-}
-type localAICandidateBuild struct {
-	CandidateVersion       string                 `json:"candidateVersion"`
-	CLIVersion             string                 `json:"cliVersion"`
-	GoVersion              string                 `json:"goVersion"`
-	GoReleaserVersion      string                 `json:"goreleaserVersion"`
-	GoReleaserConfigSHA256 string                 `json:"goreleaserConfigSha256"`
-	Target                 localAICandidateTarget `json:"target"`
-	Environment            map[string]string      `json:"environment"`
-}
-type localAICandidateTarget struct {
-	GOOS       string `json:"goos"`
-	GOARCH     string `json:"goarch"`
-	CgoEnabled *bool  `json:"cgoEnabled"`
-}
-type localAICandidateArtifact struct {
-	Role   string `json:"role"`
-	File   string `json:"file"`
-	Bytes  *int64 `json:"bytes"`
-	SHA256 string `json:"sha256"`
-}
-type localAICandidateLimits struct {
-	TemporaryDiskBytesMaximum     *int64 `json:"temporaryDiskBytesMaximum"`
-	OrdinaryToolDownloadMaximum   *int64 `json:"ordinaryToolDownloadBytesMaximum"`
-	ModelBackendDownloadMaximum   *int64 `json:"modelBackendDownloadBytesMaximum"`
-	ModelCallsMaximum             *int64 `json:"modelCallsMaximum"`
-	PaidUSDMaximum                *int64 `json:"paidUSDMaximum"`
-	DescendantMaximum             *int64 `json:"descendantMaximum"`
-	PackagingOrSmokeRerunsMaximum *int64 `json:"packagingOrSmokeRerunsMaximum"`
-	GOFLAGS                       string `json:"goflags"`
-	GOMAXPROCS                    string `json:"gomaxprocs"`
-}
-type localAICandidateAttempts struct {
-	PriorCycles          []string `json:"priorCycles"`
-	Cycle063BuildMaximum *int64   `json:"cycle063BuildMaximum"`
-	Cycle063BuildUsed    *int64   `json:"cycle063BuildUsed"`
-	Cycle067BuildMaximum *int64   `json:"cycle067BuildMaximum"`
-	Cycle067BuildUsed    *int64   `json:"cycle067BuildUsed"`
-	Cycle068BuildMaximum *int64   `json:"cycle068BuildMaximum"`
-	Cycle068BuildUsed    *int64   `json:"cycle068BuildUsed"`
-	Cycle070BuildMaximum *int64   `json:"cycle070BuildMaximum"`
-	Cycle070BuildUsed    *int64   `json:"cycle070BuildUsed"`
-}
-type localAICandidateArtifactEvidence struct {
-	Role   string `json:"role"`
-	File   string `json:"file"`
-	Bytes  int64  `json:"bytes"`
-	SHA256 string `json:"sha256"`
-}
-type localAICandidateValidationEvidence struct {
-	Status                 string                           `json:"status"`
-	Property               string                           `json:"property"`
-	SchemaVersion          string                           `json:"schemaVersion"`
-	SourceCommit           string                           `json:"sourceCommit"`
-	SourceTree             string                           `json:"sourceTree"`
-	EmbeddedSourceRevision string                           `json:"embeddedSourceRevision"`
-	EmbeddedVCSModified    bool                             `json:"embeddedVCSModified"`
-	CandidateVersion       string                           `json:"candidateVersion"`
-	CLIVersion             string                           `json:"cliVersion"`
-	Target                 string                           `json:"target"`
-	Archive                localAICandidateArtifactEvidence `json:"archive"`
-	Installer              localAICandidateArtifactEvidence `json:"installer"`
-	Manifest               localAICandidateArtifactEvidence `json:"manifest"`
-	Preconditions          string                           `json:"preconditions"`
-}
-type localAICandidateRoot struct {
-	Name string
-	Path string
-}
-type localAICandidateProcessNetworkObserver struct {
-	StartedBeforeRoot              bool     `json:"startedBeforeRoot"`
-	ContinuedThroughDescendantExit bool     `json:"continuedThroughDescendantExit"`
-	MaximumGapMilliseconds         int64    `json:"maximumGapMilliseconds"`
-	Status                         string   `json:"status"`
-	NonLoopbackConnections         int      `json:"nonLoopbackConnections"`
-	ExternalTransferBytes          int64    `json:"externalTransferBytes"`
-	SampleCount                    int      `json:"sampleCount"`
-	TCPTableQueries                int      `json:"tcpTableQueries"`
-	ZeroConnectionSamples          int      `json:"zeroConnectionSamples"`
-	OwnedConnectionMatches         int      `json:"ownedConnectionMatches"`
-	OwnedProcessIdentityCount      int      `json:"ownedProcessIdentityCount"`
-	QueryMode                      string   `json:"queryMode"`
-	ForbiddenProcesses             []string `json:"forbiddenProcesses"`
-	Error                          string   `json:"error"`
-	ReleaseStatusCleanBeforeRoot   bool     `json:"releaseStatusCleanBeforeRoot"`
-	ReleaseStatusCleanDuringRoot   bool     `json:"releaseStatusCleanDuringRoot"`
-	ReleaseStatusCleanAfterOutput  bool     `json:"releaseStatusCleanAfterOutput"`
-	ReleaseStatusChecks            int      `json:"releaseStatusChecks"`
-}
-type localAICandidateDiskObserver struct {
-	Independent            bool   `json:"independent"`
-	StartPeriodicFinal     bool   `json:"startPeriodicFinal"`
-	MaximumGapMilliseconds int64  `json:"maximumGapMilliseconds"`
-	Status                 string `json:"status"`
-	PeakDeltaBytes         int64  `json:"peakDeltaBytes"`
-	Error                  string `json:"error"`
-}
-type localAICandidateRootOutputStream struct {
-	Status        string `json:"status"`
-	Path          string `json:"path"`
-	Present       bool   `json:"present"`
-	TotalBytes    int64  `json:"totalBytes"`
-	CapturedBytes int64  `json:"capturedBytes"`
-	Truncated     bool   `json:"truncated"`
-	RedactedBytes int64  `json:"redactedBytes"`
-	SHA256        string `json:"sha256"`
-}
-type localAICandidateRootOutput struct {
-	Status       string                           `json:"status"`
-	MaximumBytes int64                            `json:"maximumBytes"`
-	Stdout       localAICandidateRootOutputStream `json:"stdout"`
-	Stderr       localAICandidateRootOutputStream `json:"stderr"`
-}
-type localAICandidateObserverEvidence struct {
-	Environment            map[string]string                      `json:"environment"`
-	ProcessNetworkObserver localAICandidateProcessNetworkObserver `json:"processNetworkObserver"`
-	DiskObserver           localAICandidateDiskObserver           `json:"diskObserver"`
-	DescendantMaximum      int64                                  `json:"descendantMaximum"`
-	DescendantHighWater    int64                                  `json:"descendantHighWater"`
-	RootExitCode           *int64                                 `json:"rootExitCode"`
-	RootOutput             localAICandidateRootOutput             `json:"rootOutput"`
-	FailurePropagation     string                                 `json:"failurePropagation"`
-	ModelBackendBytes      int64                                  `json:"modelBackendBytes"`
-	ModelBackendCalls      int64                                  `json:"modelBackendCalls"`
-}
-type localAICandidateObserverCleanup struct {
-	Status             string   `json:"status"`
-	RemainingTaskPaths []string `json:"remainingTaskPaths"`
-	Errors             []string `json:"errors"`
-}
-type localAICandidateReleaseCheckoutEvidence struct {
-	Status                      string   `json:"status"`
-	GitDirIsDirectory           bool     `json:"gitDirIsDirectory"`
-	CheckoutPath                string   `json:"checkoutPath"`
-	DetachedHead                bool     `json:"detachedHead"`
-	Head                        string   `json:"head"`
-	Tree                        string   `json:"tree"`
-	Origin                      string   `json:"origin"`
-	PrivateExcludePath          string   `json:"privateExcludePath"`
-	PrivateExcludeBefore        []string `json:"privateExcludeBefore"`
-	PrivateExcludeAfter         []string `json:"privateExcludeAfter"`
-	PrivateExcludeAdded         []string `json:"privateExcludeAdded"`
-	StatusCleanBefore           bool     `json:"statusCleanBefore"`
-	StatusCleanAfterPreparation bool     `json:"statusCleanAfterPreparation"`
-	StatusCleanDuringOutput     bool     `json:"statusCleanDuringOutput"`
-	StatusCleanAfterOutput      bool     `json:"statusCleanAfterOutput"`
-	StatusChecks                int      `json:"statusChecks"`
-}
-type localAICandidateDependencyManifestEvidence struct {
-	Status            string `json:"status"`
-	ManifestPath      string `json:"manifestPath"`
-	ManifestSHA256    string `json:"manifestSHA256"`
-	EntryCount        int64  `json:"entryCount"`
-	FileCount         int64  `json:"fileCount"`
-	DirectoryCount    int64  `json:"directoryCount"`
-	JunctionCount     int64  `json:"junctionCount"`
-	SymbolicLinkCount int64  `json:"symbolicLinkCount"`
-	TotalBytes        int64  `json:"totalBytes"`
-}
-type localAICandidateDependencyReport struct {
-	SchemaVersion  string                                     `json:"schemaVersion"`
-	Status         string                                     `json:"status"`
-	Phase          string                                     `json:"phase"`
-	SourceRoot     string                                     `json:"sourceRoot"`
-	StageRoot      string                                     `json:"stageRoot"`
-	PackageInstall string                                     `json:"packageInstallation"`
-	SourceManifest localAICandidateDependencyManifestEvidence `json:"sourceManifest"`
-	StageManifest  localAICandidateDependencyManifestEvidence `json:"stageManifest"`
-	SourceLock     any                                        `json:"sourceLockClosure"`
-	StageLock      any                                        `json:"stageLockClosure"`
-	Copy           any                                        `json:"copy"`
-	Equality       struct {
-		SourceStageManifestEqual  bool  `json:"sourceStageManifestEqual"`
-		SourceStagePostBuildEqual bool  `json:"sourceStagePostBuildEqual"`
-		SourceEntryCount          int64 `json:"sourceEntryCount"`
-		StageEntryCount           int64 `json:"stageEntryCount"`
-		SourceTotalBytes          int64 `json:"sourceTotalBytes"`
-		StageTotalBytes           int64 `json:"stageTotalBytes"`
-	} `json:"equality"`
-	Error string `json:"error"`
-}
-type localAICandidateObserverReport struct {
-	SchemaVersion   string                                   `json:"schemaVersion"`
-	Status          string                                   `json:"status"`
-	Cycle           string                                   `json:"cycle"`
-	ReleaseStatus   string                                   `json:"releaseStatus"`
-	Observation     localAICandidateObserverEvidence         `json:"observation"`
-	Cleanup         localAICandidateObserverCleanup          `json:"cleanup"`
-	ReleaseCheckout *localAICandidateReleaseCheckoutEvidence `json:"releaseCheckout"`
-}
-
-func localAICandidateManifestPath(t *testing.T, purpose string) string {
-	t.Helper()
+func TestLocalAICandidateScriptParses(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS != "windows" {
-		t.Skip("Windows " + purpose + " is only available on Windows")
+		t.Skip("PowerShell candidate delivery is Windows-only")
 	}
-	manifestPath := strings.TrimSpace(os.Getenv(localAICandidateManifestEnv))
-	if manifestPath == "" {
-		t.Skip("set " + localAICandidateManifestEnv + " to run the " + purpose)
+
+	scriptPath := localAICandidateScriptPath(t)
+	command := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-Command", fmt.Sprintf(`
+$errors = $null
+$tokens = $null
+[System.Management.Automation.Language.Parser]::ParseFile(%s, [ref]$tokens, [ref]$errors) | Out-Null
+if ($errors.Count -ne 0) { $errors | ForEach-Object { [Console]::Error.WriteLine($_.Message) }; exit 1 }
+`, localAICandidatePowerShellLiteral(scriptPath)))
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("parse candidate delivery script: %v\n%s", err, output)
 	}
-	if !filepath.IsAbs(manifestPath) {
-		t.Fatalf("candidate manifest path %q is not absolute; %s must name an absolute path", manifestPath, localAICandidateManifestEnv)
-	}
-	return manifestPath
 }
-func TestLocalAICandidate_ValidatesOptInPrebuiltWindowsCandidate(t *testing.T) {
-	manifestPath := localAICandidateManifestPath(t, "candidate release cell")
-	evidence, err := validateLocalAICandidate(manifestPath)
-	if err != nil {
-		t.Logf("LOCALAI-CANDIDATE status=FAIL property=prebuilt-candidate-schema-source-target-artifact-and-detached-digest-identity reason=%q", err)
-		t.Fatalf("validate prebuilt Windows candidate: %v", err)
+
+func TestLocalAICandidateCommandPreservesArgumentsFailureAndRedaction(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell candidate delivery is Windows-only")
 	}
-	encoded, err := json.Marshal(evidence)
-	if err != nil {
-		t.Fatalf("marshal candidate evidence: %v", err)
+
+	tempDir := filepath.Join(t.TempDir(), "path with spaces")
+	if err := os.MkdirAll(tempDir, 0o700); err != nil {
+		t.Fatalf("create fixture directory: %v", err)
 	}
-	t.Logf("LOCALAI-CANDIDATE status=PASS property=%s evidence=%s", evidence.Property, encoded)
-}
-func TestLocalAICandidate_PublicInstallDiscoveryAndCleanup(t *testing.T) {
-	manifestPath := localAICandidateManifestPath(t, "candidate release smoke")
-	if _, err := validateLocalAICandidate(manifestPath); err != nil {
-		t.Fatalf("validate candidate before public install smoke: %v", err)
+	recordPath := filepath.Join(tempDir, "arguments.json")
+	recorderPath := filepath.Join(tempDir, "record arguments.ps1")
+	recorder := `param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Values)
+[System.IO.File]::WriteAllText($env:LOCALAI_ARGUMENT_RECORD, ($Values | ConvertTo-Json -Compress))
+[Console]::Out.WriteLine("token=fixture-secret")
+[Console]::Out.Write("stdout retained")
+[Console]::Error.WriteLine("api_key=fixture-secret")
+[Console]::Error.Write("stderr retained")
+exit 23
+`
+	if err := os.WriteFile(recorderPath, []byte(recorder), 0o600); err != nil {
+		t.Fatalf("write argument recorder: %v", err)
 	}
-	installDir := filepath.Join(t.TempDir(), "installed-bin")
-	reportPath := filepath.Join(t.TempDir(), "install-validation-report.json")
-	output, err := localAICandidateSmokeCommand(t, manifestPath, installDir, reportPath).CombinedOutput()
-	if err != nil {
-		t.Fatalf("public Windows candidate install smoke: %v\n%s", err, output)
+
+	stdoutPath := filepath.Join(tempDir, "stdout.log")
+	stderrPath := filepath.Join(tempDir, "stderr.log")
+	resultPath := filepath.Join(tempDir, "result.json")
+	installDir := filepath.Join(tempDir, "unused install")
+	wantArguments := []string{"release", "--snapshot", "--clean", "-f", ".goreleaser.yml", filepath.Join(tempDir, "value with spaces")}
+	argumentLiterals := make([]string, 0, len(wantArguments)+5)
+	for _, value := range append([]string{"-NoProfile", "-NonInteractive", "-File", recorderPath}, wantArguments...) {
+		argumentLiterals = append(argumentLiterals, localAICandidatePowerShellLiteral(value))
 	}
-	reportBytes, err := os.ReadFile(reportPath)
-	if err != nil {
-		t.Fatalf("read candidate install smoke report: %v\n%s", err, output)
+	harnessPath := filepath.Join(tempDir, "invoke.ps1")
+	harness := fmt.Sprintf(`
+. %s -InstallDir %s
+$result = Invoke-CandidateCommand -FilePath %s -ArgumentList @(%s) -WorkingDirectory %s -StdoutPath %s -StderrPath %s
+$result | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath %s -Encoding UTF8
+if ($result.exitCode -ne 23) { exit 2 }
+`,
+		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
+		localAICandidatePowerShellLiteral(installDir),
+		localAICandidatePowerShellLiteral(localAICandidatePowerShell(t)),
+		strings.Join(argumentLiterals, ", "),
+		localAICandidatePowerShellLiteral(tempDir),
+		localAICandidatePowerShellLiteral(stdoutPath),
+		localAICandidatePowerShellLiteral(stderrPath),
+		localAICandidatePowerShellLiteral(resultPath),
+	)
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
+		t.Fatalf("write command harness: %v", err)
 	}
-	var report map[string]any
-	if err := json.Unmarshal(reportBytes, &report); err != nil {
-		t.Fatalf("decode candidate install smoke report: %v\n%s", err, reportBytes)
+	command := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath)
+	command.Env = append(os.Environ(), "LOCALAI_ARGUMENT_RECORD="+recordPath)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("run candidate command helper: %v\n%s", err, output)
 	}
-	run, _ := report["run"].(map[string]any)
-	cleanup, _ := report["cleanup"].(map[string]any)
-	postCleanup, _ := report["postCleanup"].(map[string]any)
-	installer, _ := report["installer"].(map[string]any)
-	requests, _ := installer["requests"].([]any)
-	if report["status"] != "PASS" || report["property"] != "public-install-identity-discovery-zero-model-backend-activity-cleanup" ||
-		run["status"] != "PASS" || cleanup["status"] != "PASS" || len(requests) != 3 ||
-		postCleanup["candidateHashesStable"] != true {
-		t.Fatalf("candidate install smoke report = %#v, want PASS with complete run/install/cleanup evidence", report)
+
+	var gotArguments []string
+	readJSONFile(t, recordPath, &gotArguments)
+	if strings.Join(gotArguments, "\x00") != strings.Join(wantArguments, "\x00") {
+		t.Fatalf("recorded arguments = %#v, want %#v", gotArguments, wantArguments)
 	}
-	reportBytes = regexp.MustCompile(`\s+`).ReplaceAll(reportBytes, nil)
-	for _, want := range []string{
-		`"powershell"`, `"commandMilliseconds"`, `"loopbackServerReadyMilliseconds"`,
-		`"loopbackCompletionMilliseconds"`, `"networkObserverSampleMilliseconds"`, `"observer"`,
-		`"networkSamples"`, `"unexpectedConnections": 0`, `"port7437Connections": 0`,
-		`"modelBackendDownloadBytes": 0`, `"modelCalls": 0`, `"backendRequestsObserved": 0`,
-		`"remainingTaskPaths": []`,
-	} {
-		if !bytes.Contains(reportBytes, []byte(strings.ReplaceAll(want, " ", ""))) {
-			t.Fatalf("candidate install report missing %q: %s", want, reportBytes)
+	var result struct {
+		ExitCode       int      `json:"exitCode"`
+		Arguments      []string `json:"arguments"`
+		Stdout         string   `json:"stdout"`
+		Stderr         string   `json:"stderr"`
+		StdoutEvidence struct {
+			SHA256 string `json:"sha256"`
+		} `json:"stdoutEvidence"`
+		StderrEvidence struct {
+			SHA256 string `json:"sha256"`
+		} `json:"stderrEvidence"`
+	}
+	readJSONFile(t, resultPath, &result)
+	if result.ExitCode != 23 || len(result.Arguments) != len(wantArguments)+4 {
+		t.Fatalf("command result = %#v", result)
+	}
+	if !strings.Contains(result.Stdout, "token=<redacted>") || !strings.Contains(result.Stderr, "api_key=<redacted>") {
+		t.Fatalf("redacted output = stdout %q stderr %q", result.Stdout, result.Stderr)
+	}
+	for _, path := range []string{stdoutPath, stderrPath} {
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read retained output %s: %v", path, err)
+		}
+		if strings.Contains(string(contents), "fixture-secret") || !strings.Contains(string(contents), "<redacted>") {
+			t.Fatalf("retained output %s was not redacted: %q", path, contents)
 		}
 	}
+	if len(result.StdoutEvidence.SHA256) != 64 || len(result.StderrEvidence.SHA256) != 64 {
+		t.Fatalf("retained output hashes are missing: %#v", result)
+	}
+}
+
+func TestLocalAICandidateSourceIdentityComesFromRuntimeInput(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell candidate delivery is Windows-only")
+	}
+
+	repoRoot := testutil.MustRepoRoot(t)
+	commit := localAICandidateGit(t, repoRoot, "rev-parse", "HEAD")
+	tree := localAICandidateGit(t, repoRoot, "rev-parse", "HEAD^{tree}")
+	repository := localAICandidateGit(t, repoRoot, "remote", "get-url", "origin")
+	tempDir := t.TempDir()
+	resultPath := filepath.Join(tempDir, "identity.json")
+	harnessPath := filepath.Join(tempDir, "identity.ps1")
+	harness := fmt.Sprintf(`
+. %s -InstallDir %s
+Get-CandidateSourceIdentity -SourcePath %s -Commit %s -Repository %s | ConvertTo-Json -Compress | Set-Content -LiteralPath %s -Encoding UTF8
+`,
+		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "unused-install")),
+		localAICandidatePowerShellLiteral(repoRoot),
+		localAICandidatePowerShellLiteral(commit),
+		localAICandidatePowerShellLiteral(repository),
+		localAICandidatePowerShellLiteral(resultPath),
+	)
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
+		t.Fatalf("write source identity harness: %v", err)
+	}
+	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
+		t.Fatalf("resolve candidate source identity: %v\n%s", err, output)
+	}
+	var identity struct {
+		Repository string `json:"repository"`
+		Commit     string `json:"commit"`
+		Tree       string `json:"tree"`
+	}
+	readJSONFile(t, resultPath, &identity)
+	if identity.Repository != repository || identity.Commit != commit || identity.Tree != tree {
+		t.Fatalf("source identity = %#v, want repository %s commit %s tree %s", identity, repository, commit, tree)
+	}
+
+	badHarness := fmt.Sprintf(`
+. %s -InstallDir %s
+Get-CandidateSourceIdentity -SourcePath %s -Commit %s -Repository 'https://example.invalid/different'
+`,
+		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "unused-install")),
+		localAICandidatePowerShellLiteral(repoRoot),
+		localAICandidatePowerShellLiteral(commit),
+	)
+	badHarnessPath := filepath.Join(tempDir, "bad-identity.ps1")
+	if err := os.WriteFile(badHarnessPath, []byte(badHarness), 0o600); err != nil {
+		t.Fatalf("write rejected source identity harness: %v", err)
+	}
+	output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", badHarnessPath).CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "candidate source origin") {
+		t.Fatalf("mismatched repository result = %v\n%s", err, output)
+	}
+}
+
+func TestLocalAICandidateWorkAccountingSkipsLinkedDependencyTree(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell candidate delivery is Windows-only")
+	}
+
+	tempDir := t.TempDir()
+	workDir := filepath.Join(tempDir, "work")
+	dependencyDir := filepath.Join(tempDir, "dependencies")
+	if err := os.MkdirAll(workDir, 0o700); err != nil {
+		t.Fatalf("create work directory: %v", err)
+	}
+	if err := os.MkdirAll(dependencyDir, 0o700); err != nil {
+		t.Fatalf("create dependency directory: %v", err)
+	}
+	localBytes := []byte("tracked")
+	if err := os.WriteFile(filepath.Join(workDir, "local.txt"), localBytes, 0o600); err != nil {
+		t.Fatalf("write local work file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dependencyDir, "large-cache.bin"), make([]byte, 1<<20), 0o600); err != nil {
+		t.Fatalf("write linked dependency fixture: %v", err)
+	}
+
+	resultPath := filepath.Join(tempDir, "bytes.txt")
+	harnessPath := filepath.Join(tempDir, "measure.ps1")
+	harness := fmt.Sprintf(`
+. %s -InstallDir %s
+New-Item -ItemType Junction -Path %s -Target %s | Out-Null
+Get-SmokeDirectoryBytes %s | Set-Content -LiteralPath %s -Encoding ASCII
+`,
+		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "unused-install")),
+		localAICandidatePowerShellLiteral(filepath.Join(workDir, "node_modules")),
+		localAICandidatePowerShellLiteral(dependencyDir),
+		localAICandidatePowerShellLiteral(workDir),
+		localAICandidatePowerShellLiteral(resultPath),
+	)
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
+		t.Fatalf("write work accounting harness: %v", err)
+	}
+	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
+		t.Fatalf("measure candidate work directory: %v\n%s", err, output)
+	}
+	contents, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatalf("read measured work bytes: %v", err)
+	}
+	got, err := strconv.ParseInt(strings.TrimSpace(string(contents)), 10, 64)
+	if err != nil {
+		t.Fatalf("parse measured work bytes: %v", err)
+	}
+	if got != int64(len(localBytes)) {
+		t.Fatalf("measured work bytes = %d, want only local bytes %d", got, len(localBytes))
+	}
+}
+
+func TestLocalAICandidatePublicInstallUsesPrebuiltArtifact(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell candidate delivery is Windows-only")
+	}
+	binaryPath := strings.TrimSpace(os.Getenv("INFINITE_YOU_LOCALAI_PREBUILT_BINARY"))
+	if binaryPath == "" {
+		t.Skip("set INFINITE_YOU_LOCALAI_PREBUILT_BINARY to an already compiled you.exe")
+	}
+	if !filepath.IsAbs(binaryPath) {
+		t.Fatalf("INFINITE_YOU_LOCALAI_PREBUILT_BINARY must be absolute: %s", binaryPath)
+	}
+	versionOutput, err := exec.Command(binaryPath, "--version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("read prebuilt candidate version: %v\n%s", err, versionOutput)
+	}
+	version := strings.TrimSpace(string(versionOutput))
+	if version == "" {
+		t.Fatal("prebuilt candidate returned an empty version")
+	}
+
+	tempDir := t.TempDir()
+	candidateDir := filepath.Join(tempDir, "candidate")
+	stageDir := filepath.Join(tempDir, "stage")
+	workDir := filepath.Join(tempDir, "work")
+	installDir := filepath.Join(tempDir, "install")
+	for _, directory := range []string{candidateDir, stageDir} {
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			t.Fatalf("create fixture directory: %v", err)
+		}
+	}
+	stagedBinary := filepath.Join(stageDir, "you.exe")
+	copyLocalAICandidateFile(t, binaryPath, stagedBinary)
+	archiveName := "you_" + version + "_windows_amd64.zip"
+	archivePath := filepath.Join(candidateDir, archiveName)
+	writeLocalAICandidateZip(t, archivePath, stagedBinary)
+	archiveBytes, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read candidate archive: %v", err)
+	}
+	archiveDigest := sha256.Sum256(archiveBytes)
+	checksumPath := filepath.Join(candidateDir, "you_"+version+"_checksums.txt")
+	checksum := fmt.Sprintf("%x  %s\n", archiveDigest, archiveName)
+	if err := os.WriteFile(checksumPath, []byte(checksum), 0o600); err != nil {
+		t.Fatalf("write candidate checksums: %v", err)
+	}
+	installerPath := filepath.Join(candidateDir, "install.ps1")
+	copyLocalAICandidateFile(t, filepath.Join(testutil.MustRepoRoot(t), "scripts", "install.ps1"), installerPath)
+
+	resultPath := filepath.Join(tempDir, "install-result.json")
+	harnessPath := filepath.Join(tempDir, "install.ps1")
+	harness := fmt.Sprintf(`
+. %s -InstallDir %s
+$result = Invoke-InstalledCandidateSmoke -CandidateDirectory %s -ArchivePath %s -ChecksumPath %s -InstallerPath %s -ArchiveExecutablePath %s -Version %s -RequestedInstallDir %s -WorkDirectory %s
+$result | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath %s -Encoding UTF8
+`,
+		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
+		localAICandidatePowerShellLiteral(installDir),
+		localAICandidatePowerShellLiteral(candidateDir),
+		localAICandidatePowerShellLiteral(archivePath),
+		localAICandidatePowerShellLiteral(checksumPath),
+		localAICandidatePowerShellLiteral(installerPath),
+		localAICandidatePowerShellLiteral(stagedBinary),
+		localAICandidatePowerShellLiteral(version),
+		localAICandidatePowerShellLiteral(installDir),
+		localAICandidatePowerShellLiteral(workDir),
+		localAICandidatePowerShellLiteral(resultPath),
+	)
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
+		t.Fatalf("write install harness: %v", err)
+	}
+	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
+		t.Fatalf("run public candidate install smoke: %v\n%s", err, output)
+	}
+	var result struct {
+		Status                    string `json:"status"`
+		ModelCalls                int    `json:"modelCalls"`
+		ModelBackendDownloadBytes int64  `json:"modelBackendDownloadBytes"`
+	}
+	readJSONFile(t, resultPath, &result)
+	if result.Status != "PASS" || result.ModelCalls != 0 || result.ModelBackendDownloadBytes != 0 {
+		t.Fatalf("public candidate install result = %#v", result)
+	}
 	if _, err := os.Stat(installDir); !os.IsNotExist(err) {
-		t.Fatalf("install directory stat error = %v, want task-owned install directory removed", err)
+		t.Fatalf("install directory remains after smoke: %v", err)
 	}
 }
-func TestLocalAICandidate_PublicInstallPreconditionsRemainFailClosed(t *testing.T) {
-	manifestPath := localAICandidateManifestPath(t, "candidate release smoke")
-	installDir := filepath.Join(t.TempDir(), "installed-bin")
-	if err := os.MkdirAll(installDir, 0o700); err != nil {
-		t.Fatalf("create nonempty install directory: %v", err)
-	}
-	markerPath := filepath.Join(installDir, "ambient-marker.txt")
-	if err := os.WriteFile(markerPath, []byte("must remain untouched"), 0o600); err != nil {
-		t.Fatalf("write install precondition marker: %v", err)
-	}
-	reportPath := filepath.Join(t.TempDir(), "install-validation-report.json")
-	output, err := localAICandidateSmokeCommand(t, manifestPath, installDir, reportPath).CombinedOutput()
-	if err == nil {
-		t.Fatalf("nonempty install precondition unexpectedly passed\n%s", output)
-	}
-	if !strings.Contains(string(output), "declared root 'install' is not empty") {
-		t.Fatalf("precondition output = %q, want fail-closed install-root evidence", output)
-	}
-	if _, statErr := os.Stat(markerPath); statErr != nil {
-		t.Fatalf("precondition marker stat error = %v, want marker preserved", statErr)
-	}
-	if _, statErr := os.Stat(filepath.Join(installDir, "you.exe")); !os.IsNotExist(statErr) {
-		t.Fatalf("installed binary stat error = %v, want no installation after precondition failure", statErr)
-	}
-	reportBytes, err := os.ReadFile(reportPath)
-	if err != nil {
-		t.Fatalf("read failed candidate install smoke report: %v", err)
-	}
-	var report map[string]any
-	if err := json.Unmarshal(reportBytes, &report); err != nil {
-		t.Fatalf("decode failed candidate install smoke report: %v", err)
-	}
-	cleanup, _ := report["cleanup"].(map[string]any)
-	remaining, _ := cleanup["remainingTaskPaths"].([]any)
-	if report["status"] != "FAIL" || cleanup["status"] != "PASS" || len(remaining) != 0 {
-		t.Fatalf("failed candidate install smoke report = %#v, want failed operation with clean task roots", report)
-	}
-}
-func localAICandidateSmokeCommand(t *testing.T, manifestPath, installDir, reportPath string) *exec.Cmd {
+
+func localAICandidateScriptPath(t *testing.T) string {
 	t.Helper()
-	pwsh, err := exec.LookPath("powershell.exe")
-	if err != nil {
-		t.Fatalf("candidate release smoke requires Windows PowerShell (powershell.exe): %v", err)
-	}
-	root := testutil.MustRepoRoot(t)
-	command := exec.Command(pwsh, "-NoProfile", "-File", filepath.Join(root, "scripts", "release", "smoke-install.ps1"), "-CandidateManifestPath", manifestPath, "-InstallDir", installDir, "-ReportPath", reportPath)
-	command.Dir = root
-	return command
+	return filepath.Join(testutil.MustRepoRoot(t), "scripts", "release", "smoke-install.ps1")
 }
-func localAICandidatePowerShellCommand(t *testing.T, arguments ...string) *exec.Cmd {
+
+func localAICandidatePowerShell(t *testing.T) string {
 	t.Helper()
-	pwsh, err := exec.LookPath("powershell.exe")
+	path, err := exec.LookPath("powershell.exe")
 	if err != nil {
-		t.Fatalf("candidate release smoke requires Windows PowerShell (powershell.exe): %v", err)
+		t.Skip("Windows PowerShell is unavailable")
 	}
-	root := testutil.MustRepoRoot(t)
-	commandArguments := append([]string{"-NoProfile", "-NonInteractive", "-File", filepath.Join(root, "scripts", "release", "smoke-install.ps1")}, arguments...)
-	command := exec.Command(pwsh, commandArguments...)
-	command.Dir = root
-	return command
+	return path
 }
+
 func localAICandidatePowerShellLiteral(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
 }
-func utf16LE(value string) []byte {
-	encoded := utf16.Encode([]rune(value))
-	result := make([]byte, len(encoded)*2)
-	for index, character := range encoded {
-		binary.LittleEndian.PutUint16(result[index*2:], character)
-	}
-	return result
-}
-func localAICandidateRunGit(t *testing.T, directory string, arguments ...string) string {
+
+func localAICandidateGit(t *testing.T, directory string, arguments ...string) string {
 	t.Helper()
-	commandArguments := append([]string{"-C", directory}, arguments...)
-	output, err := exec.Command("git", commandArguments...).CombinedOutput()
+	command := exec.Command("git", append([]string{"-C", directory}, arguments...)...)
+	output, err := command.CombinedOutput()
 	if err != nil {
-		t.Fatalf("git -C %s %s: %v\n%s", directory, strings.Join(arguments, " "), err, output)
+		t.Fatalf("git %v: %v\n%s", arguments, err, output)
 	}
 	return strings.TrimSpace(string(output))
 }
-func TestLocalAICandidateManifestValidationRejectsDriftAndAmbiguity(t *testing.T) {
-	tests := []struct {
-		name string
-		edit func(*localAICandidateFixture)
-		want string
-	}{
-		{
-			name: "archive hash drift",
-			edit: func(fixture *localAICandidateFixture) {
-				fixture.manifest.Artifacts[0].SHA256 = strings.Repeat("d", sha256.Size*2)
-				fixture.writeManifest(t)
-			},
-			want: "sha256 mismatch",
-		},
-		{
-			name: "installer hash drift",
-			edit: func(fixture *localAICandidateFixture) {
-				fixture.manifest.Artifacts[1].SHA256 = strings.Repeat("d", sha256.Size*2)
-				fixture.writeManifest(t)
-			},
-			want: "sha256 mismatch",
-		},
-		{
-			name: "ambiguous archive",
-			edit: func(fixture *localAICandidateFixture) {
-				second := filepath.Join(fixture.root, "you_9.9.9_windows_amd64.zip")
-				if err := os.WriteFile(second, fixture.archiveBytes, 0o600); err != nil {
-					t.Fatalf("write ambiguous archive: %v", err)
-				}
-			},
-			want: "exactly one windows-amd64 ZIP",
-		},
-		{
-			name: "old descendant ceiling",
-			edit: func(fixture *localAICandidateFixture) {
-				fixture.manifest.Limits.DescendantMaximum = candidateInt64Pointer(12)
-				fixture.writeManifest(t)
-			},
-			want: "candidate limits.descendantMaximum = 12, want 36",
-		},
-		{
-			name: "ordinary download allowance",
-			edit: func(fixture *localAICandidateFixture) {
-				fixture.manifest.Limits.OrdinaryToolDownloadMaximum = candidateInt64Pointer(536870912)
-				fixture.writeManifest(t)
-			},
-			want: "candidate limits.ordinaryToolDownloadBytesMaximum = 536870912, want 0",
-		},
-		{name: "changed source commit", edit: func(fixture *localAICandidateFixture) {
-			fixture.manifest.Source.Commit = strings.Repeat("d", 40)
-			fixture.writeManifest(t)
-		}, want: "candidate source identity"},
-		{name: "changed source tree", edit: func(fixture *localAICandidateFixture) {
-			fixture.manifest.Source.Tree = strings.Repeat("e", 40)
-			fixture.writeManifest(t)
-		}, want: "candidate source identity"},
-		{name: "changed Go controls", edit: func(fixture *localAICandidateFixture) {
-			fixture.manifest.Limits.GOFLAGS = "-p=8"
-			fixture.manifest.Limits.GOMAXPROCS = "8"
-			fixture.writeManifest(t)
-		}, want: "candidate Go controls"},
-		{name: "changed Go version", edit: func(fixture *localAICandidateFixture) {
-			fixture.manifest.Build.GoVersion = "go1.25.0"
-			fixture.writeManifest(t)
-		}, want: "candidate Go version"},
-	}
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			fixture := newLocalAICandidateFixture(t)
-			test.edit(fixture)
-			if _, err := validateLocalAICandidate(fixture.manifestPath); err == nil || !strings.Contains(err.Error(), test.want) {
-				t.Fatalf("validate candidate error = %v, want substring %q", err, test.want)
-			}
-		})
-	}
-	for _, cycle := range []string{"030", "040", "042", "045", "048", "050", "063", "067", "068"} {
-		cycle := cycle
-		t.Run("historical cycle "+cycle, func(t *testing.T) {
-			fixture := newLocalAICandidateFixture(t)
-			fixture.manifest.Cycle = cycle
-			fixture.writeManifest(t)
-			if _, err := validateLocalAICandidate(fixture.manifestPath); err == nil || !strings.Contains(err.Error(), `candidate cycle = "`+cycle+`", want "`+localAICandidateCycle+`"`) {
-				t.Fatalf("validate historical cycle error = %v, want cycle %s rejection", err, cycle)
-			}
-		})
-	}
-}
-func TestLocalAICandidateManifestValidationRejectsReparseCandidateDirectory(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows junction fixture is only available on Windows")
-	}
-	fixture := newLocalAICandidateFixture(t)
-	linkRoot := filepath.Join(t.TempDir(), "candidate-link")
-	command := exec.Command("cmd.exe", "/c", "mklink", "/J", linkRoot, fixture.root)
-	if output, err := command.CombinedOutput(); err != nil {
-		t.Skipf("junction/reparse fixture unavailable: %v (%s)", err, output)
-	}
-	t.Cleanup(func() { _ = os.Remove(linkRoot) })
-	linkedManifest := filepath.Join(linkRoot, filepath.Base(fixture.manifestPath))
-	if _, err := validateLocalAICandidate(linkedManifest); err == nil || !strings.Contains(strings.ToLower(err.Error()), "symlink/reparse") {
-		t.Fatalf("validate reparse candidate directory error = %v, want symlink/reparse rejection", err)
-	}
-	externalArchive := filepath.Join(t.TempDir(), fixture.manifest.Artifacts[0].File)
-	if err := os.WriteFile(externalArchive, fixture.archiveBytes, 0o600); err != nil {
-		t.Fatalf("write external archive: %v", err)
-	}
-	retainedArchive := filepath.Join(fixture.root, fixture.manifest.Artifacts[0].File)
-	if err := os.Remove(retainedArchive); err != nil {
-		t.Fatalf("remove retained archive: %v", err)
-	}
-	if err := os.Symlink(externalArchive, retainedArchive); err != nil {
-		t.Logf("file symlink fixture unavailable: %v", err)
-		return
-	}
-	if _, err := validateLocalAICandidate(fixture.manifestPath); err == nil || !strings.Contains(strings.ToLower(err.Error()), "symlink/reparse") {
-		t.Fatalf("validate reparse artifact error = %v, want symlink/reparse rejection", err)
-	}
-}
-func TestLocalAICandidateManifestValidationAcceptsMatchingArtifacts(t *testing.T) {
-	fixture := newLocalAICandidateFixture(t)
-	evidence, err := validateLocalAICandidateWithBuildInfoReader(fixture.manifestPath, func(string) (*debug.BuildInfo, error) {
-		return localAICandidateCleanBuildInfo(), nil
-	})
-	if err != nil {
-		t.Fatalf("validate matching candidate: %v", err)
-	}
-	if evidence.Status != "PASS" || evidence.Property == "" || evidence.SourceCommit != localAICandidateSourceCommit || evidence.SourceTree != localAICandidateSourceTree || evidence.EmbeddedSourceRevision != localAICandidateSourceCommit || evidence.EmbeddedVCSModified || evidence.Archive.File != "you_1.2.3-snapshot-test_windows_amd64.zip" || evidence.Archive.Bytes != int64(len(fixture.archiveBytes)) || evidence.Installer.File != "install.ps1" || evidence.Installer.Bytes <= 0 {
-		t.Fatalf("candidate evidence = %#v, want PASS with matching archive, executable, and clean embedded revision", evidence)
-	}
-}
-func TestLocalAICandidateBuildInfoValidationRejectsDriftAndAmbiguity(t *testing.T) {
-	tests := []struct {
-		name     string
-		settings []debug.BuildSetting
-		readErr  error
-		want     string
-	}{
-		{
-			name: "clean revision and VCS state",
-			settings: []debug.BuildSetting{
-				{Key: "vcs.revision", Value: localAICandidateSourceCommit},
-				{Key: "vcs.modified", Value: "false"},
-			},
-		},
-		{
-			name:     "missing revision",
-			settings: []debug.BuildSetting{{Key: "vcs.modified", Value: "false"}},
-			want:     "vcs.revision is missing",
-		},
-		{
-			name: "mismatched revision",
-			settings: []debug.BuildSetting{
-				{Key: "vcs.revision", Value: strings.Repeat("d", 40)},
-				{Key: "vcs.modified", Value: "false"},
-			},
-			want: "vcs.revision =",
-		},
-		{
-			name:     "missing modified state",
-			settings: []debug.BuildSetting{{Key: "vcs.revision", Value: localAICandidateSourceCommit}},
-			want:     "vcs.modified is missing",
-		},
-		{
-			name: "dirty modified state",
-			settings: []debug.BuildSetting{
-				{Key: "vcs.revision", Value: localAICandidateSourceCommit},
-				{Key: "vcs.modified", Value: "true"},
-			},
-			want: "vcs.modified =",
-		},
-		{
-			name: "duplicate revision settings",
-			settings: []debug.BuildSetting{
-				{Key: "vcs.revision", Value: localAICandidateSourceCommit},
-				{Key: "vcs.revision", Value: localAICandidateSourceCommit},
-				{Key: "vcs.modified", Value: "false"},
-			},
-			want: "duplicate \"vcs.revision\" settings",
-		},
-		{
-			name: "duplicate modified settings",
-			settings: []debug.BuildSetting{
-				{Key: "vcs.revision", Value: localAICandidateSourceCommit},
-				{Key: "vcs.modified", Value: "false"},
-				{Key: "vcs.modified", Value: "true"},
-			},
-			want: "duplicate \"vcs.modified\" settings",
-		},
-		{
-			name:    "unreadable executable metadata",
-			readErr: errors.New("not a Go executable"),
-			want:    "read executable build info",
-		},
-	}
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			build := &debug.BuildInfo{Settings: test.settings}
-			revision, modified, err := readAndValidateLocalAICandidateBuildInfo("candidate.exe", func(string) (*debug.BuildInfo, error) {
-				return build, test.readErr
-			})
-			if test.want == "" {
-				if err != nil || revision != localAICandidateSourceCommit || modified {
-					t.Fatalf("build-info validation = revision=%q modified=%v error=%v, want clean protected revision", revision, modified, err)
-				}
-				return
-			}
-			if err == nil || !strings.Contains(err.Error(), test.want) {
-				t.Fatalf("build-info validation error = %v, want substring %q", err, test.want)
-			}
-		})
-	}
-}
-func TestLocalAICandidateBuildInfoReadFailureFailsClosed(t *testing.T) {
-	fixture := newLocalAICandidateFixture(t)
-	if _, err := validateLocalAICandidate(fixture.manifestPath); err == nil || !strings.Contains(err.Error(), "read executable build info") {
-		t.Fatalf("candidate build-info read error = %v, want fail-closed metadata evidence", err)
-	}
-}
-func TestLocalAICandidatePreconditionsFailClosedBeforeInstallation(t *testing.T) {
-	tests := []struct {
-		name string
-		edit func(*localAICandidateFixture)
-		want string
-	}{
-		{
-			name: "ambient you on task PATH",
-			edit: func(fixture *localAICandidateFixture) {
-				ambientDir := filepath.Join(fixture.root, "ambient-bin")
-				if err := os.MkdirAll(ambientDir, 0o700); err != nil {
-					t.Fatalf("create ambient bin: %v", err)
-				}
-				if err := os.WriteFile(filepath.Join(ambientDir, "you.exe"), []byte("ambient"), 0o600); err != nil {
-					t.Fatalf("write ambient you: %v", err)
-				}
-				fixture.taskPath = ambientDir
-			},
-			want: "task PATH already resolves you",
-		},
-		{
-			name: "nonempty declared state",
-			edit: func(fixture *localAICandidateFixture) {
-				stateDir := fixture.roots[0].Path
-				if err := os.MkdirAll(stateDir, 0o700); err != nil {
-					t.Fatalf("create state root: %v", err)
-				}
-				if err := os.WriteFile(filepath.Join(stateDir, "existing.json"), []byte("ambient state"), 0o600); err != nil {
-					t.Fatalf("write state: %v", err)
-				}
-			},
-			want: "declared root \"HOME\" is not empty",
-		},
-	}
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			fixture := newLocalAICandidateFixture(t)
-			test.edit(fixture)
-			if err := validateLocalAICandidatePreconditions(fixture.taskPath, fixture.roots); err == nil || !strings.Contains(err.Error(), test.want) {
-				t.Fatalf("precondition error = %v, want substring %q", err, test.want)
-			}
-		})
-	}
-	fixture := newLocalAICandidateFixture(t)
-	if err := validateLocalAICandidatePreconditions(fixture.taskPath, fixture.roots); err != nil {
-		t.Fatalf("validate absent roots: %v", err)
-	}
-	if err := os.Mkdir(fixture.roots[0].Path, 0o700); err != nil {
-		t.Fatalf("create empty root: %v", err)
-	}
-	if err := validateLocalAICandidatePreconditions(fixture.taskPath, fixture.roots); err != nil {
-		t.Fatalf("validate empty roots: %v", err)
-	}
-}
-func TestLocalAICandidateObserverEnvelopeFixture(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows observer fixture is only available on Windows")
-	}
-	pwsh, err := exec.LookPath("powershell.exe")
-	if err != nil {
-		t.Fatalf("observer fixture requires Windows PowerShell: %v", err)
-	}
-	reportPath := filepath.Join(t.TempDir(), "observer-report.json")
-	command := exec.Command(pwsh, "-NoProfile", "-NonInteractive", "-File", filepath.Join(testutil.MustRepoRoot(t), "scripts", "release", "smoke-install.ps1"), "-InstallDir", t.TempDir(), "-ObserverFixture", "-ObserverReportPath", reportPath)
-	command.Env = append(os.Environ(), "GOFLAGS="+localAICandidateGOFLAGS, "GOMAXPROCS="+localAICandidateGOMAXPROCS)
-	output, err := command.CombinedOutput()
-	if err != nil {
-		t.Fatalf("observer fixture: %v\n%s", err, output)
-	}
-	raw, err := os.ReadFile(reportPath)
-	if err != nil {
-		t.Fatalf("read observer report: %v", err)
-	}
-	var report localAICandidateObserverReport
-	if err := decodeLocalAICandidateJSON(raw, &report); err != nil {
-		t.Fatalf("decode observer report: %v", err)
-	}
-	if report.SchemaVersion != "localai-windows-install-candidate-observer/v1" || report.Status != "PASS" || report.Cycle != localAICandidateCycle || report.ReleaseStatus != "observer-fixture" {
-		t.Fatalf("observer report identity/status = %#v, want cycle-%s PASS observer-fixture", report, localAICandidateCycle)
-	}
-	if err := validateLocalAICandidateObserverEvidence(report.Observation); err != nil {
-		t.Fatalf("observer report evidence: %v", err)
-	}
-	if report.Cleanup.Status != "PASS" || len(report.Cleanup.RemainingTaskPaths) != 0 || len(report.Cleanup.Errors) != 0 {
-		t.Fatalf("observer cleanup evidence = %#v, want complete cleanup", report.Cleanup)
-	}
-	for _, stream := range []localAICandidateRootOutputStream{report.Observation.RootOutput.Stdout, report.Observation.RootOutput.Stderr} {
-		contents, err := os.ReadFile(stream.Path)
-		if err != nil {
-			t.Fatalf("read retained root output %q: %v", stream.Path, err)
-		}
-		if strings.Contains(string(contents), "observer-secret") || !strings.Contains(string(contents), "<redacted>") {
-			t.Fatalf("retained root output %q was not redacted: %q", stream.Path, contents)
-		}
-	}
-	t.Logf("LOCALAI-OBSERVER status=PASS evidence=%s", raw)
-}
-func TestLocalAICandidateObserverRootFailureRetainsOutput(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows observer fixture is only available on Windows")
-	}
-	reportPath := filepath.Join(t.TempDir(), "observer-failure-report.json")
-	command := localAICandidatePowerShellCommand(t, "-InstallDir", t.TempDir(), "-ObserverFixture", "-ObserverRootExitCode", "7", "-ObserverReportPath", reportPath)
-	command.Env = append(os.Environ(), "GOFLAGS="+localAICandidateGOFLAGS, "GOMAXPROCS="+localAICandidateGOMAXPROCS)
-	output, err := command.CombinedOutput()
-	if err == nil {
-		t.Fatalf("observer failure fixture unexpectedly succeeded: %s", output)
-	}
-	raw, err := os.ReadFile(reportPath)
-	if err != nil {
-		t.Fatalf("read observer failure report: %v\n%s", err, output)
-	}
-	var report localAICandidateObserverReport
-	if err := decodeLocalAICandidateJSON(raw, &report); err != nil {
-		t.Fatalf("decode observer failure report: %v", err)
-	}
-	if report.Status != "FAIL" || report.Observation.RootExitCode == nil || *report.Observation.RootExitCode != 7 || report.Observation.FailurePropagation != "FAIL" {
-		t.Fatalf("observer failure evidence = %#v, want exit 7 and failure propagation", report.Observation)
-	}
-	if report.Observation.RootOutput.Status != "PASS" || report.Cleanup.Status != "PASS" {
-		t.Fatalf("observer failure output/cleanup evidence = %#v / %#v, want retained output and cleanup", report.Observation.RootOutput, report.Cleanup)
-	}
-	for _, stream := range []localAICandidateRootOutputStream{report.Observation.RootOutput.Stdout, report.Observation.RootOutput.Stderr} {
-		contents, err := os.ReadFile(stream.Path)
-		if err != nil {
-			t.Fatalf("read retained failed-root output %q: %v", stream.Path, err)
-		}
-		if strings.Contains(string(contents), "observer-secret") || !strings.Contains(string(contents), "<redacted>") {
-			t.Fatalf("failed-root output %q was not redacted: %q", stream.Path, contents)
-		}
-	}
-	t.Logf("LOCALAI-OBSERVER-FAILURE status=PASS evidence=%s", raw)
-}
-func TestLocalAICandidateObserverArgumentVector(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows argument-vector fixture is only available on Windows")
-	}
-	repo := testutil.MustRepoRoot(t)
-	shell, err := exec.LookPath("pwsh.exe")
-	if err != nil {
-		shell, err = exec.LookPath("powershell.exe")
-		if err != nil {
-			t.Fatalf("argument-vector fixture requires PowerShell: %v", err)
-		}
-	}
-	recorderPath := filepath.Join(t.TempDir(), "argv-recorder.ps1")
-	recorder := `$observed = [string[]]$args
-Write-Output (ConvertTo-Json -InputObject $observed -Compress)
-[Console]::Error.WriteLine("argv-recorder stderr")
-$sleepScript = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("Start-Sleep -Milliseconds 1500"))
-$childPath = Join-Path $PSHOME "pwsh.exe"
-if (-not (Test-Path -LiteralPath $childPath)) { $childPath = Join-Path $PSHOME "powershell.exe" }
-$child = Start-Process -FilePath $childPath -WindowStyle Hidden -ArgumentList @("-NoProfile", "-NonInteractive", "-EncodedCommand", $sleepScript) -PassThru
-Wait-Process -Id $child.Id
-exit 0
-`
-	if err := os.WriteFile(recorderPath, []byte(recorder), 0o600); err != nil {
-		t.Fatalf("write argv recorder: %v", err)
-	}
-	spacedArgument := filepath.Join(t.TempDir(), "config path with spaces", ".goreleaser.yml")
-	wantArguments := []string{"release", "--snapshot", "--clean", "-f", spacedArgument}
-	collapsedArguments := "'" + strings.Join([]string{"release", "--snapshot", "--clean", "-f", spacedArgument}, "','") + "'"
-	readArguments := func(t *testing.T, reportPath string) []string {
-		t.Helper()
-		raw, err := os.ReadFile(reportPath)
-		if err != nil {
-			t.Fatalf("read argument observer report: %v", err)
-		}
-		var report localAICandidateObserverReport
-		if err := decodeLocalAICandidateJSON(raw, &report); err != nil {
-			t.Fatalf("decode argument observer report: %v", err)
-		}
-		if report.Status != "PASS" || report.Observation.RootExitCode == nil || *report.Observation.RootExitCode != 0 {
-			t.Fatalf("argument observer report = %#v, want successful observed root", report)
-		}
-		if err := validateLocalAICandidateObserverEvidence(report.Observation); err != nil {
-			t.Fatalf("argument observer evidence: %v", err)
-		}
-		stdout, err := os.ReadFile(report.Observation.RootOutput.Stdout.Path)
-		if err != nil {
-			t.Fatalf("read argument recorder stdout: %v", err)
-		}
-		stderr, err := os.ReadFile(report.Observation.RootOutput.Stderr.Path)
-		if err != nil {
-			t.Fatalf("read argument recorder stderr: %v", err)
-		}
-		if !strings.Contains(string(stderr), "argv-recorder stderr") {
-			t.Fatalf("argument recorder stderr = %q, want retained stderr", stderr)
-		}
-		var observed []string
-		if err := json.Unmarshal([]byte(strings.TrimSpace(string(stdout))), &observed); err != nil {
-			t.Fatalf("decode recorded argv %q: %v", stdout, err)
-		}
-		return observed
-	}
-	newInstallDir := filepath.Join(t.TempDir(), "install-root")
-	if err := os.MkdirAll(newInstallDir, 0o700); err != nil {
-		t.Fatalf("create direct-array install root: %v", err)
-	}
-	newReportPath := filepath.Join(t.TempDir(), "direct-array-report.json")
-	newStdoutPath := filepath.Join(filepath.Dir(newReportPath), "direct-array.stdout.txt")
-	newStderrPath := filepath.Join(filepath.Dir(newReportPath), "direct-array.stderr.txt")
-	argumentLiterals := make([]string, 0, len(wantArguments)+4)
-	for _, argument := range append([]string{"-NoProfile", "-NonInteractive", "-File", recorderPath}, wantArguments...) {
-		argumentLiterals = append(argumentLiterals, localAICandidatePowerShellLiteral(argument))
-	}
-	invocation := fmt.Sprintf(`$parameters = @{
-    InstallDir = %s
-    ObserverFixture = $true
-    ObserverReportPath = %s
-    ObserverRootCommand = %s
-    ObserverRootArgumentList = @(%s)
-    ObserverRootWorkingDirectory = %s
-    ObserverRootStdoutPath = %s
-    ObserverRootStderrPath = %s
-    ObserverRootOutputMaximumBytes = 65536
-    ObserverTimeoutSeconds = 10
-}
-& %s @parameters`, localAICandidatePowerShellLiteral(newInstallDir), localAICandidatePowerShellLiteral(newReportPath), localAICandidatePowerShellLiteral(shell), strings.Join(argumentLiterals, ", "), localAICandidatePowerShellLiteral(repo), localAICandidatePowerShellLiteral(newStdoutPath), localAICandidatePowerShellLiteral(newStderrPath), localAICandidatePowerShellLiteral(filepath.Join(repo, "scripts", "release", "smoke-install.ps1")))
-	command := exec.Command(shell, "-NoProfile", "-NonInteractive", "-EncodedCommand", base64.StdEncoding.EncodeToString(utf16LE(invocation)))
-	command.Dir = repo
-	command.Env = append(os.Environ(), "GOFLAGS="+localAICandidateGOFLAGS, "GOMAXPROCS="+localAICandidateGOMAXPROCS)
-	if output, err := command.CombinedOutput(); err != nil {
-		report, readErr := os.ReadFile(newReportPath)
-		t.Fatalf("direct argument-vector observer: %v\n%s\nreport=%s readError=%v", err, output, report, readErr)
-	}
-	observed := readArguments(t, newReportPath)
-	if !slices.Equal(observed, wantArguments) {
-		t.Fatalf("direct argument-vector recorder = %#v, want %#v", observed, wantArguments)
-	}
-	t.Logf("LOCALAI-ARGV status=PASS requested=%#v observed=%#v", wantArguments, observed)
 
-	collapsedInstallDir := filepath.Join(t.TempDir(), "install-root")
-	if err := os.MkdirAll(collapsedInstallDir, 0o700); err != nil {
-		t.Fatalf("create collapsed-array install root: %v", err)
-	}
-	collapsedReportPath := filepath.Join(t.TempDir(), "collapsed-array-report.json")
-	collapsedStdoutPath := filepath.Join(filepath.Dir(collapsedReportPath), "collapsed-array.stdout.txt")
-	collapsedStderrPath := filepath.Join(filepath.Dir(collapsedReportPath), "collapsed-array.stderr.txt")
-	collapsedCommand := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", "-File", filepath.Join(repo, "scripts", "release", "smoke-install.ps1"), "-InstallDir", collapsedInstallDir, "-ObserverFixture", "-ObserverReportPath", collapsedReportPath, "-ObserverRootCommand", shell, "-ObserverRootWorkingDirectory", repo, "-ObserverRootStdoutPath", collapsedStdoutPath, "-ObserverRootStderrPath", collapsedStderrPath, "-ObserverRootOutputMaximumBytes", "65536", "-ObserverTimeoutSeconds", "10", "-ObserverRootArgumentList", collapsedArguments)
-	collapsedCommand.Dir = repo
-	collapsedCommand.Env = append(os.Environ(), "GOFLAGS="+localAICandidateGOFLAGS, "GOMAXPROCS="+localAICandidateGOMAXPROCS)
-	if output, err := collapsedCommand.CombinedOutput(); err == nil {
-		t.Fatalf("retained collapsed argument-vector observer unexpectedly succeeded: %s", output)
-	}
-	collapsedRaw, err := os.ReadFile(collapsedReportPath)
-	if err != nil {
-		t.Fatalf("read collapsed argument observer report: %v", err)
-	}
-	var collapsedReport localAICandidateObserverReport
-	if err := decodeLocalAICandidateJSON(collapsedRaw, &collapsedReport); err != nil {
-		t.Fatalf("decode collapsed argument observer report: %v", err)
-	}
-	if collapsedReport.Status != "FAIL" || collapsedReport.Observation.RootExitCode == nil || *collapsedReport.Observation.RootExitCode == 0 || collapsedReport.Observation.RootOutput.Status != "PASS" {
-		t.Fatalf("collapsed argument observer report = %#v, want retained failure with root output", collapsedReport)
-	}
-	t.Logf("LOCALAI-ARGV-REGRESSION status=PASS retainedCollapsed=%q rootExit=%d", collapsedArguments, *collapsedReport.Observation.RootExitCode)
-}
-func TestLocalAICandidateObserverIdentityFixture(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows observer identity fixture is only available on Windows")
-	}
-	reportPath := filepath.Join(t.TempDir(), "observer-identity-report.json")
-	command := localAICandidatePowerShellCommand(t, "-InstallDir", t.TempDir(), "-ObserverIdentityFixture", "-ObserverReportPath", reportPath)
-	command.Env = append(os.Environ(), "GOFLAGS="+localAICandidateGOFLAGS, "GOMAXPROCS="+localAICandidateGOMAXPROCS)
-	output, err := command.CombinedOutput()
-	if err != nil {
-		t.Fatalf("observer identity fixture: %v\n%s", err, output)
-	}
-	var report struct {
-		SchemaVersion string `json:"schemaVersion"`
-		Status        string `json:"status"`
-		Cycle         string `json:"cycle"`
-		ReleaseStatus string `json:"releaseStatus"`
-		CrossInterval struct {
-			Status               string   `json:"status"`
-			ActiveIdentity       string   `json:"activeIdentity"`
-			HistoricalIdentities []string `json:"historicalIdentities"`
-			Continued            bool     `json:"continued"`
-		} `json:"crossInterval"`
-		WithinSample struct {
-			Status   string `json:"status"`
-			Rejected bool   `json:"rejected"`
-			Error    string `json:"error"`
-		} `json:"withinSample"`
-		EmptyTCP struct {
-			Status   string `json:"status"`
-			RowCount int    `json:"rowCount"`
-		} `json:"emptyTCP"`
-		QueryError struct {
-			Status string `json:"status"`
-			Error  string `json:"error"`
-		} `json:"queryError"`
-	}
-	raw, err := os.ReadFile(reportPath)
-	if err != nil {
-		t.Fatalf("read observer identity report: %v", err)
-	}
-	if err := decodeLocalAICandidateJSON(raw, &report); err != nil {
-		t.Fatalf("decode observer identity report: %v", err)
-	}
-	if report.SchemaVersion != "localai-windows-install-candidate-observer-identity/v1" || report.Status != "PASS" || report.Cycle != localAICandidateCycle || report.ReleaseStatus != "observer-identity-fixture" {
-		t.Fatalf("observer identity report identity/status = %#v, want cycle-%s PASS observer-identity-fixture", report, localAICandidateCycle)
-	}
-	if report.CrossInterval.Status != "PASS" || report.CrossInterval.ActiveIdentity != "42/B" || !report.CrossInterval.Continued || !slices.Equal(report.CrossInterval.HistoricalIdentities, []string{"100/root", "42/A", "42/B"}) {
-		t.Fatalf("cross-interval identity evidence = %#v, want retired 42/A with historical 42/A and 42/B", report.CrossInterval)
-	}
-	if report.WithinSample.Status != "PASS" || !report.WithinSample.Rejected || !strings.Contains(report.WithinSample.Error, "changed identity") {
-		t.Fatalf("within-sample identity evidence = %#v, want fail-closed PID reuse", report.WithinSample)
-	}
-	if report.EmptyTCP.Status != "PASS" || report.EmptyTCP.RowCount != 0 {
-		t.Fatalf("empty TCP evidence = %#v, want valid zero-row sample", report.EmptyTCP)
-	}
-	if report.QueryError.Status != "PASS" || !strings.Contains(report.QueryError.Error, "synthetic query error") {
-		t.Fatalf("query-error evidence = %#v, want preserved query failure", report.QueryError)
-	}
-	t.Logf("LOCALAI-OBSERVER-IDENTITY status=PASS evidence=%s", raw)
-}
-func TestLocalAICandidateReleaseCheckoutPreparation(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows release checkout preparation is only available on Windows")
-	}
-	repoRoot := testutil.MustRepoRoot(t)
-	clonePath := filepath.Join(t.TempDir(), "source-clone")
-	cloneOutput, err := exec.Command("git", "clone", "--no-local", "--no-checkout", repoRoot, clonePath).CombinedOutput()
-	if err != nil {
-		t.Fatalf("clone exact-source fixture: %v\n%s", err, cloneOutput)
-	}
-	localAICandidateRunGit(t, clonePath, "checkout", "--detach", localAICandidateSourceCommit)
-	reportPath := filepath.Join(t.TempDir(), "release-checkout-report.json")
-	command := localAICandidatePowerShellCommand(t, "-InstallDir", t.TempDir(), "-PrepareReleaseCheckout", "-ReleaseCheckoutPath", clonePath, "-ReleaseCheckoutReportPath", reportPath)
-	output, err := command.CombinedOutput()
-	if err != nil {
-		t.Fatalf("prepare release checkout: %v\n%s", err, output)
-	}
-	var report localAICandidateReleaseCheckoutEvidence
-	raw, err := os.ReadFile(reportPath)
-	if err != nil {
-		t.Fatalf("read release checkout report: %v", err)
-	}
-	if err := decodeLocalAICandidateJSON(raw, &report); err != nil {
-		t.Fatalf("decode release checkout report: %v", err)
-	}
-	distEntryCount := 0
-	for _, line := range report.PrivateExcludeAfter {
-		if line == "/dist/" {
-			distEntryCount++
-		}
-	}
-	remoteIsNonLocal := strings.Contains(report.Origin, "://") && !strings.HasPrefix(report.Origin, "file://") || strings.HasPrefix(report.Origin, "git@")
-	if report.Status != "PASS" || !report.GitDirIsDirectory || !report.DetachedHead || report.Head != localAICandidateSourceCommit || report.Tree != localAICandidateSourceTree || report.Origin == "" || remoteIsNonLocal || !report.StatusCleanBefore || !report.StatusCleanAfterPreparation || !slices.Equal(report.PrivateExcludeAdded, []string{"/dist/"}) || distEntryCount != 1 {
-		t.Fatalf("release checkout preparation evidence = %#v, want exact detached clean local clone and /dist/ addition", report)
-	}
-	distPath := filepath.Join(clonePath, "dist")
-	if err := os.MkdirAll(distPath, 0o700); err != nil {
-		t.Fatalf("create representative dist root: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(distPath, "representative-output.txt"), []byte("ignored release output"), 0o600); err != nil {
-		t.Fatalf("write representative dist output: %v", err)
-	}
-	if status := localAICandidateRunGit(t, clonePath, "status", "--porcelain=v1", "--untracked-files=all"); status != "" {
-		t.Fatalf("status after ignored dist output = %q, want clean", status)
-	}
-	trackedPath := filepath.Join(clonePath, ".goreleaser.yml")
-	trackedFile, err := os.OpenFile(trackedPath, os.O_APPEND|os.O_WRONLY, 0)
-	if err != nil {
-		t.Fatalf("open tracked fixture: %v", err)
-	}
-	if _, err := trackedFile.WriteString("\n# controlled dirty fixture\n"); err != nil {
-		trackedFile.Close()
-		t.Fatalf("modify tracked fixture: %v", err)
-	}
-	if err := trackedFile.Close(); err != nil {
-		t.Fatalf("close tracked fixture: %v", err)
-	}
-	if status := localAICandidateRunGit(t, clonePath, "status", "--porcelain=v1", "--untracked-files=all"); !strings.Contains(status, ".goreleaser.yml") {
-		t.Fatalf("status after tracked source modification = %q, want tracked modification", status)
-	}
-	t.Logf("LOCALAI-CLONE status=PASS evidence=%s", raw)
-}
-func TestLocalAICandidateDependencyStageCopiesExactContainedClosure(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows dependency staging is only available on Windows")
-	}
-	fixtureRoot := t.TempDir()
-	sourceRepo := filepath.Join(fixtureRoot, "source-repo")
-	stageRepo := filepath.Join(fixtureRoot, "stage-repo")
-	if err := os.MkdirAll(sourceRepo, 0o700); err != nil {
-		t.Fatalf("create source repository: %v", err)
-	}
-	if err := os.MkdirAll(stageRepo, 0o700); err != nil {
-		t.Fatalf("create stage repository: %v", err)
-	}
-	localAICandidateWriteDependencyFixture(t, sourceRepo, true)
-	localAICandidateWriteDependencyFixture(t, stageRepo, false)
-	sourceUI := filepath.Join(sourceRepo, "ui")
-	stageUI := filepath.Join(stageRepo, "ui")
-	sourceNodeModules := filepath.Join(sourceUI, "node_modules")
-	stageNodeModules := filepath.Join(stageUI, "node_modules")
-	linkPath := filepath.Join(sourceNodeModules, "workspace-link")
-	linkTarget := filepath.Join(sourceUI, "packages", "app")
-	linkCommand := exec.Command("cmd.exe", "/c", "mklink", "/J", linkPath, linkTarget)
-	if output, err := linkCommand.CombinedOutput(); err != nil {
-		t.Skipf("contained junction fixture unavailable: %v (%s)", err, output)
-	}
-	t.Cleanup(func() { _ = os.Remove(linkPath) })
-	stageEvidence := filepath.Join(fixtureRoot, "evidence")
-	if err := os.MkdirAll(stageEvidence, 0o700); err != nil {
-		t.Fatalf("create dependency evidence root: %v", err)
-	}
-	lockPath := filepath.Join(sourceUI, "bun.lock")
-	lockSHA256, err := sha256File(lockPath)
-	if err != nil {
-		t.Fatalf("hash fixture lock: %v", err)
-	}
-	lockBlob := localAICandidateRunGit(t, sourceRepo, "rev-parse", "HEAD:ui/bun.lock")
-	command := localAICandidatePowerShellCommand(t,
-		"-InstallDir", stageEvidence,
-		"-StageDependencyClosure",
-		"-DependencySourceRoot", sourceNodeModules,
-		"-DependencyStageRoot", stageNodeModules,
-		"-DependencySourceManifestPath", filepath.Join(stageEvidence, "source-manifest.jsonl"),
-		"-DependencyStageManifestPath", filepath.Join(stageEvidence, "stage-manifest.jsonl"),
-		"-DependencyReportPath", filepath.Join(stageEvidence, "stage-report.json"),
-		"-DependencyExpectedLockSHA256", lockSHA256,
-		"-DependencyExpectedLockBlob", lockBlob,
-	)
-	output, err := command.CombinedOutput()
-	if err != nil {
-		reportBytes, _ := os.ReadFile(filepath.Join(stageEvidence, "stage-report.json"))
-		t.Fatalf("exact dependency staging: %v\n%s\nreport=%s", err, output, reportBytes)
-	}
-	var report localAICandidateDependencyReport
-	raw, err := os.ReadFile(filepath.Join(stageEvidence, "stage-report.json"))
-	if err != nil {
-		t.Fatalf("read dependency stage report: %v", err)
-	}
-	if err := decodeLocalAICandidateJSON(raw, &report); err != nil {
-		t.Fatalf("decode dependency stage report: %v", err)
-	}
-	if report.SchemaVersion != "localai-windows-install-candidate-dependency-stage/v1" || report.Status != "PASS" || report.Phase != "stage" || report.PackageInstall != "NOT_RUN" || !report.Equality.SourceStageManifestEqual || report.SourceManifest.EntryCount != 5 || report.StageManifest.EntryCount != 5 || report.SourceManifest.JunctionCount != 1 || report.StageManifest.JunctionCount != 1 || report.SourceManifest.ManifestSHA256 != report.StageManifest.ManifestSHA256 || report.Error != "" {
-		t.Fatalf("dependency stage evidence = %#v, want exact no-install closure copy", report)
-	}
-	if copyEvidence, ok := report.Copy.(map[string]any); !ok || copyEvidence["rewrittenLinks"] != float64(1) {
-		t.Fatalf("dependency stage copy evidence = %#v, want one rewritten contained junction", report.Copy)
-	}
-	if _, err := os.Stat(filepath.Join(stageNodeModules, "dep", "index.js")); err != nil {
-		t.Fatalf("staged dependency content missing: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(stageNodeModules, "workspace-link", "package.json")); err != nil {
-		t.Fatalf("staged contained junction target missing: %v", err)
-	}
-	indexPath := filepath.Join(stageNodeModules, "dep", "index.js")
-	originalIndex, err := os.ReadFile(indexPath)
-	if err != nil {
-		t.Fatalf("read staged dependency fixture before mutation: %v", err)
-	}
-	if err := os.WriteFile(indexPath, []byte("module.exports = false;\n"), 0o600); err != nil {
-		t.Fatalf("mutate staged dependency fixture: %v", err)
-	}
-	mutationReportPath := filepath.Join(stageEvidence, "post-build-mutation-report.json")
-	mutationCommand := localAICandidatePowerShellCommand(t,
-		"-InstallDir", stageEvidence,
-		"-VerifyDependencyClosure",
-		"-DependencySourceRoot", sourceNodeModules,
-		"-DependencyStageRoot", stageNodeModules,
-		"-DependencyExpectedManifestPath", filepath.Join(stageEvidence, "stage-manifest.jsonl"),
-		"-DependencyPostBuildManifestPath", filepath.Join(stageEvidence, "post-build-mutation-manifest.jsonl"),
-		"-DependencySourceAfterManifestPath", filepath.Join(stageEvidence, "source-after-mutation-manifest.jsonl"),
-		"-DependencyReportPath", mutationReportPath,
-		"-DependencyExpectedLockSHA256", lockSHA256,
-		"-DependencyExpectedLockBlob", lockBlob,
-	)
-	mutationOutput, mutationErr := mutationCommand.CombinedOutput()
-	if mutationErr == nil {
-		t.Fatalf("post-build dependency mutation unexpectedly passed\n%s", mutationOutput)
-	}
-	mutationReportBytes, err := os.ReadFile(mutationReportPath)
-	if err != nil {
-		t.Fatalf("read post-build mutation report: %v", err)
-	}
-	var mutationReport struct {
-		Status string `json:"status"`
-		Error  string `json:"error"`
-	}
-	if err := json.Unmarshal(mutationReportBytes, &mutationReport); err != nil {
-		t.Fatalf("decode post-build mutation report: %v", err)
-	}
-	if mutationReport.Status != "FAIL" || !strings.Contains(mutationReport.Error, "differs") {
-		t.Fatalf("post-build mutation evidence = %#v, want fail-closed equality drift", mutationReport)
-	}
-	if err := os.WriteFile(indexPath, originalIndex, 0o600); err != nil {
-		t.Fatalf("restore staged dependency fixture: %v", err)
-	}
-	verifyCommand := localAICandidatePowerShellCommand(t,
-		"-InstallDir", stageEvidence,
-		"-VerifyDependencyClosure",
-		"-DependencySourceRoot", sourceNodeModules,
-		"-DependencyStageRoot", stageNodeModules,
-		"-DependencyExpectedManifestPath", filepath.Join(stageEvidence, "stage-manifest.jsonl"),
-		"-DependencyPostBuildManifestPath", filepath.Join(stageEvidence, "post-build-manifest.jsonl"),
-		"-DependencySourceAfterManifestPath", filepath.Join(stageEvidence, "source-after-manifest.jsonl"),
-		"-DependencyReportPath", filepath.Join(stageEvidence, "post-build-report.json"),
-		"-DependencyExpectedLockSHA256", lockSHA256,
-		"-DependencyExpectedLockBlob", lockBlob,
-	)
-	verifyOutput, err := verifyCommand.CombinedOutput()
-	if err != nil {
-		t.Fatalf("post-build dependency equality verification: %v\n%s", err, verifyOutput)
-	}
-	verifyReportBytes, err := os.ReadFile(filepath.Join(stageEvidence, "post-build-report.json"))
-	if err != nil {
-		t.Fatalf("read post-build report: %v", err)
-	}
-	var verifyReport struct {
-		Status   string `json:"status"`
-		Phase    string `json:"phase"`
-		Equality struct {
-			SourceStagePostBuildEqual bool `json:"sourceStagePostBuildEqual"`
-		} `json:"equality"`
-	}
-	if err := json.Unmarshal(verifyReportBytes, &verifyReport); err != nil {
-		t.Fatalf("decode post-build report: %v", err)
-	}
-	if verifyReport.Status != "PASS" || verifyReport.Phase != "post-build" || !verifyReport.Equality.SourceStagePostBuildEqual {
-		t.Fatalf("post-build equality evidence = %#v, want source/stage/post-build equality", verifyReport)
-	}
-	t.Logf("LOCALAI-STAGE status=PASS evidence=%s", raw)
-}
-func TestLocalAICandidateDependencyStageRejectsExternalLink(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows dependency staging is only available on Windows")
-	}
-	fixtureRoot := t.TempDir()
-	sourceRepo := filepath.Join(fixtureRoot, "source-repo")
-	stageRepo := filepath.Join(fixtureRoot, "stage-repo")
-	for _, repository := range []string{sourceRepo, stageRepo} {
-		if err := os.MkdirAll(repository, 0o700); err != nil {
-			t.Fatalf("create fixture repository: %v", err)
-		}
-	}
-	localAICandidateWriteDependencyFixture(t, sourceRepo, true)
-	localAICandidateWriteDependencyFixture(t, stageRepo, false)
-	sourceUI := filepath.Join(sourceRepo, "ui")
-	externalTarget := filepath.Join(fixtureRoot, "external-target")
-	if err := os.MkdirAll(externalTarget, 0o700); err != nil {
-		t.Fatalf("create external link target: %v", err)
-	}
-	externalLink := filepath.Join(sourceUI, "node_modules", "external-link")
-	linkCommand := exec.Command("cmd.exe", "/c", "mklink", "/J", externalLink, externalTarget)
-	if output, err := linkCommand.CombinedOutput(); err != nil {
-		t.Skipf("external junction fixture unavailable: %v (%s)", err, output)
-	}
-	t.Cleanup(func() { _ = os.Remove(externalLink) })
-	lockPath := filepath.Join(sourceUI, "bun.lock")
-	lockSHA256, err := sha256File(lockPath)
-	if err != nil {
-		t.Fatalf("hash fixture lock: %v", err)
-	}
-	lockBlob := localAICandidateRunGit(t, sourceRepo, "rev-parse", "HEAD:ui/bun.lock")
-	evidenceRoot := filepath.Join(fixtureRoot, "evidence")
-	if err := os.MkdirAll(evidenceRoot, 0o700); err != nil {
-		t.Fatalf("create dependency evidence root: %v", err)
-	}
-	reportPath := filepath.Join(evidenceRoot, "stage-report.json")
-	command := localAICandidatePowerShellCommand(t,
-		"-InstallDir", evidenceRoot,
-		"-StageDependencyClosure",
-		"-DependencySourceRoot", filepath.Join(sourceUI, "node_modules"),
-		"-DependencyStageRoot", filepath.Join(stageRepo, "ui", "node_modules"),
-		"-DependencySourceManifestPath", filepath.Join(evidenceRoot, "source-manifest.jsonl"),
-		"-DependencyStageManifestPath", filepath.Join(evidenceRoot, "stage-manifest.jsonl"),
-		"-DependencyReportPath", reportPath,
-		"-DependencyExpectedLockSHA256", lockSHA256,
-		"-DependencyExpectedLockBlob", lockBlob,
-	)
-	output, err := command.CombinedOutput()
-	if err == nil {
-		t.Fatalf("external dependency junction unexpectedly passed\n%s", output)
-	}
-	var report localAICandidateDependencyReport
-	raw, readErr := os.ReadFile(reportPath)
-	if readErr != nil {
-		t.Fatalf("read external-link failure report: %v\n%s", readErr, output)
-	}
-	if decodeErr := decodeLocalAICandidateJSON(raw, &report); decodeErr != nil {
-		t.Fatalf("decode external-link failure report: %v", decodeErr)
-	}
-	if report.Status != "FAIL" || !strings.Contains(report.Error, "outside the contained root") {
-		t.Fatalf("external-link failure evidence = %#v, want containment rejection", report)
-	}
-	t.Logf("LOCALAI-STAGE-EXTERNAL-LINK status=PASS evidence=%s", raw)
-}
-func TestLocalAICandidateDependencyStageRejectsMissingRequiredPackage(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows dependency staging is only available on Windows")
-	}
-	fixtureRoot := t.TempDir()
-	sourceRepo := filepath.Join(fixtureRoot, "source-repo")
-	stageRepo := filepath.Join(fixtureRoot, "stage-repo")
-	for _, repository := range []string{sourceRepo, stageRepo} {
-		if err := os.MkdirAll(repository, 0o700); err != nil {
-			t.Fatalf("create fixture repository: %v", err)
-		}
-	}
-	localAICandidateWriteDependencyFixture(t, sourceRepo, true)
-	localAICandidateWriteDependencyFixture(t, stageRepo, false)
-	sourceUI := filepath.Join(sourceRepo, "ui")
-	missingManifest := filepath.Join(sourceUI, "node_modules", "dep", "package.json")
-	if err := os.Remove(missingManifest); err != nil {
-		t.Fatalf("remove required fixture package: %v", err)
-	}
-	localAICandidateRunGit(t, sourceRepo, "add", "-A")
-	localAICandidateRunGit(t, sourceRepo, "commit", "-m", "remove required package")
-	lockPath := filepath.Join(sourceUI, "bun.lock")
-	lockSHA256, err := sha256File(lockPath)
-	if err != nil {
-		t.Fatalf("hash fixture lock: %v", err)
-	}
-	lockBlob := localAICandidateRunGit(t, sourceRepo, "rev-parse", "HEAD:ui/bun.lock")
-	evidenceRoot := filepath.Join(fixtureRoot, "evidence")
-	if err := os.MkdirAll(evidenceRoot, 0o700); err != nil {
-		t.Fatalf("create failure evidence root: %v", err)
-	}
-	command := localAICandidatePowerShellCommand(t,
-		"-InstallDir", evidenceRoot,
-		"-StageDependencyClosure",
-		"-DependencySourceRoot", filepath.Join(sourceUI, "node_modules"),
-		"-DependencyStageRoot", filepath.Join(stageRepo, "ui", "node_modules"),
-		"-DependencySourceManifestPath", filepath.Join(evidenceRoot, "source-manifest.jsonl"),
-		"-DependencyStageManifestPath", filepath.Join(evidenceRoot, "stage-manifest.jsonl"),
-		"-DependencyReportPath", filepath.Join(evidenceRoot, "stage-report.json"),
-		"-DependencyExpectedLockSHA256", lockSHA256,
-		"-DependencyExpectedLockBlob", lockBlob,
-	)
-	output, err := command.CombinedOutput()
-	if err == nil {
-		t.Fatalf("missing required dependency unexpectedly passed\n%s", output)
-	}
-	var report localAICandidateDependencyReport
-	raw, readErr := os.ReadFile(filepath.Join(evidenceRoot, "stage-report.json"))
-	if readErr != nil {
-		t.Fatalf("read dependency failure report: %v\n%s", readErr, output)
-	}
-	if decodeErr := decodeLocalAICandidateJSON(raw, &report); decodeErr != nil {
-		t.Fatalf("decode dependency failure report: %v", decodeErr)
-	}
-	if report.Status != "FAIL" || !strings.Contains(report.Error, "missing required package") {
-		t.Fatalf("dependency failure evidence = %#v, want fail-closed missing package", report)
-	}
-	t.Logf("LOCALAI-STAGE-FAILURE status=PASS evidence=%s", raw)
-}
-func localAICandidateWriteDependencyFixture(t *testing.T, repository string, includeDependency bool) {
+func readJSONFile(t *testing.T, path string, target any) {
 	t.Helper()
-	uiRoot := filepath.Join(repository, "ui")
-	workspaceRoot := filepath.Join(uiRoot, "packages", "app")
-	if err := os.MkdirAll(workspaceRoot, 0o700); err != nil {
-		t.Fatalf("create fixture workspace: %v", err)
-	}
-	dependencyName := "dep"
-	rootPackage := fmt.Sprintf(`{"name":"fixture-root","private":true,"workspaces":["packages/*"],"dependencies":{"%s":"1.0.0"},"devDependencies":{},"optionalDependencies":{}}`, dependencyName)
-	workspacePackage := fmt.Sprintf(`{"name":"fixture-app","dependencies":{"%s":"1.0.0"},"devDependencies":{},"optionalDependencies":{}}`, dependencyName)
-	lock := fmt.Sprintf(`{"lockfileVersion":1,"configVersion":0,"workspaces":{"":{"name":"fixture-root","dependencies":{"%s":"1.0.0"},"devDependencies":{},"optionalDependencies":{}},"packages/app":{"name":"fixture-app","dependencies":{"%s":"1.0.0"},"devDependencies":{},"optionalDependencies":{}}},"packages":{"dep@1.0.0":["dep@1.0.0","",{},""]}}`, dependencyName, dependencyName)
-	for path, contents := range map[string]string{
-		filepath.Join(uiRoot, "package.json"):        rootPackage,
-		filepath.Join(workspaceRoot, "package.json"): workspacePackage,
-		filepath.Join(uiRoot, "bun.lock"):            lock,
-	} {
-		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
-			t.Fatalf("write fixture file %s: %v", path, err)
-		}
-	}
-	if includeDependency {
-		dependencyRoot := filepath.Join(uiRoot, "node_modules", dependencyName)
-		if err := os.MkdirAll(dependencyRoot, 0o700); err != nil {
-			t.Fatalf("create fixture dependency: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(dependencyRoot, "package.json"), []byte(`{"name":"dep","version":"1.0.0","dependencies":{},"optionalDependencies":{},"peerDependencies":{}}`), 0o600); err != nil {
-			t.Fatalf("write fixture dependency manifest: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(dependencyRoot, "index.js"), []byte("module.exports = true;\n"), 0o600); err != nil {
-			t.Fatalf("write fixture dependency file: %v", err)
-		}
-	}
-	localAICandidateRunGit(t, repository, "init")
-	localAICandidateRunGit(t, repository, "config", "user.email", "fixture@example.invalid")
-	localAICandidateRunGit(t, repository, "config", "user.name", "dependency-fixture")
-	localAICandidateRunGit(t, repository, "add", ".")
-	localAICandidateRunGit(t, repository, "commit", "-m", "dependency fixture")
-}
-func validateLocalAICandidateObserverEvidence(observation localAICandidateObserverEvidence) error {
-	process := observation.ProcessNetworkObserver
-	if process.Status != "PASS" || !process.StartedBeforeRoot || !process.ContinuedThroughDescendantExit || process.MaximumGapMilliseconds < 0 || process.MaximumGapMilliseconds > localAICandidateProcessNetworkGapMaximum || process.NonLoopbackConnections != 0 || process.ExternalTransferBytes != 0 || process.SampleCount <= 0 || process.TCPTableQueries != process.SampleCount || process.ZeroConnectionSamples <= 0 || process.OwnedConnectionMatches < 0 || process.OwnedProcessIdentityCount <= 0 || process.QueryMode != localAICandidateObserverQueryMode || len(process.ForbiddenProcesses) != 0 || process.Error != "" {
-		return fmt.Errorf("invalid process/network observer evidence: %#v", process)
-	}
-	disk := observation.DiskObserver
-	if disk.Status != "PASS" || !disk.Independent || !disk.StartPeriodicFinal || disk.MaximumGapMilliseconds < 0 || disk.MaximumGapMilliseconds > localAICandidateDiskGapMaximum || disk.PeakDeltaBytes < 0 || disk.PeakDeltaBytes > localAICandidateTemporaryDiskMaximum || disk.Error != "" {
-		return fmt.Errorf("invalid disk observer evidence: %#v", disk)
-	}
-	if observation.DescendantMaximum != localAICandidateDescendantMaximum || observation.DescendantHighWater < 1 || observation.DescendantHighWater > observation.DescendantMaximum {
-		return fmt.Errorf("descendant observation = high-water %d maximum %d, want high-water 1..%d", observation.DescendantHighWater, observation.DescendantMaximum, localAICandidateDescendantMaximum)
-	}
-	if observation.RootExitCode == nil {
-		return errors.New("root exit code is required before process disposal")
-	}
-	rootOutput := observation.RootOutput
-	if rootOutput.Status != "PASS" || rootOutput.MaximumBytes <= 0 {
-		return fmt.Errorf("invalid root output evidence: %#v", rootOutput)
-	}
-	for name, stream := range map[string]localAICandidateRootOutputStream{"stdout": rootOutput.Stdout, "stderr": rootOutput.Stderr} {
-		if stream.Status != "PASS" || !stream.Present || !filepath.IsAbs(stream.Path) || stream.TotalBytes < 0 || stream.CapturedBytes < 0 || stream.CapturedBytes > stream.TotalBytes || stream.CapturedBytes > rootOutput.MaximumBytes || stream.RedactedBytes < 0 || !localAICandidateSHA256Pattern.MatchString(stream.SHA256) {
-			return fmt.Errorf("invalid root %s output evidence: %#v", name, stream)
-		}
-		if stream.Truncated != (stream.TotalBytes > rootOutput.MaximumBytes) {
-			return fmt.Errorf("root %s truncation metadata does not match byte counts: %#v", name, stream)
-		}
-	}
-	if *observation.RootExitCode != 0 || observation.FailurePropagation != "PASS" || observation.ModelBackendBytes != 0 || observation.ModelBackendCalls != 0 {
-		return fmt.Errorf("invalid observer completion evidence: %#v", observation)
-	}
-	return nil
-}
-func TestLocalAICandidateObserverEvidenceRejectsUnprovenSamples(t *testing.T) {
-	rootExitCode := int64(0)
-	rootOutputPath := filepath.Join(os.TempDir(), "localai-observer-output.txt")
-	base := localAICandidateObserverEvidence{
-		ProcessNetworkObserver: localAICandidateProcessNetworkObserver{
-			StartedBeforeRoot: true, ContinuedThroughDescendantExit: true, MaximumGapMilliseconds: 1,
-			Status: "PASS", SampleCount: 3, TCPTableQueries: 3, ZeroConnectionSamples: 3,
-			OwnedProcessIdentityCount: 3, QueryMode: localAICandidateObserverQueryMode,
-		},
-		DiskObserver:        localAICandidateDiskObserver{Independent: true, StartPeriodicFinal: true, MaximumGapMilliseconds: 1, Status: "PASS"},
-		DescendantMaximum:   localAICandidateDescendantMaximum,
-		DescendantHighWater: 1,
-		RootExitCode:        &rootExitCode,
-		RootOutput: localAICandidateRootOutput{
-			Status:       "PASS",
-			MaximumBytes: 1024,
-			Stdout:       localAICandidateRootOutputStream{Status: "PASS", Path: rootOutputPath, Present: true, TotalBytes: 10, CapturedBytes: 10, SHA256: strings.Repeat("a", sha256.Size*2)},
-			Stderr:       localAICandidateRootOutputStream{Status: "PASS", Path: rootOutputPath, Present: true, TotalBytes: 10, CapturedBytes: 10, SHA256: strings.Repeat("b", sha256.Size*2)},
-		},
-		FailurePropagation: "PASS",
-	}
-	tests := []struct {
-		name string
-		edit func(*localAICandidateObserverEvidence)
-	}{
-		{name: "query count drift", edit: func(evidence *localAICandidateObserverEvidence) { evidence.ProcessNetworkObserver.TCPTableQueries = 2 }},
-		{name: "zero row not recorded", edit: func(evidence *localAICandidateObserverEvidence) {
-			evidence.ProcessNetworkObserver.ZeroConnectionSamples = 0
-		}},
-		{name: "identity count missing", edit: func(evidence *localAICandidateObserverEvidence) {
-			evidence.ProcessNetworkObserver.OwnedProcessIdentityCount = 0
-		}},
-		{name: "query mode missing", edit: func(evidence *localAICandidateObserverEvidence) {
-			evidence.ProcessNetworkObserver.QueryMode = "per-pid"
-		}},
-		{name: "query error", edit: func(evidence *localAICandidateObserverEvidence) {
-			evidence.ProcessNetworkObserver.Error = "query failed"
-		}},
-		{name: "disk gap over limit", edit: func(evidence *localAICandidateObserverEvidence) {
-			evidence.DiskObserver.MaximumGapMilliseconds = localAICandidateDiskGapMaximum + 1
-		}},
-		{name: "disk error", edit: func(evidence *localAICandidateObserverEvidence) { evidence.DiskObserver.Error = "disk sample failed" }},
-		{name: "root output missing", edit: func(evidence *localAICandidateObserverEvidence) { evidence.RootOutput.Stdout.Present = false }},
-		{name: "root output hash missing", edit: func(evidence *localAICandidateObserverEvidence) { evidence.RootOutput.Stderr.SHA256 = "" }},
-	}
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-			evidence := base
-			test.edit(&evidence)
-			if err := validateLocalAICandidateObserverEvidence(evidence); err == nil {
-				t.Fatal("observer evidence unexpectedly passed")
-			}
-		})
-	}
-}
-func validateLocalAICandidate(manifestPath string) (localAICandidateValidationEvidence, error) {
-	return validateLocalAICandidateWithBuildInfoReader(manifestPath, buildinfo.ReadFile)
-}
-func validateLocalAICandidateWithBuildInfoReader(manifestPath string, readBuildInfo func(string) (*debug.BuildInfo, error)) (localAICandidateValidationEvidence, error) {
-	if !filepath.IsAbs(manifestPath) {
-		return localAICandidateValidationEvidence{}, fmt.Errorf("candidate manifest path %q must be absolute", manifestPath)
-	}
-	candidateDir := filepath.Dir(manifestPath)
-	if _, err := validateLocalAICandidatePath(candidateDir, "candidate directory"); err != nil {
-		return localAICandidateValidationEvidence{}, err
-	}
-	manifestInfo, err := validateLocalAICandidatePath(manifestPath, "candidate manifest")
+	contents, err := os.ReadFile(path)
 	if err != nil {
-		return localAICandidateValidationEvidence{}, err
+		t.Fatalf("read %s: %v", path, err)
 	}
-	manifestBytes, manifest, err := readLocalAICandidateManifest(manifestPath)
-	if err != nil {
-		return localAICandidateValidationEvidence{}, err
+	contents = bytes.TrimPrefix(contents, []byte{0xef, 0xbb, 0xbf})
+	if err := json.Unmarshal(contents, target); err != nil {
+		t.Fatalf("decode %s: %v\n%s", path, err, contents)
 	}
-	if err := validateLocalAICandidateIdentity(manifest); err != nil {
-		return localAICandidateValidationEvidence{}, err
-	}
-	manifestDigest, err := sha256File(manifestPath)
-	if err != nil {
-		return localAICandidateValidationEvidence{}, fmt.Errorf("hash candidate manifest: %w", err)
-	}
-	if int64(len(manifestBytes)) != manifestInfo.Size() {
-		return localAICandidateValidationEvidence{}, fmt.Errorf("candidate manifest changed while reading: read %d bytes, stat reported %d", len(manifestBytes), manifestInfo.Size())
-	}
-	if err := validateLocalAICandidateDetachedDigest(filepath.Dir(manifestPath), manifestDigest); err != nil {
-		return localAICandidateValidationEvidence{}, err
-	}
-	artifactByRole := make(map[string]localAICandidateArtifact, len(manifest.Artifacts))
-	for _, artifact := range manifest.Artifacts {
-		if _, exists := artifactByRole[artifact.Role]; exists {
-			return localAICandidateValidationEvidence{}, fmt.Errorf("candidate manifest contains duplicate artifact role %q", artifact.Role)
-		}
-		artifactByRole[artifact.Role] = artifact
-	}
-	archive, ok := artifactByRole["windows-amd64-archive"]
-	if !ok {
-		return localAICandidateValidationEvidence{}, errors.New("candidate manifest is missing windows-amd64-archive artifact")
-	}
-	installer, ok := artifactByRole["windows-installer"]
-	if !ok {
-		return localAICandidateValidationEvidence{}, errors.New("candidate manifest is missing windows-installer artifact")
-	}
-	executable, ok := artifactByRole["windows-amd64-executable"]
-	if !ok {
-		return localAICandidateValidationEvidence{}, errors.New("candidate manifest is missing windows-amd64-executable artifact")
-	}
-	archiveCandidates, err := localAICandidateArchiveCandidates(candidateDir)
-	if err != nil {
-		return localAICandidateValidationEvidence{}, err
-	}
-	if len(archiveCandidates) != 1 {
-		return localAICandidateValidationEvidence{}, fmt.Errorf("candidate archive selection: expected exactly one windows-amd64 ZIP, found %d (%s)", len(archiveCandidates), strings.Join(archiveCandidates, ", "))
-	}
-	if archiveCandidates[0] != archive.File {
-		return localAICandidateValidationEvidence{}, fmt.Errorf("candidate archive selection: manifest names %q, retained archive is %q", archive.File, archiveCandidates[0])
-	}
-	archiveEvidence, err := validateLocalAICandidateArtifact(candidateDir, archive, true)
-	if err != nil {
-		return localAICandidateValidationEvidence{}, fmt.Errorf("validate windows archive: %w", err)
-	}
-	installerEvidence, err := validateLocalAICandidateArtifact(candidateDir, installer, false)
-	if err != nil {
-		return localAICandidateValidationEvidence{}, fmt.Errorf("validate windows installer: %w", err)
-	}
-	embeddedSourceRevision, embeddedVCSModified, err := readAndValidateLocalAICandidateBuildInfo(filepath.Join(candidateDir, filepath.FromSlash(executable.File)), readBuildInfo)
-	if err != nil {
-		return localAICandidateValidationEvidence{}, err
-	}
-	return localAICandidateValidationEvidence{
-		Status:                 "PASS",
-		Property:               "prebuilt-candidate-schema-source-target-artifact-and-detached-digest-identity",
-		SchemaVersion:          manifest.SchemaVersion,
-		SourceCommit:           manifest.Source.Commit,
-		SourceTree:             manifest.Source.Tree,
-		EmbeddedSourceRevision: embeddedSourceRevision,
-		EmbeddedVCSModified:    embeddedVCSModified,
-		CandidateVersion:       manifest.Build.CandidateVersion,
-		CLIVersion:             manifest.Build.CLIVersion,
-		Target:                 manifest.Build.Target.GOOS + "/" + manifest.Build.Target.GOARCH,
-		Archive:                archiveEvidence,
-		Installer:              installerEvidence,
-		Manifest: localAICandidateArtifactEvidence{
-			Role:   "candidate-manifest",
-			File:   filepath.Base(manifestPath),
-			Bytes:  manifestInfo.Size(),
-			SHA256: manifestDigest,
-		},
-		Preconditions: "not-run-by-schema-cell; install cell must supply task-owned PATH and roots",
-	}, nil
-}
-func readAndValidateLocalAICandidateBuildInfo(path string, readBuildInfo func(string) (*debug.BuildInfo, error)) (string, bool, error) {
-	if readBuildInfo == nil {
-		return "", false, errors.New("read executable build info: reader is nil")
-	}
-	build, err := readBuildInfo(path)
-	if err != nil {
-		return "", false, fmt.Errorf("read executable build info %q: %w", path, err)
-	}
-	if build == nil {
-		return "", false, fmt.Errorf("read executable build info %q: returned no metadata", path)
-	}
-	revision, err := localAICandidateBuildSetting(build, "vcs.revision")
-	if err != nil {
-		return "", false, err
-	}
-	if revision != localAICandidateSourceCommit {
-		return "", false, fmt.Errorf("candidate executable build info vcs.revision = %q, want %q", revision, localAICandidateSourceCommit)
-	}
-	modified, err := localAICandidateBuildSetting(build, "vcs.modified")
-	if err != nil {
-		return "", false, err
-	}
-	if modified != "false" {
-		return "", false, fmt.Errorf("candidate executable build info vcs.modified = %q, want %q", modified, "false")
-	}
-	return revision, false, nil
-}
-func localAICandidateBuildSetting(build *debug.BuildInfo, key string) (string, error) {
-	var value string
-	found := false
-	for _, setting := range build.Settings {
-		if setting.Key != key {
-			continue
-		}
-		if found {
-			return "", fmt.Errorf("candidate executable build info contains duplicate %q settings", key)
-		}
-		found = true
-		value = strings.TrimSpace(setting.Value)
-	}
-	if !found || value == "" {
-		return "", fmt.Errorf("candidate executable build info %s is missing", key)
-	}
-	return value, nil
-}
-func readLocalAICandidateManifest(manifestPath string) ([]byte, localAICandidateManifest, error) {
-	manifestBytes, err := os.ReadFile(manifestPath)
-	if err != nil {
-		return nil, localAICandidateManifest{}, fmt.Errorf("read candidate manifest %q: %w", manifestPath, err)
-	}
-	var manifest localAICandidateManifest
-	if err := decodeLocalAICandidateJSON(manifestBytes, &manifest); err != nil {
-		return nil, localAICandidateManifest{}, fmt.Errorf("decode candidate manifest %q: %w", manifestPath, err)
-	}
-	return manifestBytes, manifest, nil
-}
-func decodeLocalAICandidateJSON(raw []byte, target any) error {
-	decoder := json.NewDecoder(bytes.NewReader(raw))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(target); err != nil {
-		return err
-	}
-	var trailing any
-	if err := decoder.Decode(&trailing); err != io.EOF {
-		if err == nil {
-			return errors.New("trailing JSON value")
-		}
-		return fmt.Errorf("trailing data: %w", err)
-	}
-	return nil
-}
-func validateLocalAICandidateIdentity(manifest localAICandidateManifest) error {
-	if manifest.SchemaVersion != localAICandidateSchemaVersion {
-		return fmt.Errorf("candidate schemaVersion = %q, want %q", manifest.SchemaVersion, localAICandidateSchemaVersion)
-	}
-	if manifest.Project != localAICandidateProject {
-		return fmt.Errorf("candidate project = %q, want %q", manifest.Project, localAICandidateProject)
-	}
-	if manifest.Cycle != localAICandidateCycle {
-		return fmt.Errorf("candidate cycle = %q, want %q", manifest.Cycle, localAICandidateCycle)
-	}
-	if manifest.Source.Repository != localAICandidateRepository ||
-		manifest.Source.Commit != localAICandidateSourceCommit ||
-		manifest.Source.Tree != localAICandidateSourceTree {
-		return fmt.Errorf("candidate source identity = repository=%q commit=%q tree=%q, want repository=%q commit=%q tree=%q", manifest.Source.Repository, manifest.Source.Commit, manifest.Source.Tree, localAICandidateRepository, localAICandidateSourceCommit, localAICandidateSourceTree)
-	}
-	if strings.TrimSpace(manifest.Build.CandidateVersion) == "" || strings.ContainsAny(manifest.Build.CandidateVersion, "/\\\\:*?\"<>|\t\r\n ") {
-		return fmt.Errorf("candidateVersion %q is not a usable release version", manifest.Build.CandidateVersion)
-	}
-	for name, value := range map[string]string{
-		"cliVersion":             manifest.Build.CLIVersion,
-		"goVersion":              manifest.Build.GoVersion,
-		"goreleaserVersion":      manifest.Build.GoReleaserVersion,
-		"goreleaserConfigSha256": manifest.Build.GoReleaserConfigSHA256,
-	} {
-		if strings.TrimSpace(value) == "" {
-			return fmt.Errorf("candidate build.%s is required", name)
-		}
-	}
-	if manifest.Build.GoVersion != localAICandidateGoVersion {
-		return fmt.Errorf("candidate Go version = %q, want %q", manifest.Build.GoVersion, localAICandidateGoVersion)
-	}
-	if manifest.Build.GoReleaserVersion != localAICandidateGoReleaser {
-		return fmt.Errorf("candidate goreleaserVersion = %q, want %q", manifest.Build.GoReleaserVersion, localAICandidateGoReleaser)
-	}
-	if !localAICandidateSHA256Pattern.MatchString(manifest.Build.GoReleaserConfigSHA256) {
-		return fmt.Errorf("candidate goreleaserConfigSha256 = %q, want lowercase SHA-256", manifest.Build.GoReleaserConfigSHA256)
-	}
-	if manifest.Build.Target.GOOS != localAICandidateGOOS || manifest.Build.Target.GOARCH != localAICandidateGOARCH {
-		return fmt.Errorf("candidate target = %s/%s, want %s/%s", manifest.Build.Target.GOOS, manifest.Build.Target.GOARCH, localAICandidateGOOS, localAICandidateGOARCH)
-	}
-	if manifest.Build.Target.CgoEnabled == nil || *manifest.Build.Target.CgoEnabled {
-		return fmt.Errorf("candidate target.cgoEnabled = %v, want false", manifest.Build.Target.CgoEnabled != nil && *manifest.Build.Target.CgoEnabled)
-	}
-	if len(manifest.Artifacts) != 3 {
-		return fmt.Errorf("candidate artifacts count = %d, want exactly 3", len(manifest.Artifacts))
-	}
-	for _, artifact := range manifest.Artifacts {
-		if (artifact.Role != "windows-amd64-archive" && artifact.Role != "windows-installer" && artifact.Role != "windows-amd64-executable") || !isLocalAICandidateBasename(artifact.File) {
-			return fmt.Errorf("candidate artifact %q has an unsupported role or unsafe file %q", artifact.Role, artifact.File)
-		}
-		if artifact.Bytes == nil || *artifact.Bytes <= 0 || !localAICandidateSHA256Pattern.MatchString(artifact.SHA256) {
-			return fmt.Errorf("candidate artifact %q has invalid positive-byte/lowercase-SHA256 metadata", artifact.Role)
-		}
-	}
-	for _, limit := range []struct {
-		name   string
-		actual *int64
-		want   int64
-	}{
-		{"temporaryDiskBytesMaximum", manifest.Limits.TemporaryDiskBytesMaximum, localAICandidateTemporaryDiskMaximum},
-		{"ordinaryToolDownloadBytesMaximum", manifest.Limits.OrdinaryToolDownloadMaximum, localAICandidateToolDownloadMaximum},
-		{"modelBackendDownloadBytesMaximum", manifest.Limits.ModelBackendDownloadMaximum, localAICandidateModelDownloadMaximum},
-		{"modelCallsMaximum", manifest.Limits.ModelCallsMaximum, localAICandidateModelCallsMaximum},
-		{"paidUSDMaximum", manifest.Limits.PaidUSDMaximum, localAICandidatePaidUSDMaximum},
-		{"descendantMaximum", manifest.Limits.DescendantMaximum, localAICandidateDescendantMaximum},
-		{"packagingOrSmokeRerunsMaximum", manifest.Limits.PackagingOrSmokeRerunsMaximum, localAICandidateRerunsMaximum},
-	} {
-		if err := validateLocalAICandidateLimit(limit.name, limit.actual, limit.want); err != nil {
-			return err
-		}
-	}
-	if strings.TrimSpace(manifest.Limits.GOFLAGS) == "" || manifest.Limits.GOFLAGS != localAICandidateGOFLAGS || strings.TrimSpace(manifest.Limits.GOMAXPROCS) == "" || manifest.Limits.GOMAXPROCS != localAICandidateGOMAXPROCS {
-		return fmt.Errorf("candidate Go controls = GOFLAGS=%q GOMAXPROCS=%q, want GOFLAGS=%q GOMAXPROCS=%q", manifest.Limits.GOFLAGS, manifest.Limits.GOMAXPROCS, localAICandidateGOFLAGS, localAICandidateGOMAXPROCS)
-	}
-	if err := validateLocalAICandidateAttempts(manifest.Attempts); err != nil {
-		return err
-	}
-	return nil
-}
-func validateLocalAICandidateAttempts(attempts localAICandidateAttempts) error {
-	wantPriorCycles := []string{"030", "040", "042", "045", "048", "050", "063", "067", "068"}
-	if !slices.Equal(attempts.PriorCycles, wantPriorCycles) {
-		return fmt.Errorf("candidate attempts priorCycles = %v, want %v", attempts.PriorCycles, wantPriorCycles)
-	}
-	for _, attempt := range []struct {
-		name    string
-		maximum *int64
-		used    *int64
-		wantMax int64
-		wantUse int64
-	}{
-		{name: "cycle063", maximum: attempts.Cycle063BuildMaximum, used: attempts.Cycle063BuildUsed, wantMax: 1, wantUse: 1},
-		{name: "cycle067", maximum: attempts.Cycle067BuildMaximum, used: attempts.Cycle067BuildUsed, wantMax: 2, wantUse: 2},
-		{name: "cycle068", maximum: attempts.Cycle068BuildMaximum, used: attempts.Cycle068BuildUsed, wantMax: 1, wantUse: 1},
-		{name: "cycle070", maximum: attempts.Cycle070BuildMaximum, used: attempts.Cycle070BuildUsed, wantMax: 1, wantUse: 1},
-	} {
-		if attempt.maximum == nil || attempt.used == nil || *attempt.maximum != attempt.wantMax || *attempt.used != attempt.wantUse {
-			return fmt.Errorf("candidate attempts %sBuildMaximum/Used = %v/%v, want %d/%d", attempt.name, valueOrZero(attempt.maximum), valueOrZero(attempt.used), attempt.wantMax, attempt.wantUse)
-		}
-	}
-	return nil
-}
-func valueOrZero(value *int64) int64 {
-	if value == nil {
-		return 0
-	}
-	return *value
-}
-func validateLocalAICandidateLimit(name string, actual *int64, want int64) error {
-	if actual == nil {
-		return fmt.Errorf("candidate limits.%s is required", name)
-	}
-	if *actual != want {
-		return fmt.Errorf("candidate limits.%s = %d, want %d", name, *actual, want)
-	}
-	return nil
-}
-func localAICandidateArchiveCandidates(directory string) ([]string, error) {
-	entries, err := os.ReadDir(directory)
-	if err != nil {
-		return nil, fmt.Errorf("read candidate directory: %w", err)
-	}
-	var candidates []string
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasPrefix(entry.Name(), "you_") || !strings.HasSuffix(strings.ToLower(entry.Name()), "_windows_amd64.zip") {
-			continue
-		}
-		if _, err := validateLocalAICandidatePath(filepath.Join(directory, entry.Name()), "candidate archive"); err != nil {
-			return nil, err
-		}
-		candidates = append(candidates, entry.Name())
-	}
-	slices.Sort(candidates)
-	return candidates, nil
-}
-func validateLocalAICandidateArtifact(directory string, artifact localAICandidateArtifact, requireWindowsArchive bool) (localAICandidateArtifactEvidence, error) {
-	if !isLocalAICandidateBasename(artifact.File) {
-		return localAICandidateArtifactEvidence{}, fmt.Errorf("artifact file %q must be a basename", artifact.File)
-	}
-	path := filepath.Join(directory, filepath.FromSlash(artifact.File))
-	info, err := validateLocalAICandidatePath(path, fmt.Sprintf("artifact %s", artifact.Role))
-	if err != nil {
-		return localAICandidateArtifactEvidence{}, err
-	}
-	if artifact.Bytes == nil || info.Size() != *artifact.Bytes {
-		wantBytes := int64(0)
-		if artifact.Bytes != nil {
-			wantBytes = *artifact.Bytes
-		}
-		return localAICandidateArtifactEvidence{}, fmt.Errorf("artifact %s byte count = %d, want %d", artifact.File, info.Size(), wantBytes)
-	}
-	actualSHA256, err := sha256File(path)
-	if err != nil {
-		return localAICandidateArtifactEvidence{}, fmt.Errorf("hash %s: %w", artifact.File, err)
-	}
-	if actualSHA256 != artifact.SHA256 {
-		return localAICandidateArtifactEvidence{}, fmt.Errorf("artifact %s sha256 mismatch: manifest=%s actual=%s", artifact.File, artifact.SHA256, actualSHA256)
-	}
-	if requireWindowsArchive {
-		if err := validateLocalAICandidateArchive(path); err != nil {
-			return localAICandidateArtifactEvidence{}, err
-		}
-	}
-	return localAICandidateArtifactEvidence{Role: artifact.Role, File: artifact.File, Bytes: info.Size(), SHA256: actualSHA256}, nil
-}
-func validateLocalAICandidateArchive(path string) error {
-	archive, err := zip.OpenReader(path)
-	if err != nil {
-		return fmt.Errorf("open archive %s: %w", filepath.Base(path), err)
-	}
-	defer archive.Close()
-	entries := 0
-	for _, entry := range archive.File {
-		if entry.Name != "you.exe" || entry.FileInfo().IsDir() {
-			continue
-		}
-		entries++
-	}
-	if entries != 1 {
-		return fmt.Errorf("archive %s contains %d regular you.exe entries, want exactly 1", filepath.Base(path), entries)
-	}
-	return nil
-}
-func validateLocalAICandidateDetachedDigest(directory, expected string) error {
-	digestPath := filepath.Join(directory, "candidate-manifest.sha256")
-	if _, err := validateLocalAICandidatePath(digestPath, "detached candidate manifest digest"); err != nil {
-		return err
-	}
-	contents, err := os.ReadFile(digestPath)
-	if err != nil {
-		return fmt.Errorf("read detached candidate manifest digest: %w", err)
-	}
-	fields := strings.Fields(string(contents))
-	if len(fields) == 0 || len(fields) > 2 || !localAICandidateSHA256Pattern.MatchString(fields[0]) || fields[0] != expected {
-		return fmt.Errorf("detached candidate manifest digest does not match manifest: expected %s", expected)
-	}
-	if len(fields) == 2 && filepath.Base(filepath.FromSlash(fields[1])) != "candidate-manifest.json" {
-		return fmt.Errorf("detached candidate manifest digest names %q, want candidate-manifest.json", fields[1])
-	}
-	return nil
-}
-func validateLocalAICandidatePath(path, role string) (os.FileInfo, error) {
-	info, err := os.Lstat(path)
-	if err != nil {
-		return nil, fmt.Errorf("inspect %s %q: %w", role, path, err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return nil, fmt.Errorf("%s %q is a symlink/reparse point; candidate paths must be regular in-tree entries", role, path)
-	}
-	absolutePath, err := filepath.Abs(path)
-	if err != nil {
-		return nil, fmt.Errorf("resolve %s %q: %w", role, path, err)
-	}
-	resolvedPath, err := filepath.EvalSymlinks(absolutePath)
-	if err != nil {
-		return nil, fmt.Errorf("resolve %s %q for reparse validation: %w", role, path, err)
-	}
-	absolutePath, resolvedPath = filepath.Clean(absolutePath), filepath.Clean(resolvedPath)
-	pathsEqual := absolutePath == resolvedPath
-	if runtime.GOOS == "windows" {
-		pathsEqual = strings.EqualFold(absolutePath, resolvedPath)
-	}
-	if !pathsEqual {
-		return nil, fmt.Errorf("%s %q resolves through a symlink/reparse point to %q; candidate paths must stay in place", role, path, resolvedPath)
-	}
-	if runtime.GOOS == "windows" && !info.IsDir() && !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("%s %q is a Windows symlink/reparse point or unsupported filesystem entry", role, path)
-	}
-	if info.IsDir() {
-		return info, nil
-	}
-	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("%s %q is not a regular file", role, path)
-	}
-	return info, nil
-}
-func validateLocalAICandidatePreconditions(taskPath string, roots []localAICandidateRoot) error {
-	if localAICandidatePathResolvesYou(taskPath) {
-		return errors.New("task PATH already resolves you; remove ambient you before installation")
-	}
-	seen := make(map[string]string, len(roots))
-	for _, root := range roots {
-		if strings.TrimSpace(root.Name) == "" {
-			return errors.New("declared precondition root has an empty name")
-		}
-		if !filepath.IsAbs(root.Path) {
-			return fmt.Errorf("declared root %q path %q is not absolute", root.Name, root.Path)
-		}
-		key := strings.ToLower(filepath.Clean(root.Path))
-		if previous, exists := seen[key]; exists {
-			return fmt.Errorf("declared roots %q and %q refer to the same path %q", previous, root.Name, root.Path)
-		}
-		seen[key] = root.Name
-		info, err := os.Lstat(root.Path)
-		if os.IsNotExist(err) {
-			continue
-		}
-		if err != nil {
-			return fmt.Errorf("inspect declared root %q: %w", root.Name, err)
-		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("declared root %q is a symlink; it must be absent or empty without following ambient state", root.Name)
-		}
-		if info.IsDir() {
-			entries, readErr := os.ReadDir(root.Path)
-			if readErr != nil {
-				return fmt.Errorf("inspect declared root %q: %w", root.Name, readErr)
-			}
-			if len(entries) != 0 {
-				return fmt.Errorf("declared root %q is not empty", root.Name)
-			}
-			continue
-		}
-		if info.Mode().IsRegular() && info.Size() == 0 {
-			continue
-		}
-		return fmt.Errorf("declared root %q is not absent or empty", root.Name)
-	}
-	return nil
-}
-func localAICandidatePathResolvesYou(pathValue string) bool {
-	for _, directory := range strings.Split(pathValue, string(filepath.ListSeparator)) {
-		directory = strings.TrimSpace(directory)
-		if directory == "" {
-			continue
-		}
-		for _, executable := range []string{"you.exe", "you.cmd", "you.bat", "you.com", "you"} {
-			if info, err := os.Stat(filepath.Join(directory, executable)); err == nil && info.Mode().IsRegular() {
-				return true
-			}
-		}
-	}
-	return false
-}
-func isLocalAICandidateBasename(value string) bool {
-	return value != "" && value == filepath.Base(filepath.FromSlash(value)) && !strings.ContainsAny(value, `/\\`)
-}
-func sha256File(path string) (string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-	hash := sha256.New()
-	if _, err := io.Copy(hash, file); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
-type localAICandidateFixture struct {
-	root         string
-	manifestPath string
-	archiveBytes []byte
-	manifest     localAICandidateManifest
-	roots        []localAICandidateRoot
-	taskPath     string
+func copyLocalAICandidateFile(t *testing.T, sourcePath, destinationPath string) {
+	t.Helper()
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatalf("open %s: %v", sourcePath, err)
+	}
+	defer source.Close()
+	destination, err := os.Create(destinationPath)
+	if err != nil {
+		t.Fatalf("create %s: %v", destinationPath, err)
+	}
+	if _, err := io.Copy(destination, source); err != nil {
+		destination.Close()
+		t.Fatalf("copy %s: %v", destinationPath, err)
+	}
+	if err := destination.Close(); err != nil {
+		t.Fatalf("close %s: %v", destinationPath, err)
+	}
 }
 
-func newLocalAICandidateFixture(t *testing.T) *localAICandidateFixture {
+func writeLocalAICandidateZip(t *testing.T, archivePath, binaryPath string) {
 	t.Helper()
-	root := t.TempDir()
-	archiveBytes := localAICandidateZip(t)
-	archiveName := "you_1.2.3-snapshot-test_windows_amd64.zip"
-	archivePath := filepath.Join(root, archiveName)
-	if err := os.WriteFile(archivePath, archiveBytes, 0o600); err != nil {
-		t.Fatalf("write candidate archive: %v", err)
-	}
-	installerBytes := []byte("Write-Output 'candidate installer'\n")
-	installerPath := filepath.Join(root, "install.ps1")
-	if err := os.WriteFile(installerPath, installerBytes, 0o600); err != nil {
-		t.Fatalf("write candidate installer: %v", err)
-	}
-	executableBytes := []byte("prebuilt-you-executable")
-	executablePath := filepath.Join(root, "you.exe")
-	if err := os.WriteFile(executablePath, executableBytes, 0o600); err != nil {
-		t.Fatalf("write candidate executable: %v", err)
-	}
-	cgoDisabled := false
-	archiveSize := int64(len(archiveBytes))
-	installerSize := int64(len(installerBytes))
-	executableSize := int64(len(executableBytes))
-	manifest := localAICandidateManifest{
-		SchemaVersion: localAICandidateSchemaVersion,
-		Project:       localAICandidateProject,
-		Cycle:         localAICandidateCycle,
-		Source:        localAICandidateSource{Repository: localAICandidateRepository, Commit: localAICandidateSourceCommit, Tree: localAICandidateSourceTree},
-		Build: localAICandidateBuild{
-			CandidateVersion: "1.2.3-snapshot-test", CLIVersion: "1.2.3-snapshot-test",
-			GoVersion: localAICandidateGoVersion, GoReleaserVersion: localAICandidateGoReleaser,
-			GoReleaserConfigSHA256: strings.Repeat("c", sha256.Size*2),
-			Target: localAICandidateTarget{
-				GOOS: localAICandidateGOOS, GOARCH: localAICandidateGOARCH,
-				CgoEnabled: &cgoDisabled,
-			},
-			Environment: map[string]string{"GOPROXY": "file:///C:/cache/download", "GOSUMDB": "off", "GOTOOLCHAIN": "go1.26.8", "npm_config_offline": "true", "GOFLAGS": localAICandidateGOFLAGS, "GOMAXPROCS": localAICandidateGOMAXPROCS},
-		},
-		Artifacts: []localAICandidateArtifact{
-			{Role: "windows-amd64-archive", File: archiveName, Bytes: &archiveSize, SHA256: localAICandidateSHA256(t, archivePath)},
-			{Role: "windows-installer", File: "install.ps1", Bytes: &installerSize, SHA256: localAICandidateSHA256(t, installerPath)},
-			{Role: "windows-amd64-executable", File: "you.exe", Bytes: &executableSize, SHA256: localAICandidateSHA256(t, executablePath)},
-		},
-		Limits: localAICandidateLimits{
-			TemporaryDiskBytesMaximum:     candidateInt64Pointer(localAICandidateTemporaryDiskMaximum),
-			OrdinaryToolDownloadMaximum:   candidateInt64Pointer(localAICandidateToolDownloadMaximum),
-			ModelBackendDownloadMaximum:   candidateInt64Pointer(localAICandidateModelDownloadMaximum),
-			ModelCallsMaximum:             candidateInt64Pointer(localAICandidateModelCallsMaximum),
-			PaidUSDMaximum:                candidateInt64Pointer(localAICandidatePaidUSDMaximum),
-			DescendantMaximum:             candidateInt64Pointer(localAICandidateDescendantMaximum),
-			PackagingOrSmokeRerunsMaximum: candidateInt64Pointer(localAICandidateRerunsMaximum),
-			GOFLAGS:                       localAICandidateGOFLAGS, GOMAXPROCS: localAICandidateGOMAXPROCS,
-		},
-		Attempts: localAICandidateAttempts{
-			PriorCycles:          []string{"030", "040", "042", "045", "048", "050", "063", "067", "068"},
-			Cycle063BuildMaximum: candidateInt64Pointer(1), Cycle063BuildUsed: candidateInt64Pointer(1),
-			Cycle067BuildMaximum: candidateInt64Pointer(2), Cycle067BuildUsed: candidateInt64Pointer(2),
-			Cycle068BuildMaximum: candidateInt64Pointer(1), Cycle068BuildUsed: candidateInt64Pointer(1),
-			Cycle070BuildMaximum: candidateInt64Pointer(1), Cycle070BuildUsed: candidateInt64Pointer(1),
-		},
-	}
-	roots := make([]localAICandidateRoot, 0, 8)
-	for _, name := range []string{"HOME", "USERPROFILE", "install", "config", "state", "models", "backend", "HF"} {
-		pathName := strings.Replace(strings.ToLower(name), "userprofile", "profile", 1)
-		roots = append(roots, localAICandidateRoot{Name: name, Path: filepath.Join(root, pathName)})
-	}
-	fixture := &localAICandidateFixture{
-		root:         root,
-		manifestPath: filepath.Join(root, "candidate-manifest.json"),
-		archiveBytes: archiveBytes,
-		manifest:     manifest,
-		roots:        roots,
-		taskPath:     "",
-	}
-	fixture.writeManifest(t)
-	return fixture
-}
-func (fixture *localAICandidateFixture) writeManifest(t *testing.T) {
-	t.Helper()
-	manifestBytes, err := json.MarshalIndent(fixture.manifest, "", "  ")
+	archive, err := os.Create(archivePath)
 	if err != nil {
-		t.Fatalf("marshal candidate fixture manifest: %v", err)
+		t.Fatalf("create candidate archive: %v", err)
 	}
-	manifestBytes = append(manifestBytes, '\n')
-	if err := os.WriteFile(fixture.manifestPath, manifestBytes, 0o600); err != nil {
-		t.Fatalf("write candidate fixture manifest: %v", err)
+	writer := zip.NewWriter(archive)
+	entry, err := writer.Create("you.exe")
+	if err != nil {
+		t.Fatalf("create candidate archive entry: %v", err)
 	}
-	digest := sha256.Sum256(manifestBytes)
-	digestPath := filepath.Join(fixture.root, "candidate-manifest.sha256")
-	if err := os.WriteFile(digestPath, []byte(hex.EncodeToString(digest[:])+"  candidate-manifest.json\n"), 0o600); err != nil {
-		t.Fatalf("write candidate fixture manifest digest: %v", err)
+	binary, err := os.Open(binaryPath)
+	if err != nil {
+		t.Fatalf("open staged candidate: %v", err)
 	}
-}
-func localAICandidateZip(t *testing.T) []byte {
-	t.Helper()
-	var buffer bytes.Buffer
-	writer := zip.NewWriter(&buffer)
-	for name, contents := range map[string][]byte{
-		"you.exe":   []byte("prebuilt-you-executable"),
-		"README.md": []byte("candidate documentation"),
-	} {
-		entry, err := writer.Create(name)
-		if err != nil {
-			t.Fatalf("create candidate ZIP entry %q: %v", name, err)
-		}
-		if _, err := entry.Write(contents); err != nil {
-			t.Fatalf("write candidate ZIP entry %q: %v", name, err)
-		}
+	if _, err := io.Copy(entry, binary); err != nil {
+		binary.Close()
+		t.Fatalf("write candidate archive entry: %v", err)
+	}
+	if err := binary.Close(); err != nil {
+		t.Fatalf("close staged candidate: %v", err)
 	}
 	if err := writer.Close(); err != nil {
-		t.Fatalf("close candidate ZIP: %v", err)
+		t.Fatalf("close candidate archive: %v", err)
 	}
-	return buffer.Bytes()
-}
-func localAICandidateSHA256(t *testing.T, path string) string {
-	t.Helper()
-	digest, err := sha256File(path)
-	if err != nil {
-		t.Fatalf("hash candidate fixture %q: %v", path, err)
+	if err := archive.Close(); err != nil {
+		t.Fatalf("close candidate archive file: %v", err)
 	}
-	return digest
 }
-func localAICandidateCleanBuildInfo() *debug.BuildInfo {
-	return &debug.BuildInfo{Settings: []debug.BuildSetting{
-		{Key: "vcs.revision", Value: localAICandidateSourceCommit},
-		{Key: "vcs.modified", Value: "false"},
-	}}
-}
-func candidateInt64Pointer(value int64) *int64 { return &value }

--- a/tests/release/localai_install_candidate_test.go
+++ b/tests/release/localai_install_candidate_test.go
@@ -144,6 +144,22 @@ type localAICandidateDiskObserver struct {
 	PeakDeltaBytes         int64  `json:"peakDeltaBytes"`
 	Error                  string `json:"error"`
 }
+type localAICandidateRootOutputStream struct {
+	Status        string `json:"status"`
+	Path          string `json:"path"`
+	Present       bool   `json:"present"`
+	TotalBytes    int64  `json:"totalBytes"`
+	CapturedBytes int64  `json:"capturedBytes"`
+	Truncated     bool   `json:"truncated"`
+	RedactedBytes int64  `json:"redactedBytes"`
+	SHA256        string `json:"sha256"`
+}
+type localAICandidateRootOutput struct {
+	Status       string                           `json:"status"`
+	MaximumBytes int64                            `json:"maximumBytes"`
+	Stdout       localAICandidateRootOutputStream `json:"stdout"`
+	Stderr       localAICandidateRootOutputStream `json:"stderr"`
+}
 type localAICandidateObserverEvidence struct {
 	Environment            map[string]string                      `json:"environment"`
 	ProcessNetworkObserver localAICandidateProcessNetworkObserver `json:"processNetworkObserver"`
@@ -151,6 +167,7 @@ type localAICandidateObserverEvidence struct {
 	DescendantMaximum      int64                                  `json:"descendantMaximum"`
 	DescendantHighWater    int64                                  `json:"descendantHighWater"`
 	RootExitCode           *int64                                 `json:"rootExitCode"`
+	RootOutput             localAICandidateRootOutput             `json:"rootOutput"`
 	FailurePropagation     string                                 `json:"failurePropagation"`
 	ModelBackendBytes      int64                                  `json:"modelBackendBytes"`
 	ModelBackendCalls      int64                                  `json:"modelBackendCalls"`
@@ -177,6 +194,39 @@ type localAICandidateReleaseCheckoutEvidence struct {
 	StatusCleanDuringOutput     bool     `json:"statusCleanDuringOutput"`
 	StatusCleanAfterOutput      bool     `json:"statusCleanAfterOutput"`
 	StatusChecks                int      `json:"statusChecks"`
+}
+type localAICandidateDependencyManifestEvidence struct {
+	Status            string `json:"status"`
+	ManifestPath      string `json:"manifestPath"`
+	ManifestSHA256    string `json:"manifestSHA256"`
+	EntryCount        int64  `json:"entryCount"`
+	FileCount         int64  `json:"fileCount"`
+	DirectoryCount    int64  `json:"directoryCount"`
+	JunctionCount     int64  `json:"junctionCount"`
+	SymbolicLinkCount int64  `json:"symbolicLinkCount"`
+	TotalBytes        int64  `json:"totalBytes"`
+}
+type localAICandidateDependencyReport struct {
+	SchemaVersion  string                                     `json:"schemaVersion"`
+	Status         string                                     `json:"status"`
+	Phase          string                                     `json:"phase"`
+	SourceRoot     string                                     `json:"sourceRoot"`
+	StageRoot      string                                     `json:"stageRoot"`
+	PackageInstall string                                     `json:"packageInstallation"`
+	SourceManifest localAICandidateDependencyManifestEvidence `json:"sourceManifest"`
+	StageManifest  localAICandidateDependencyManifestEvidence `json:"stageManifest"`
+	SourceLock     any                                        `json:"sourceLockClosure"`
+	StageLock      any                                        `json:"stageLockClosure"`
+	Copy           any                                        `json:"copy"`
+	Equality       struct {
+		SourceStageManifestEqual  bool  `json:"sourceStageManifestEqual"`
+		SourceStagePostBuildEqual bool  `json:"sourceStagePostBuildEqual"`
+		SourceEntryCount          int64 `json:"sourceEntryCount"`
+		StageEntryCount           int64 `json:"stageEntryCount"`
+		SourceTotalBytes          int64 `json:"sourceTotalBytes"`
+		StageTotalBytes           int64 `json:"stageTotalBytes"`
+	} `json:"equality"`
+	Error string `json:"error"`
 }
 type localAICandidateObserverReport struct {
 	SchemaVersion   string                                   `json:"schemaVersion"`
@@ -639,7 +689,52 @@ func TestLocalAICandidateObserverEnvelopeFixture(t *testing.T) {
 	if report.Cleanup.Status != "PASS" || len(report.Cleanup.RemainingTaskPaths) != 0 || len(report.Cleanup.Errors) != 0 {
 		t.Fatalf("observer cleanup evidence = %#v, want complete cleanup", report.Cleanup)
 	}
+	for _, stream := range []localAICandidateRootOutputStream{report.Observation.RootOutput.Stdout, report.Observation.RootOutput.Stderr} {
+		contents, err := os.ReadFile(stream.Path)
+		if err != nil {
+			t.Fatalf("read retained root output %q: %v", stream.Path, err)
+		}
+		if strings.Contains(string(contents), "observer-secret") || !strings.Contains(string(contents), "<redacted>") {
+			t.Fatalf("retained root output %q was not redacted: %q", stream.Path, contents)
+		}
+	}
 	t.Logf("LOCALAI-OBSERVER status=PASS evidence=%s", raw)
+}
+func TestLocalAICandidateObserverRootFailureRetainsOutput(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows observer fixture is only available on Windows")
+	}
+	reportPath := filepath.Join(t.TempDir(), "observer-failure-report.json")
+	command := localAICandidatePowerShellCommand(t, "-InstallDir", t.TempDir(), "-ObserverFixture", "-ObserverRootExitCode", "7", "-ObserverReportPath", reportPath)
+	command.Env = append(os.Environ(), "GOFLAGS="+localAICandidateGOFLAGS, "GOMAXPROCS="+localAICandidateGOMAXPROCS)
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("observer failure fixture unexpectedly succeeded: %s", output)
+	}
+	raw, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("read observer failure report: %v\n%s", err, output)
+	}
+	var report localAICandidateObserverReport
+	if err := decodeLocalAICandidateJSON(raw, &report); err != nil {
+		t.Fatalf("decode observer failure report: %v", err)
+	}
+	if report.Status != "FAIL" || report.Observation.RootExitCode == nil || *report.Observation.RootExitCode != 7 || report.Observation.FailurePropagation != "FAIL" {
+		t.Fatalf("observer failure evidence = %#v, want exit 7 and failure propagation", report.Observation)
+	}
+	if report.Observation.RootOutput.Status != "PASS" || report.Cleanup.Status != "PASS" {
+		t.Fatalf("observer failure output/cleanup evidence = %#v / %#v, want retained output and cleanup", report.Observation.RootOutput, report.Cleanup)
+	}
+	for _, stream := range []localAICandidateRootOutputStream{report.Observation.RootOutput.Stdout, report.Observation.RootOutput.Stderr} {
+		contents, err := os.ReadFile(stream.Path)
+		if err != nil {
+			t.Fatalf("read retained failed-root output %q: %v", stream.Path, err)
+		}
+		if strings.Contains(string(contents), "observer-secret") || !strings.Contains(string(contents), "<redacted>") {
+			t.Fatalf("failed-root output %q was not redacted: %q", stream.Path, contents)
+		}
+	}
+	t.Logf("LOCALAI-OBSERVER-FAILURE status=PASS evidence=%s", raw)
 }
 func TestLocalAICandidateObserverIdentityFixture(t *testing.T) {
 	if runtime.GOOS != "windows" {
@@ -763,6 +858,239 @@ func TestLocalAICandidateReleaseCheckoutPreparation(t *testing.T) {
 	}
 	t.Logf("LOCALAI-CLONE status=PASS evidence=%s", raw)
 }
+func TestLocalAICandidateDependencyStageCopiesExactContainedClosure(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows dependency staging is only available on Windows")
+	}
+	fixtureRoot := t.TempDir()
+	sourceRepo := filepath.Join(fixtureRoot, "source-repo")
+	stageRepo := filepath.Join(fixtureRoot, "stage-repo")
+	if err := os.MkdirAll(sourceRepo, 0o700); err != nil {
+		t.Fatalf("create source repository: %v", err)
+	}
+	if err := os.MkdirAll(stageRepo, 0o700); err != nil {
+		t.Fatalf("create stage repository: %v", err)
+	}
+	localAICandidateWriteDependencyFixture(t, sourceRepo, true)
+	localAICandidateWriteDependencyFixture(t, stageRepo, false)
+	sourceUI := filepath.Join(sourceRepo, "ui")
+	stageUI := filepath.Join(stageRepo, "ui")
+	sourceNodeModules := filepath.Join(sourceUI, "node_modules")
+	stageNodeModules := filepath.Join(stageUI, "node_modules")
+	stageEvidence := filepath.Join(fixtureRoot, "evidence")
+	if err := os.MkdirAll(stageEvidence, 0o700); err != nil {
+		t.Fatalf("create dependency evidence root: %v", err)
+	}
+	lockPath := filepath.Join(sourceUI, "bun.lock")
+	lockSHA256, err := sha256File(lockPath)
+	if err != nil {
+		t.Fatalf("hash fixture lock: %v", err)
+	}
+	lockBlob := localAICandidateRunGit(t, sourceRepo, "rev-parse", "HEAD:ui/bun.lock")
+	command := localAICandidatePowerShellCommand(t,
+		"-InstallDir", stageEvidence,
+		"-StageDependencyClosure",
+		"-DependencySourceRoot", sourceNodeModules,
+		"-DependencyStageRoot", stageNodeModules,
+		"-DependencySourceManifestPath", filepath.Join(stageEvidence, "source-manifest.jsonl"),
+		"-DependencyStageManifestPath", filepath.Join(stageEvidence, "stage-manifest.jsonl"),
+		"-DependencyReportPath", filepath.Join(stageEvidence, "stage-report.json"),
+		"-DependencyExpectedLockSHA256", lockSHA256,
+		"-DependencyExpectedLockBlob", lockBlob,
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		reportBytes, _ := os.ReadFile(filepath.Join(stageEvidence, "stage-report.json"))
+		t.Fatalf("exact dependency staging: %v\n%s\nreport=%s", err, output, reportBytes)
+	}
+	var report localAICandidateDependencyReport
+	raw, err := os.ReadFile(filepath.Join(stageEvidence, "stage-report.json"))
+	if err != nil {
+		t.Fatalf("read dependency stage report: %v", err)
+	}
+	if err := decodeLocalAICandidateJSON(raw, &report); err != nil {
+		t.Fatalf("decode dependency stage report: %v", err)
+	}
+	if report.SchemaVersion != "localai-windows-install-candidate-dependency-stage/v1" || report.Status != "PASS" || report.Phase != "stage" || report.PackageInstall != "NOT_RUN" || !report.Equality.SourceStageManifestEqual || report.SourceManifest.EntryCount != 4 || report.StageManifest.EntryCount != 4 || report.SourceManifest.ManifestSHA256 != report.StageManifest.ManifestSHA256 || report.Error != "" {
+		t.Fatalf("dependency stage evidence = %#v, want exact no-install closure copy", report)
+	}
+	if _, err := os.Stat(filepath.Join(stageNodeModules, "dep", "index.js")); err != nil {
+		t.Fatalf("staged dependency content missing: %v", err)
+	}
+	indexPath := filepath.Join(stageNodeModules, "dep", "index.js")
+	originalIndex, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("read staged dependency fixture before mutation: %v", err)
+	}
+	if err := os.WriteFile(indexPath, []byte("module.exports = false;\n"), 0o600); err != nil {
+		t.Fatalf("mutate staged dependency fixture: %v", err)
+	}
+	mutationReportPath := filepath.Join(stageEvidence, "post-build-mutation-report.json")
+	mutationCommand := localAICandidatePowerShellCommand(t,
+		"-InstallDir", stageEvidence,
+		"-VerifyDependencyClosure",
+		"-DependencySourceRoot", sourceNodeModules,
+		"-DependencyStageRoot", stageNodeModules,
+		"-DependencyExpectedManifestPath", filepath.Join(stageEvidence, "stage-manifest.jsonl"),
+		"-DependencyPostBuildManifestPath", filepath.Join(stageEvidence, "post-build-mutation-manifest.jsonl"),
+		"-DependencySourceAfterManifestPath", filepath.Join(stageEvidence, "source-after-mutation-manifest.jsonl"),
+		"-DependencyReportPath", mutationReportPath,
+		"-DependencyExpectedLockSHA256", lockSHA256,
+		"-DependencyExpectedLockBlob", lockBlob,
+	)
+	mutationOutput, mutationErr := mutationCommand.CombinedOutput()
+	if mutationErr == nil {
+		t.Fatalf("post-build dependency mutation unexpectedly passed\n%s", mutationOutput)
+	}
+	mutationReportBytes, err := os.ReadFile(mutationReportPath)
+	if err != nil {
+		t.Fatalf("read post-build mutation report: %v", err)
+	}
+	var mutationReport struct {
+		Status string `json:"status"`
+		Error  string `json:"error"`
+	}
+	if err := json.Unmarshal(mutationReportBytes, &mutationReport); err != nil {
+		t.Fatalf("decode post-build mutation report: %v", err)
+	}
+	if mutationReport.Status != "FAIL" || !strings.Contains(mutationReport.Error, "differs") {
+		t.Fatalf("post-build mutation evidence = %#v, want fail-closed equality drift", mutationReport)
+	}
+	if err := os.WriteFile(indexPath, originalIndex, 0o600); err != nil {
+		t.Fatalf("restore staged dependency fixture: %v", err)
+	}
+	verifyCommand := localAICandidatePowerShellCommand(t,
+		"-InstallDir", stageEvidence,
+		"-VerifyDependencyClosure",
+		"-DependencySourceRoot", sourceNodeModules,
+		"-DependencyStageRoot", stageNodeModules,
+		"-DependencyExpectedManifestPath", filepath.Join(stageEvidence, "stage-manifest.jsonl"),
+		"-DependencyPostBuildManifestPath", filepath.Join(stageEvidence, "post-build-manifest.jsonl"),
+		"-DependencySourceAfterManifestPath", filepath.Join(stageEvidence, "source-after-manifest.jsonl"),
+		"-DependencyReportPath", filepath.Join(stageEvidence, "post-build-report.json"),
+		"-DependencyExpectedLockSHA256", lockSHA256,
+		"-DependencyExpectedLockBlob", lockBlob,
+	)
+	verifyOutput, err := verifyCommand.CombinedOutput()
+	if err != nil {
+		t.Fatalf("post-build dependency equality verification: %v\n%s", err, verifyOutput)
+	}
+	verifyReportBytes, err := os.ReadFile(filepath.Join(stageEvidence, "post-build-report.json"))
+	if err != nil {
+		t.Fatalf("read post-build report: %v", err)
+	}
+	var verifyReport struct {
+		Status   string `json:"status"`
+		Phase    string `json:"phase"`
+		Equality struct {
+			SourceStagePostBuildEqual bool `json:"sourceStagePostBuildEqual"`
+		} `json:"equality"`
+	}
+	if err := json.Unmarshal(verifyReportBytes, &verifyReport); err != nil {
+		t.Fatalf("decode post-build report: %v", err)
+	}
+	if verifyReport.Status != "PASS" || verifyReport.Phase != "post-build" || !verifyReport.Equality.SourceStagePostBuildEqual {
+		t.Fatalf("post-build equality evidence = %#v, want source/stage/post-build equality", verifyReport)
+	}
+	t.Logf("LOCALAI-STAGE status=PASS evidence=%s", raw)
+}
+func TestLocalAICandidateDependencyStageRejectsMissingRequiredPackage(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows dependency staging is only available on Windows")
+	}
+	fixtureRoot := t.TempDir()
+	sourceRepo := filepath.Join(fixtureRoot, "source-repo")
+	stageRepo := filepath.Join(fixtureRoot, "stage-repo")
+	for _, repository := range []string{sourceRepo, stageRepo} {
+		if err := os.MkdirAll(repository, 0o700); err != nil {
+			t.Fatalf("create fixture repository: %v", err)
+		}
+	}
+	localAICandidateWriteDependencyFixture(t, sourceRepo, true)
+	localAICandidateWriteDependencyFixture(t, stageRepo, false)
+	sourceUI := filepath.Join(sourceRepo, "ui")
+	missingManifest := filepath.Join(sourceUI, "node_modules", "dep", "package.json")
+	if err := os.Remove(missingManifest); err != nil {
+		t.Fatalf("remove required fixture package: %v", err)
+	}
+	localAICandidateRunGit(t, sourceRepo, "add", "-A")
+	localAICandidateRunGit(t, sourceRepo, "commit", "-m", "remove required package")
+	lockPath := filepath.Join(sourceUI, "bun.lock")
+	lockSHA256, err := sha256File(lockPath)
+	if err != nil {
+		t.Fatalf("hash fixture lock: %v", err)
+	}
+	lockBlob := localAICandidateRunGit(t, sourceRepo, "rev-parse", "HEAD:ui/bun.lock")
+	evidenceRoot := filepath.Join(fixtureRoot, "evidence")
+	if err := os.MkdirAll(evidenceRoot, 0o700); err != nil {
+		t.Fatalf("create failure evidence root: %v", err)
+	}
+	command := localAICandidatePowerShellCommand(t,
+		"-InstallDir", evidenceRoot,
+		"-StageDependencyClosure",
+		"-DependencySourceRoot", filepath.Join(sourceUI, "node_modules"),
+		"-DependencyStageRoot", filepath.Join(stageRepo, "ui", "node_modules"),
+		"-DependencySourceManifestPath", filepath.Join(evidenceRoot, "source-manifest.jsonl"),
+		"-DependencyStageManifestPath", filepath.Join(evidenceRoot, "stage-manifest.jsonl"),
+		"-DependencyReportPath", filepath.Join(evidenceRoot, "stage-report.json"),
+		"-DependencyExpectedLockSHA256", lockSHA256,
+		"-DependencyExpectedLockBlob", lockBlob,
+	)
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("missing required dependency unexpectedly passed\n%s", output)
+	}
+	var report localAICandidateDependencyReport
+	raw, readErr := os.ReadFile(filepath.Join(evidenceRoot, "stage-report.json"))
+	if readErr != nil {
+		t.Fatalf("read dependency failure report: %v\n%s", readErr, output)
+	}
+	if decodeErr := decodeLocalAICandidateJSON(raw, &report); decodeErr != nil {
+		t.Fatalf("decode dependency failure report: %v", decodeErr)
+	}
+	if report.Status != "FAIL" || !strings.Contains(report.Error, "missing required package") {
+		t.Fatalf("dependency failure evidence = %#v, want fail-closed missing package", report)
+	}
+	t.Logf("LOCALAI-STAGE-FAILURE status=PASS evidence=%s", raw)
+}
+func localAICandidateWriteDependencyFixture(t *testing.T, repository string, includeDependency bool) {
+	t.Helper()
+	uiRoot := filepath.Join(repository, "ui")
+	workspaceRoot := filepath.Join(uiRoot, "packages", "app")
+	if err := os.MkdirAll(workspaceRoot, 0o700); err != nil {
+		t.Fatalf("create fixture workspace: %v", err)
+	}
+	dependencyName := "dep"
+	rootPackage := fmt.Sprintf(`{"name":"fixture-root","private":true,"workspaces":["packages/*"],"dependencies":{"%s":"1.0.0"},"devDependencies":{},"optionalDependencies":{}}`, dependencyName)
+	workspacePackage := fmt.Sprintf(`{"name":"fixture-app","dependencies":{"%s":"1.0.0"},"devDependencies":{},"optionalDependencies":{}}`, dependencyName)
+	lock := fmt.Sprintf(`{"lockfileVersion":1,"configVersion":0,"workspaces":{"":{"name":"fixture-root","dependencies":{"%s":"1.0.0"},"devDependencies":{},"optionalDependencies":{}},"packages/app":{"name":"fixture-app","dependencies":{"%s":"1.0.0"},"devDependencies":{},"optionalDependencies":{}}},"packages":{"dep@1.0.0":["dep@1.0.0","",{},""]}}`, dependencyName, dependencyName)
+	for path, contents := range map[string]string{
+		filepath.Join(uiRoot, "package.json"):        rootPackage,
+		filepath.Join(workspaceRoot, "package.json"): workspacePackage,
+		filepath.Join(uiRoot, "bun.lock"):            lock,
+	} {
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("write fixture file %s: %v", path, err)
+		}
+	}
+	if includeDependency {
+		dependencyRoot := filepath.Join(uiRoot, "node_modules", dependencyName)
+		if err := os.MkdirAll(dependencyRoot, 0o700); err != nil {
+			t.Fatalf("create fixture dependency: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dependencyRoot, "package.json"), []byte(`{"name":"dep","version":"1.0.0","dependencies":{},"optionalDependencies":{},"peerDependencies":{}}`), 0o600); err != nil {
+			t.Fatalf("write fixture dependency manifest: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dependencyRoot, "index.js"), []byte("module.exports = true;\n"), 0o600); err != nil {
+			t.Fatalf("write fixture dependency file: %v", err)
+		}
+	}
+	localAICandidateRunGit(t, repository, "init")
+	localAICandidateRunGit(t, repository, "config", "user.email", "fixture@example.invalid")
+	localAICandidateRunGit(t, repository, "config", "user.name", "dependency-fixture")
+	localAICandidateRunGit(t, repository, "add", ".")
+	localAICandidateRunGit(t, repository, "commit", "-m", "dependency fixture")
+}
 func validateLocalAICandidateObserverEvidence(observation localAICandidateObserverEvidence) error {
 	process := observation.ProcessNetworkObserver
 	if process.Status != "PASS" || !process.StartedBeforeRoot || !process.ContinuedThroughDescendantExit || process.MaximumGapMilliseconds < 0 || process.MaximumGapMilliseconds > localAICandidateProcessNetworkGapMaximum || process.NonLoopbackConnections != 0 || process.ExternalTransferBytes != 0 || process.SampleCount <= 0 || process.TCPTableQueries != process.SampleCount || process.ZeroConnectionSamples <= 0 || process.OwnedConnectionMatches < 0 || process.OwnedProcessIdentityCount <= 0 || process.QueryMode != localAICandidateObserverQueryMode || len(process.ForbiddenProcesses) != 0 || process.Error != "" {
@@ -778,6 +1106,18 @@ func validateLocalAICandidateObserverEvidence(observation localAICandidateObserv
 	if observation.RootExitCode == nil {
 		return errors.New("root exit code is required before process disposal")
 	}
+	rootOutput := observation.RootOutput
+	if rootOutput.Status != "PASS" || rootOutput.MaximumBytes <= 0 {
+		return fmt.Errorf("invalid root output evidence: %#v", rootOutput)
+	}
+	for name, stream := range map[string]localAICandidateRootOutputStream{"stdout": rootOutput.Stdout, "stderr": rootOutput.Stderr} {
+		if stream.Status != "PASS" || !stream.Present || !filepath.IsAbs(stream.Path) || stream.TotalBytes < 0 || stream.CapturedBytes < 0 || stream.CapturedBytes > stream.TotalBytes || stream.CapturedBytes > rootOutput.MaximumBytes || stream.RedactedBytes < 0 || !localAICandidateSHA256Pattern.MatchString(stream.SHA256) {
+			return fmt.Errorf("invalid root %s output evidence: %#v", name, stream)
+		}
+		if stream.Truncated != (stream.TotalBytes > rootOutput.MaximumBytes) {
+			return fmt.Errorf("root %s truncation metadata does not match byte counts: %#v", name, stream)
+		}
+	}
 	if *observation.RootExitCode != 0 || observation.FailurePropagation != "PASS" || observation.ModelBackendBytes != 0 || observation.ModelBackendCalls != 0 {
 		return fmt.Errorf("invalid observer completion evidence: %#v", observation)
 	}
@@ -785,6 +1125,7 @@ func validateLocalAICandidateObserverEvidence(observation localAICandidateObserv
 }
 func TestLocalAICandidateObserverEvidenceRejectsUnprovenSamples(t *testing.T) {
 	rootExitCode := int64(0)
+	rootOutputPath := filepath.Join(os.TempDir(), "localai-observer-output.txt")
 	base := localAICandidateObserverEvidence{
 		ProcessNetworkObserver: localAICandidateProcessNetworkObserver{
 			StartedBeforeRoot: true, ContinuedThroughDescendantExit: true, MaximumGapMilliseconds: 1,
@@ -795,7 +1136,13 @@ func TestLocalAICandidateObserverEvidenceRejectsUnprovenSamples(t *testing.T) {
 		DescendantMaximum:   localAICandidateDescendantMaximum,
 		DescendantHighWater: 1,
 		RootExitCode:        &rootExitCode,
-		FailurePropagation:  "PASS",
+		RootOutput: localAICandidateRootOutput{
+			Status:       "PASS",
+			MaximumBytes: 1024,
+			Stdout:       localAICandidateRootOutputStream{Status: "PASS", Path: rootOutputPath, Present: true, TotalBytes: 10, CapturedBytes: 10, SHA256: strings.Repeat("a", sha256.Size*2)},
+			Stderr:       localAICandidateRootOutputStream{Status: "PASS", Path: rootOutputPath, Present: true, TotalBytes: 10, CapturedBytes: 10, SHA256: strings.Repeat("b", sha256.Size*2)},
+		},
+		FailurePropagation: "PASS",
 	}
 	tests := []struct {
 		name string
@@ -818,6 +1165,8 @@ func TestLocalAICandidateObserverEvidenceRejectsUnprovenSamples(t *testing.T) {
 			evidence.DiskObserver.MaximumGapMilliseconds = localAICandidateDiskGapMaximum + 1
 		}},
 		{name: "disk error", edit: func(evidence *localAICandidateObserverEvidence) { evidence.DiskObserver.Error = "disk sample failed" }},
+		{name: "root output missing", edit: func(evidence *localAICandidateObserverEvidence) { evidence.RootOutput.Stdout.Present = false }},
+		{name: "root output hash missing", edit: func(evidence *localAICandidateObserverEvidence) { evidence.RootOutput.Stderr.SHA256 = "" }},
 	}
 	for _, test := range tests {
 		test := test

--- a/tests/release/localai_install_candidate_test.go
+++ b/tests/release/localai_install_candidate_test.go
@@ -877,6 +877,13 @@ func TestLocalAICandidateDependencyStageCopiesExactContainedClosure(t *testing.T
 	stageUI := filepath.Join(stageRepo, "ui")
 	sourceNodeModules := filepath.Join(sourceUI, "node_modules")
 	stageNodeModules := filepath.Join(stageUI, "node_modules")
+	linkPath := filepath.Join(sourceNodeModules, "workspace-link")
+	linkTarget := filepath.Join(sourceUI, "packages", "app")
+	linkCommand := exec.Command("cmd.exe", "/c", "mklink", "/J", linkPath, linkTarget)
+	if output, err := linkCommand.CombinedOutput(); err != nil {
+		t.Skipf("contained junction fixture unavailable: %v (%s)", err, output)
+	}
+	t.Cleanup(func() { _ = os.Remove(linkPath) })
 	stageEvidence := filepath.Join(fixtureRoot, "evidence")
 	if err := os.MkdirAll(stageEvidence, 0o700); err != nil {
 		t.Fatalf("create dependency evidence root: %v", err)
@@ -911,11 +918,17 @@ func TestLocalAICandidateDependencyStageCopiesExactContainedClosure(t *testing.T
 	if err := decodeLocalAICandidateJSON(raw, &report); err != nil {
 		t.Fatalf("decode dependency stage report: %v", err)
 	}
-	if report.SchemaVersion != "localai-windows-install-candidate-dependency-stage/v1" || report.Status != "PASS" || report.Phase != "stage" || report.PackageInstall != "NOT_RUN" || !report.Equality.SourceStageManifestEqual || report.SourceManifest.EntryCount != 4 || report.StageManifest.EntryCount != 4 || report.SourceManifest.ManifestSHA256 != report.StageManifest.ManifestSHA256 || report.Error != "" {
+	if report.SchemaVersion != "localai-windows-install-candidate-dependency-stage/v1" || report.Status != "PASS" || report.Phase != "stage" || report.PackageInstall != "NOT_RUN" || !report.Equality.SourceStageManifestEqual || report.SourceManifest.EntryCount != 5 || report.StageManifest.EntryCount != 5 || report.SourceManifest.JunctionCount != 1 || report.StageManifest.JunctionCount != 1 || report.SourceManifest.ManifestSHA256 != report.StageManifest.ManifestSHA256 || report.Error != "" {
 		t.Fatalf("dependency stage evidence = %#v, want exact no-install closure copy", report)
+	}
+	if copyEvidence, ok := report.Copy.(map[string]any); !ok || copyEvidence["rewrittenLinks"] != float64(1) {
+		t.Fatalf("dependency stage copy evidence = %#v, want one rewritten contained junction", report.Copy)
 	}
 	if _, err := os.Stat(filepath.Join(stageNodeModules, "dep", "index.js")); err != nil {
 		t.Fatalf("staged dependency content missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stageNodeModules, "workspace-link", "package.json")); err != nil {
+		t.Fatalf("staged contained junction target missing: %v", err)
 	}
 	indexPath := filepath.Join(stageNodeModules, "dep", "index.js")
 	originalIndex, err := os.ReadFile(indexPath)
@@ -993,6 +1006,70 @@ func TestLocalAICandidateDependencyStageCopiesExactContainedClosure(t *testing.T
 		t.Fatalf("post-build equality evidence = %#v, want source/stage/post-build equality", verifyReport)
 	}
 	t.Logf("LOCALAI-STAGE status=PASS evidence=%s", raw)
+}
+func TestLocalAICandidateDependencyStageRejectsExternalLink(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows dependency staging is only available on Windows")
+	}
+	fixtureRoot := t.TempDir()
+	sourceRepo := filepath.Join(fixtureRoot, "source-repo")
+	stageRepo := filepath.Join(fixtureRoot, "stage-repo")
+	for _, repository := range []string{sourceRepo, stageRepo} {
+		if err := os.MkdirAll(repository, 0o700); err != nil {
+			t.Fatalf("create fixture repository: %v", err)
+		}
+	}
+	localAICandidateWriteDependencyFixture(t, sourceRepo, true)
+	localAICandidateWriteDependencyFixture(t, stageRepo, false)
+	sourceUI := filepath.Join(sourceRepo, "ui")
+	externalTarget := filepath.Join(fixtureRoot, "external-target")
+	if err := os.MkdirAll(externalTarget, 0o700); err != nil {
+		t.Fatalf("create external link target: %v", err)
+	}
+	externalLink := filepath.Join(sourceUI, "node_modules", "external-link")
+	linkCommand := exec.Command("cmd.exe", "/c", "mklink", "/J", externalLink, externalTarget)
+	if output, err := linkCommand.CombinedOutput(); err != nil {
+		t.Skipf("external junction fixture unavailable: %v (%s)", err, output)
+	}
+	t.Cleanup(func() { _ = os.Remove(externalLink) })
+	lockPath := filepath.Join(sourceUI, "bun.lock")
+	lockSHA256, err := sha256File(lockPath)
+	if err != nil {
+		t.Fatalf("hash fixture lock: %v", err)
+	}
+	lockBlob := localAICandidateRunGit(t, sourceRepo, "rev-parse", "HEAD:ui/bun.lock")
+	evidenceRoot := filepath.Join(fixtureRoot, "evidence")
+	if err := os.MkdirAll(evidenceRoot, 0o700); err != nil {
+		t.Fatalf("create dependency evidence root: %v", err)
+	}
+	reportPath := filepath.Join(evidenceRoot, "stage-report.json")
+	command := localAICandidatePowerShellCommand(t,
+		"-InstallDir", evidenceRoot,
+		"-StageDependencyClosure",
+		"-DependencySourceRoot", filepath.Join(sourceUI, "node_modules"),
+		"-DependencyStageRoot", filepath.Join(stageRepo, "ui", "node_modules"),
+		"-DependencySourceManifestPath", filepath.Join(evidenceRoot, "source-manifest.jsonl"),
+		"-DependencyStageManifestPath", filepath.Join(evidenceRoot, "stage-manifest.jsonl"),
+		"-DependencyReportPath", reportPath,
+		"-DependencyExpectedLockSHA256", lockSHA256,
+		"-DependencyExpectedLockBlob", lockBlob,
+	)
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("external dependency junction unexpectedly passed\n%s", output)
+	}
+	var report localAICandidateDependencyReport
+	raw, readErr := os.ReadFile(reportPath)
+	if readErr != nil {
+		t.Fatalf("read external-link failure report: %v\n%s", readErr, output)
+	}
+	if decodeErr := decodeLocalAICandidateJSON(raw, &report); decodeErr != nil {
+		t.Fatalf("decode external-link failure report: %v", decodeErr)
+	}
+	if report.Status != "FAIL" || !strings.Contains(report.Error, "outside the contained root") {
+		t.Fatalf("external-link failure evidence = %#v, want containment rejection", report)
+	}
+	t.Logf("LOCALAI-STAGE-EXTERNAL-LINK status=PASS evidence=%s", raw)
 }
 func TestLocalAICandidateDependencyStageRejectsMissingRequiredPackage(t *testing.T) {
 	if runtime.GOOS != "windows" {

--- a/tests/release/localai_install_candidate_test.go
+++ b/tests/release/localai_install_candidate_test.go
@@ -20,7 +20,12 @@ import (
 	"github.com/portpowered/infinite-you/internal/testutil"
 )
 
-const localAICandidateSourceCommit = "059474b2c00915865306a33ca5e3d02b618bb6f0"
+const (
+	localAICandidateSourceCommit      = "059474b2c00915865306a33ca5e3d02b618bb6f0"
+	localAICandidateNativeToolVersion = "0.27.7"
+	localAICandidateNativeToolSHA256  = "44ce6728d54c891b1c5a6d7dbfb1a0f13419884cca0b090f1fbcf0dcd8bee0e9"
+	localAICandidateNativeToolBytes   = int64(11386368)
+)
 
 func TestLocalAICandidateScriptParses(t *testing.T) {
 	t.Parallel()
@@ -510,6 +515,57 @@ func localAICandidateRunGit(t *testing.T, directory string, arguments ...string)
 	command := exec.Command("git", append([]string{"-C", directory}, arguments...)...)
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("git %v: %v\n%s", arguments, err, output)
+	}
+}
+
+func TestLocalAICandidateCopiesNativeToolToShortPath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell candidate delivery is Windows-only")
+	}
+	sourcePath := strings.TrimSpace(os.Getenv("INFINITE_YOU_LOCALAI_ESBUILD_BINARY"))
+	if sourcePath == "" {
+		t.Skip("set INFINITE_YOU_LOCALAI_ESBUILD_BINARY to the verified esbuild executable")
+	}
+	if !filepath.IsAbs(sourcePath) {
+		t.Fatalf("INFINITE_YOU_LOCALAI_ESBUILD_BINARY must be absolute: %s", sourcePath)
+	}
+
+	tempDir := t.TempDir()
+	destinationPath := filepath.Join(tempDir, "esbuild-native.exe")
+	stdoutPath := filepath.Join(tempDir, "esbuild.stdout")
+	stderrPath := filepath.Join(tempDir, "esbuild.stderr")
+	harnessPath := filepath.Join(tempDir, "native-tool.ps1")
+	harness := fmt.Sprintf(`
+. %s -InstallDir %s
+$evidence = Copy-SmokeNativeToolToShortPath -SourcePath %s -DestinationPath %s -ExpectedSHA256 %s
+if ($evidence.destination.sha256 -cne %s) { throw 'short native tool hash changed' }
+if ($evidence.pathLength -gt 220) { throw 'short native tool path exceeded the limit' }
+$result = Invoke-CandidateCommand -FilePath %s -ArgumentList @('--version') -WorkingDirectory %s -StdoutPath %s -StderrPath %s
+if ($result.exitCode -ne 0 -or $result.stdout.Trim() -cne %s) { throw "short native tool launch failed: $($result | ConvertTo-Json -Compress)" }
+`,
+		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "unused-install")),
+		localAICandidatePowerShellLiteral(sourcePath),
+		localAICandidatePowerShellLiteral(destinationPath),
+		localAICandidatePowerShellLiteral(localAICandidateNativeToolSHA256),
+		localAICandidatePowerShellLiteral(localAICandidateNativeToolSHA256),
+		localAICandidatePowerShellLiteral(destinationPath),
+		localAICandidatePowerShellLiteral(tempDir),
+		localAICandidatePowerShellLiteral(stdoutPath),
+		localAICandidatePowerShellLiteral(stderrPath),
+		localAICandidatePowerShellLiteral(localAICandidateNativeToolVersion),
+	)
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
+		t.Fatalf("write native-tool harness: %v", err)
+	}
+	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
+		t.Fatalf("copy and launch short native tool: %v\n%s", err, output)
+	}
+	if info, err := os.Stat(destinationPath); err != nil || info.Size() != localAICandidateNativeToolBytes {
+		t.Fatalf("short native tool = %v, want %d bytes", err, localAICandidateNativeToolBytes)
+	}
+	if destinationPathLength := len(destinationPath); destinationPathLength > 220 {
+		t.Fatalf("short native tool path length = %d, want at most 220", destinationPathLength)
 	}
 }
 

--- a/tests/release/localai_install_candidate_test.go
+++ b/tests/release/localai_install_candidate_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -40,11 +41,11 @@ $tokens = $null
 [System.Management.Automation.Language.Parser]::ParseFile(%s, [ref]$tokens, [ref]$errors) | Out-Null
 if ($errors.Count -ne 0) { $errors | ForEach-Object { [Console]::Error.WriteLine($_.Message) }; exit 1 }
 `, localAICandidatePowerShellLiteral(scriptPath)))
+	command.Env = localAICandidatePowerShellEnvironment(t, t.TempDir(), nil)
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("parse candidate delivery script: %v\n%s", err, output)
 	}
 }
-
 func TestLocalAICandidateCommandPreservesArgumentsFailureAndRedaction(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS != "windows" {
@@ -94,14 +95,7 @@ if ($result.exitCode -ne 23) { exit 2 }
 		localAICandidatePowerShellLiteral(stderrPath),
 		localAICandidatePowerShellLiteral(resultPath),
 	)
-	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
-		t.Fatalf("write command harness: %v", err)
-	}
-	command := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath)
-	command.Env = append(os.Environ(), "LOCALAI_ARGUMENT_RECORD="+recordPath)
-	if output, err := command.CombinedOutput(); err != nil {
-		t.Fatalf("run candidate command helper: %v\n%s", err, output)
-	}
+	runLocalAICandidateHarness(t, harnessPath, harness, append(os.Environ(), "LOCALAI_ARGUMENT_RECORD="+recordPath), "")
 
 	var gotArguments []string
 	readJSONFile(t, recordPath, &gotArguments)
@@ -141,7 +135,6 @@ if ($result.exitCode -ne 23) { exit 2 }
 		t.Fatalf("retained output hashes are missing: %#v", result)
 	}
 }
-
 func TestLocalAICandidateCommandDeadlineKillsChildTree(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("PowerShell candidate delivery is Windows-only")
@@ -151,13 +144,13 @@ func TestLocalAICandidateCommandDeadlineKillsChildTree(t *testing.T) {
 	childPIDPath := filepath.Join(tempDir, "child.pid")
 	childPath := filepath.Join(tempDir, "child.ps1")
 	parentPath := filepath.Join(tempDir, "parent.ps1")
-	if err := os.WriteFile(childPath, []byte(`while ($true) { Start-Sleep -Milliseconds 100 }`), 0o600); err != nil {
+	if err := os.WriteFile(childPath, []byte(`[System.Threading.ManualResetEvent]::new($false).WaitOne()`), 0o600); err != nil {
 		t.Fatalf("write hanging child: %v", err)
 	}
 	parent := fmt.Sprintf(`
 $child = Start-Process -FilePath %s -ArgumentList @('-NoProfile', '-NonInteractive', '-File', %s) -PassThru
 [System.IO.File]::WriteAllText(%s, [string]$child.Id)
-while ($true) { Start-Sleep -Milliseconds 100 }
+[System.Threading.ManualResetEvent]::new($false).WaitOne()
 `,
 		localAICandidatePowerShellLiteral(localAICandidatePowerShell(t)),
 		localAICandidatePowerShellLiteral(childPath),
@@ -184,13 +177,8 @@ if (-not $result.timedOut -or $result.exitCode -ne 124) { exit 2 }
 		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "stderr.log")),
 		localAICandidatePowerShellLiteral(resultPath),
 	)
-	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
-		t.Fatalf("write deadline harness: %v", err)
-	}
 	started := time.Now()
-	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
-		t.Fatalf("run command deadline harness: %v\n%s", err, output)
-	}
+	runLocalAICandidateHarness(t, harnessPath, harness, nil, "")
 	if elapsed := time.Since(started); elapsed > 15*time.Second {
 		t.Fatalf("deadline helper took %s, want at most 15s", elapsed)
 	}
@@ -202,20 +190,13 @@ if (-not $result.timedOut -or $result.exitCode -ne 124) { exit 2 }
 	if err != nil {
 		t.Fatalf("parse hanging child PID: %v", err)
 	}
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		check := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-Command",
-			fmt.Sprintf("if (Get-Process -Id %d -ErrorAction SilentlyContinue) { exit 1 }", childPID))
-		if err := check.Run(); err == nil {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("hanging child process %d survived command deadline", childPID)
-		}
-		time.Sleep(50 * time.Millisecond)
+	check := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-Command",
+		fmt.Sprintf("if (Get-Process -Id %d -ErrorAction SilentlyContinue) { exit 1 }", childPID))
+	check.Env = localAICandidatePowerShellEnvironment(t, tempDir, nil)
+	if output, err := check.CombinedOutput(); err != nil {
+		t.Fatalf("hanging child process %d survived command deadline: %v\n%s", childPID, err, output)
 	}
 }
-
 func TestLocalAICandidateCommandBoundsRetainedOutput(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS != "windows" {
@@ -245,12 +226,7 @@ if (-not $result.outputLimitExceeded -or $result.exitCode -ne 125) { exit 2 }
 		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "stderr.log")),
 		localAICandidatePowerShellLiteral(resultPath),
 	)
-	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
-		t.Fatalf("write output-limit harness: %v", err)
-	}
-	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
-		t.Fatalf("run output-limit harness: %v\n%s", err, output)
-	}
+	runLocalAICandidateHarness(t, harnessPath, harness, nil, "")
 	info, err := os.Stat(stdoutPath)
 	if err != nil {
 		t.Fatalf("stat retained output: %v", err)
@@ -270,7 +246,85 @@ if (-not $result.outputLimitExceeded -or $result.exitCode -ne 125) { exit 2 }
 		t.Fatalf("bounded output evidence = %#v", result)
 	}
 }
-
+func TestLocalAICandidateModelActivityFailsClosed(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell candidate delivery is Windows-only")
+	}
+	tempDir := t.TempDir()
+	modelRoot := filepath.Join(tempDir, "model-case")
+	backendRoot := filepath.Join(tempDir, "backend-case")
+	modelEvidencePath := filepath.Join(tempDir, "model-runtime.jsonl")
+	backendEvidencePath := filepath.Join(tempDir, "backend-runtime.jsonl")
+	for _, directory := range []string{
+		filepath.Join(modelRoot, "models"), filepath.Join(modelRoot, "hf"), filepath.Join(modelRoot, "cache"),
+		filepath.Join(backendRoot, "models"), filepath.Join(backendRoot, "hf"), filepath.Join(backendRoot, "cache"),
+	} {
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			t.Fatalf("create activity fixture root: %v", err)
+		}
+	}
+	harnessPath := filepath.Join(tempDir, "activity.ps1")
+	harness := fmt.Sprintf(`
+. %s -InstallDir %s
+$modelPaths = @(%s, %s, %s); $modelBefore = @(
+    Get-SmokeActivitySnapshot models $modelPaths[0]; Get-SmokeActivitySnapshot hf $modelPaths[1]; Get-SmokeActivitySnapshot cache $modelPaths[2])
+[System.IO.File]::WriteAllBytes((Join-Path $modelPaths[2] "download.bin"), [byte[]](65, 66, 67)); $modelAfter = @(
+    Get-SmokeActivitySnapshot models $modelPaths[0]; Get-SmokeActivitySnapshot hf $modelPaths[1]; Get-SmokeActivitySnapshot cache $modelPaths[2])
+$modelActivity = Get-SmokeModelActivity -Before $modelBefore -After $modelAfter -Commands @([pscustomobject]@{ arguments = @("models", "invoke", "llm") }) -RuntimeEvidencePath %s; $modelRejected = $false
+try { Assert-SmokeNoModelActivity $modelActivity } catch { $modelRejected = $true }
+if ($modelActivity.modelCalls -ne 1 -or $modelActivity.modelBackendDownloadBytes -ne 3 -or -not $modelRejected) { exit 2 }
+$backendPaths = @(%s, %s, %s); $backendBefore = @(
+    Get-SmokeActivitySnapshot models $backendPaths[0]; Get-SmokeActivitySnapshot hf $backendPaths[1]; Get-SmokeActivitySnapshot cache $backendPaths[2])
+[System.IO.File]::WriteAllText(%s, '{"kind":"MANAGED_CHILD","phase":"PROCESS_STARTED"}' + [Environment]::NewLine, [System.Text.UTF8Encoding]::new($false)); $backendAfter = @(
+    Get-SmokeActivitySnapshot models $backendPaths[0]; Get-SmokeActivitySnapshot hf $backendPaths[1]; Get-SmokeActivitySnapshot cache $backendPaths[2])
+$backendActivity = Get-SmokeModelActivity -Before $backendBefore -After $backendAfter -Commands @() -RuntimeEvidencePath %s; $backendRejected = $false
+try { Assert-SmokeNoModelActivity $backendActivity } catch { $backendRejected = $true }
+if ($backendActivity.backendProcessStarts -ne 1 -or -not $backendRejected) { exit 3 }
+`,
+		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "unused-install")),
+		localAICandidatePowerShellLiteral(filepath.Join(modelRoot, "models")),
+		localAICandidatePowerShellLiteral(filepath.Join(modelRoot, "hf")),
+		localAICandidatePowerShellLiteral(filepath.Join(modelRoot, "cache")),
+		localAICandidatePowerShellLiteral(modelEvidencePath),
+		localAICandidatePowerShellLiteral(filepath.Join(backendRoot, "models")),
+		localAICandidatePowerShellLiteral(filepath.Join(backendRoot, "hf")),
+		localAICandidatePowerShellLiteral(filepath.Join(backendRoot, "cache")),
+		localAICandidatePowerShellLiteral(backendEvidencePath),
+		localAICandidatePowerShellLiteral(backendEvidencePath),
+	)
+	runLocalAICandidateHarness(t, harnessPath, harness, nil, "")
+}
+func TestLocalAICandidateFinalizationRetainsFailureReport(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell candidate delivery is Windows-only")
+	}
+	tempDir := t.TempDir()
+	outputDir := filepath.Join(tempDir, "candidate-output")
+	reportPath := filepath.Join(outputDir, "candidate-report.json")
+	harnessPath := filepath.Join(tempDir, "finalization.ps1")
+	harness := fmt.Sprintf(`
+. %s -InstallDir %s
+$report = [ordered]@{ status = "PASS"; error = ""; artifacts = @([ordered]@{ role = "missing-artifact"; file = "missing.zip"; bytes = 3; sha256 = "0000000000000000000000000000000000000000000000000000000000000000" }); cleanup = [ordered]@{ status = "PASS" } }
+$result = Finalize-SmokeCandidateReport -OutputDirectory %s -ReportPath %s -Report $report -Failure $null
+if ($null -eq $result.failure -or $result.report.status -ne "FAIL" -or $result.report.cleanup.status -ne "FAIL" -or $result.report.cleanup.retainedEvidenceHashesStable) { exit 2 }
+$digestPath = Join-Path %s "candidate-report.sha256"; $hasher = [System.Security.Cryptography.SHA256]::Create()
+$reportHash = [System.BitConverter]::ToString($hasher.ComputeHash([System.IO.File]::ReadAllBytes(%s))).Replace("-", "").ToLowerInvariant(); $hasher.Dispose()
+$digestHash = (Get-Content -LiteralPath $digestPath -Raw).Trim().Split(' ')[0]
+if (-not (Test-Path -LiteralPath %s -PathType Leaf) -or -not (Test-Path -LiteralPath $digestPath -PathType Leaf) -or $reportHash -cne $digestHash) { exit 3 }
+`,
+		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "unused-install")),
+		localAICandidatePowerShellLiteral(outputDir),
+		localAICandidatePowerShellLiteral(reportPath),
+		localAICandidatePowerShellLiteral(outputDir),
+		localAICandidatePowerShellLiteral(reportPath),
+		localAICandidatePowerShellLiteral(reportPath),
+	)
+	runLocalAICandidateHarness(t, harnessPath, harness, nil, "")
+}
 func TestLocalAICandidateRootsRejectOverlapAndReparseAncestry(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS != "windows" {
@@ -353,14 +407,8 @@ foreach ($case in $rootCases) {
 		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "install")),
 		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "output", "report.json")),
 	)
-	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
-		t.Fatalf("write path-safety harness: %v", err)
-	}
-	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
-		t.Fatalf("validate candidate roots: %v\n%s", err, output)
-	}
+	runLocalAICandidateHarness(t, harnessPath, harness, nil, "")
 }
-
 func TestLocalAICandidateCleanupPreservesSharedDependencyCache(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS != "windows" {
@@ -394,12 +442,7 @@ Remove-SmokeCandidateWork -WorkDirectory %s -DependencyJunctionPath %s
 		localAICandidatePowerShellLiteral(workDir),
 		localAICandidatePowerShellLiteral(junctionDir),
 	)
-	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
-		t.Fatalf("write cleanup harness: %v", err)
-	}
-	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
-		t.Fatalf("clean candidate work: %v\n%s", err, output)
-	}
+	runLocalAICandidateHarness(t, harnessPath, harness, nil, "")
 	if _, err := os.Stat(workDir); !os.IsNotExist(err) {
 		t.Fatalf("candidate work directory remains after cleanup: %v", err)
 	}
@@ -408,7 +451,6 @@ Remove-SmokeCandidateWork -WorkDirectory %s -DependencyJunctionPath %s
 		t.Fatalf("shared dependency cache was modified: %v %q", err, contents)
 	}
 }
-
 func TestLocalAICandidateSourceIdentityComesFromRuntimeInput(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS != "windows" {
@@ -433,12 +475,7 @@ Get-CandidateSourceIdentity -SourcePath %s -Commit %s -Repository %s | ConvertTo
 		localAICandidatePowerShellLiteral(repository),
 		localAICandidatePowerShellLiteral(resultPath),
 	)
-	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
-		t.Fatalf("write source identity harness: %v", err)
-	}
-	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
-		t.Fatalf("resolve candidate source identity: %v\n%s", err, output)
-	}
+	runLocalAICandidateHarness(t, harnessPath, harness, nil, "")
 	var identity struct {
 		Repository string `json:"repository"`
 		Commit     string `json:"commit"`
@@ -462,12 +499,13 @@ Get-CandidateSourceIdentity -SourcePath %s -Commit %s -Repository 'https://examp
 	if err := os.WriteFile(badHarnessPath, []byte(badHarness), 0o600); err != nil {
 		t.Fatalf("write rejected source identity harness: %v", err)
 	}
-	output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", badHarnessPath).CombinedOutput()
+	badCommand := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", badHarnessPath)
+	badCommand.Env = localAICandidatePowerShellEnvironment(t, tempDir, nil)
+	output, err := badCommand.CombinedOutput()
 	if err == nil || !strings.Contains(string(output), "candidate source origin") {
 		t.Fatalf("mismatched repository result = %v\n%s", err, output)
 	}
 }
-
 func TestLocalAICandidateGitCapturesCloneProgress(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS != "windows" {
@@ -502,14 +540,8 @@ if ([string]::IsNullOrWhiteSpace($result)) { throw 'clone progress was not retai
 		localAICandidatePowerShellLiteral(cloneDir),
 		localAICandidatePowerShellLiteral(cloneDir),
 	)
-	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
-		t.Fatalf("write clone harness: %v", err)
-	}
-	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
-		t.Fatalf("capture git clone progress: %v\n%s", err, output)
-	}
+	runLocalAICandidateHarness(t, harnessPath, harness, nil, "")
 }
-
 func localAICandidateRunGit(t *testing.T, directory string, arguments ...string) {
 	t.Helper()
 	command := exec.Command("git", append([]string{"-C", directory}, arguments...)...)
@@ -517,7 +549,6 @@ func localAICandidateRunGit(t *testing.T, directory string, arguments ...string)
 		t.Fatalf("git %v: %v\n%s", arguments, err, output)
 	}
 }
-
 func TestLocalAICandidateCopiesNativeToolToShortPath(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("PowerShell candidate delivery is Windows-only")
@@ -555,12 +586,7 @@ if ($result.exitCode -ne 0 -or $result.stdout.Trim() -cne %s) { throw "short nat
 		localAICandidatePowerShellLiteral(stderrPath),
 		localAICandidatePowerShellLiteral(localAICandidateNativeToolVersion),
 	)
-	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
-		t.Fatalf("write native-tool harness: %v", err)
-	}
-	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
-		t.Fatalf("copy and launch short native tool: %v\n%s", err, output)
-	}
+	runLocalAICandidateHarness(t, harnessPath, harness, nil, "")
 	if info, err := os.Stat(destinationPath); err != nil || info.Size() != localAICandidateNativeToolBytes {
 		t.Fatalf("short native tool = %v, want %d bytes", err, localAICandidateNativeToolBytes)
 	}
@@ -568,7 +594,6 @@ if ($result.exitCode -ne 0 -or $result.stdout.Trim() -cne %s) { throw "short nat
 		t.Fatalf("short native tool path length = %d, want at most 220", destinationPathLength)
 	}
 }
-
 func TestLocalAICandidateWorkAccountingSkipsLinkedDependencyTree(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS != "windows" {
@@ -606,12 +631,7 @@ Get-SmokeDirectoryBytes %s | Set-Content -LiteralPath %s -Encoding ASCII
 		localAICandidatePowerShellLiteral(workDir),
 		localAICandidatePowerShellLiteral(resultPath),
 	)
-	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
-		t.Fatalf("write work accounting harness: %v", err)
-	}
-	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
-		t.Fatalf("measure candidate work directory: %v\n%s", err, output)
-	}
+	runLocalAICandidateHarness(t, harnessPath, harness, nil, "")
 	contents, err := os.ReadFile(resultPath)
 	if err != nil {
 		t.Fatalf("read measured work bytes: %v", err)
@@ -624,7 +644,6 @@ Get-SmokeDirectoryBytes %s | Set-Content -LiteralPath %s -Encoding ASCII
 		t.Fatalf("measured work bytes = %d, want only local bytes %d", got, len(localBytes))
 	}
 }
-
 func TestLocalAICandidatePublicInstallUsesPrebuiltArtifact(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("PowerShell candidate delivery is Windows-only")
@@ -641,7 +660,12 @@ func TestLocalAICandidatePublicInstallUsesPrebuiltArtifact(t *testing.T) {
 	if err != nil {
 		t.Fatalf("locate Go for build-info inspection: %v", err)
 	}
-	versionOutput, err := exec.Command(binaryPath, "--version").CombinedOutput()
+	tempDir := t.TempDir()
+	versionRoot, isolatedEnvironment := localAICandidatePrepareIsolatedEnvironment(t, tempDir)
+	versionCommand := exec.Command(binaryPath, "--version")
+	versionCommand.Dir = versionRoot
+	versionCommand.Env = isolatedEnvironment
+	versionOutput, err := versionCommand.CombinedOutput()
 	if err != nil {
 		t.Fatalf("read prebuilt candidate version: %v\n%s", err, versionOutput)
 	}
@@ -654,7 +678,6 @@ func TestLocalAICandidatePublicInstallUsesPrebuiltArtifact(t *testing.T) {
 		t.Fatal("prebuilt candidate returned an invalid archive version")
 	}
 
-	tempDir := t.TempDir()
 	candidateDir := filepath.Join(tempDir, "candidate")
 	stageDir := filepath.Join(tempDir, "stage")
 	workDir := filepath.Join(tempDir, "work")
@@ -704,25 +727,31 @@ $result | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath %s -Encoding UTF8
 		localAICandidatePowerShellLiteral(workDir),
 		localAICandidatePowerShellLiteral(resultPath),
 	)
-	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
-		t.Fatalf("write install harness: %v", err)
-	}
-	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
-		t.Fatalf("run public candidate install smoke: %v\n%s", err, output)
-	}
+	runLocalAICandidateHarness(t, harnessPath, harness, isolatedEnvironment, tempDir)
 	assertLocalAICandidatePublicInstallResult(t, resultPath, installDir, version)
 }
-
 func assertLocalAICandidatePublicInstallResult(t *testing.T, resultPath, installDir, version string) {
 	t.Helper()
 	var result struct {
 		Status                    string `json:"status"`
 		ModelCalls                int    `json:"modelCalls"`
 		ModelBackendDownloadBytes int64  `json:"modelBackendDownloadBytes"`
-		PathResolution            string `json:"pathResolution"`
-		Version                   string `json:"version"`
-		ExpectedVersion           string `json:"expectedVersion"`
-		ExecutableBuildInfo       struct {
+		Activity                  struct {
+			Observed                  bool     `json:"observed"`
+			CacheBytesBefore          int64    `json:"cacheBytesBefore"`
+			CacheBytesAfter           int64    `json:"cacheBytesAfter"`
+			CacheBytesDelta           int64    `json:"cacheBytesDelta"`
+			ModelCalls                int      `json:"modelCalls"`
+			ModelBackendDownloadBytes int64    `json:"modelBackendDownloadBytes"`
+			RuntimeEvidenceObserved   bool     `json:"runtimeEvidenceObserved"`
+			RuntimeEvidenceRecords    int      `json:"runtimeEvidenceRecords"`
+			BackendProcessStarts      int      `json:"backendProcessStarts"`
+			CacheRoots                []string `json:"cacheRoots"`
+		} `json:"activity"`
+		PathResolution      string `json:"pathResolution"`
+		Version             string `json:"version"`
+		ExpectedVersion     string `json:"expectedVersion"`
+		ExecutableBuildInfo struct {
 			SourceRevision string `json:"sourceRevision"`
 			VCSModified    bool   `json:"vcsModified"`
 		} `json:"executableBuildInfo"`
@@ -732,7 +761,13 @@ func assertLocalAICandidatePublicInstallResult(t *testing.T, resultPath, install
 		} `json:"commands"`
 	}
 	readJSONFile(t, resultPath, &result)
-	if result.Status != "PASS" || result.ModelCalls != 0 || result.ModelBackendDownloadBytes != 0 {
+	if result.Status != "PASS" || !result.Activity.Observed ||
+		result.ModelCalls != result.Activity.ModelCalls ||
+		result.ModelBackendDownloadBytes != result.Activity.ModelBackendDownloadBytes ||
+		result.Activity.ModelCalls != 0 || result.Activity.ModelBackendDownloadBytes != 0 ||
+		result.Activity.CacheBytesBefore != 0 || result.Activity.CacheBytesAfter != 0 ||
+		result.Activity.CacheBytesDelta != 0 || result.Activity.RuntimeEvidenceRecords != 0 ||
+		result.Activity.BackendProcessStarts != 0 || len(result.Activity.CacheRoots) != 3 {
 		t.Fatalf("public candidate install result = %#v", result)
 	}
 	if result.Version != version || result.ExpectedVersion != version || result.PathResolution == "" || !strings.EqualFold(filepath.Clean(result.PathResolution), filepath.Clean(filepath.Join(installDir, "you.exe"))) {
@@ -768,12 +803,10 @@ func assertLocalAICandidatePublicInstallResult(t *testing.T, resultPath, install
 		t.Fatalf("install directory remains after smoke: %v", err)
 	}
 }
-
 func localAICandidateScriptPath(t *testing.T) string {
 	t.Helper()
 	return filepath.Join(testutil.MustRepoRoot(t), "scripts", "release", "smoke-install.ps1")
 }
-
 func localAICandidatePowerShell(t *testing.T) string {
 	t.Helper()
 	path, err := exec.LookPath("powershell.exe")
@@ -782,11 +815,95 @@ func localAICandidatePowerShell(t *testing.T) string {
 	}
 	return path
 }
-
+func runLocalAICandidateHarness(t *testing.T, path, source string, environment []string, directory string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatalf("write PowerShell harness: %v", err)
+	}
+	command := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", path)
+	taskRoot := directory
+	if taskRoot == "" {
+		taskRoot = filepath.Dir(path)
+	}
+	command.Env = localAICandidatePowerShellEnvironment(t, taskRoot, environment)
+	if directory != "" {
+		command.Dir = directory
+	}
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("run PowerShell harness: %v\n%s", err, output)
+	}
+}
+func localAICandidatePowerShellEnvironment(t *testing.T, root string, base []string) []string {
+	t.Helper()
+	moduleRoot := filepath.Join(root, "module-analysis-cache")
+	if err := os.MkdirAll(moduleRoot, 0o700); err != nil {
+		t.Fatalf("create module analysis cache root: %v", err)
+	}
+	if base == nil {
+		base = os.Environ()
+	}
+	environment := slices.DeleteFunc(base, func(entry string) bool {
+		name, _, ok := strings.Cut(entry, "=")
+		return ok && strings.EqualFold(name, "PSModuleAnalysisCachePath")
+	})
+	return append(environment, "PSModuleAnalysisCachePath="+filepath.Join(moduleRoot, "ModuleAnalysisCache"))
+}
+func localAICandidatePrepareIsolatedEnvironment(t *testing.T, root string) (string, []string) {
+	t.Helper()
+	versionRoot := filepath.Join(root, "version-probe")
+	for _, directory := range []string{versionRoot, filepath.Join(root, "profile"), filepath.Join(root, "localappdata"), filepath.Join(root, "appdata"), filepath.Join(root, "temp"), filepath.Join(root, "config"), filepath.Join(root, "cache"), filepath.Join(root, "module-analysis-cache")} {
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			t.Fatalf("create isolated probe directory: %v", err)
+		}
+	}
+	return versionRoot, localAICandidateIsolatedEnvironment(root)
+}
+func localAICandidateIsolatedEnvironment(root string) []string {
+	profile := filepath.Join(root, "profile")
+	volume := filepath.VolumeName(profile)
+	homePath := strings.TrimPrefix(profile, volume)
+	if homePath == "" {
+		homePath = string(filepath.Separator)
+	} else if !strings.HasPrefix(homePath, string(filepath.Separator)) {
+		homePath = string(filepath.Separator) + homePath
+	}
+	overrides := []string{
+		"HOME=" + profile,
+		"USERPROFILE=" + profile,
+		"HOMEDRIVE=" + volume,
+		"HOMEPATH=" + homePath,
+		"APPDATA=" + filepath.Join(root, "appdata"),
+		"LOCALAPPDATA=" + filepath.Join(root, "localappdata"),
+		"TEMP=" + filepath.Join(root, "temp"),
+		"TMP=" + filepath.Join(root, "temp"),
+		"XDG_CONFIG_HOME=" + filepath.Join(root, "config"),
+		"XDG_CACHE_HOME=" + filepath.Join(root, "cache"),
+		"PSModuleAnalysisCachePath=" + filepath.Join(root, "module-analysis-cache", "ModuleAnalysisCache"),
+		"INFINITE_YOU_INTEGRATION_MODEL_RUNTIME_EVIDENCE=" + filepath.Join(root, "model-runtime-evidence.jsonl"),
+		"HF_HUB_DISABLE_TELEMETRY=1",
+	}
+	overrideNames := make(map[string]struct{}, len(overrides))
+	for _, override := range overrides {
+		name, _, ok := strings.Cut(override, "=")
+		if ok {
+			overrideNames[strings.ToUpper(name)] = struct{}{}
+		}
+	}
+	environment := make([]string, 0, len(os.Environ())+len(overrides))
+	for _, entry := range os.Environ() {
+		name, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if _, overridden := overrideNames[strings.ToUpper(name)]; !overridden {
+			environment = append(environment, entry)
+		}
+	}
+	return append(environment, overrides...)
+}
 func localAICandidatePowerShellLiteral(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
 }
-
 func assertLocalAICandidateBuildInfo(t *testing.T, binaryPath string) {
 	t.Helper()
 	info, err := buildinfo.ReadFile(binaryPath)
@@ -804,7 +921,6 @@ func assertLocalAICandidateBuildInfo(t *testing.T, binaryPath string) {
 		t.Fatalf("candidate executable build info = %#v, want revision %s and vcs.modified=false", settings, localAICandidateSourceCommit)
 	}
 }
-
 func localAICandidateGit(t *testing.T, directory string, arguments ...string) string {
 	t.Helper()
 	command := exec.Command("git", append([]string{"-C", directory}, arguments...)...)
@@ -814,7 +930,6 @@ func localAICandidateGit(t *testing.T, directory string, arguments ...string) st
 	}
 	return strings.TrimSpace(string(output))
 }
-
 func readJSONFile(t *testing.T, path string, target any) {
 	t.Helper()
 	contents, err := os.ReadFile(path)

--- a/tests/release/localai_install_candidate_test.go
+++ b/tests/release/localai_install_candidate_test.go
@@ -463,6 +463,56 @@ Get-CandidateSourceIdentity -SourcePath %s -Commit %s -Repository 'https://examp
 	}
 }
 
+func TestLocalAICandidateGitCapturesCloneProgress(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell candidate delivery is Windows-only")
+	}
+
+	tempDir := t.TempDir()
+	sourceDir := filepath.Join(tempDir, "source")
+	cloneDir := filepath.Join(tempDir, "clone")
+	if err := os.MkdirAll(sourceDir, 0o700); err != nil {
+		t.Fatalf("create source repository: %v", err)
+	}
+	localAICandidateRunGit(t, sourceDir, "init", "--quiet")
+	localAICandidateRunGit(t, sourceDir, "config", "user.email", "candidate@example.invalid")
+	localAICandidateRunGit(t, sourceDir, "config", "user.name", "candidate")
+	if err := os.WriteFile(filepath.Join(sourceDir, "tracked.txt"), []byte("candidate"), 0o600); err != nil {
+		t.Fatalf("write source repository: %v", err)
+	}
+	localAICandidateRunGit(t, sourceDir, "add", "tracked.txt")
+	localAICandidateRunGit(t, sourceDir, "commit", "--quiet", "-m", "fixture")
+
+	harnessPath := filepath.Join(tempDir, "clone.ps1")
+	harness := fmt.Sprintf(`
+. %s -InstallDir %s
+$result = Invoke-SmokeGit @('clone', '--local', '--no-checkout', '--', %s, %s)
+if (-not (Test-Path -LiteralPath %s -PathType Container)) { throw 'clone directory was not created' }
+if ([string]::IsNullOrWhiteSpace($result)) { throw 'clone progress was not retained' }
+`,
+		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "unused-install")),
+		localAICandidatePowerShellLiteral(sourceDir),
+		localAICandidatePowerShellLiteral(cloneDir),
+		localAICandidatePowerShellLiteral(cloneDir),
+	)
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
+		t.Fatalf("write clone harness: %v", err)
+	}
+	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
+		t.Fatalf("capture git clone progress: %v\n%s", err, output)
+	}
+}
+
+func localAICandidateRunGit(t *testing.T, directory string, arguments ...string) {
+	t.Helper()
+	command := exec.Command("git", append([]string{"-C", directory}, arguments...)...)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", arguments, err, output)
+	}
+}
+
 func TestLocalAICandidateWorkAccountingSkipsLinkedDependencyTree(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS != "windows" {
@@ -543,6 +593,10 @@ func TestLocalAICandidatePublicInstallUsesPrebuiltArtifact(t *testing.T) {
 	if version == "" {
 		t.Fatal("prebuilt candidate returned an empty version")
 	}
+	archiveVersion := strings.TrimPrefix(version, "v")
+	if archiveVersion == "" {
+		t.Fatal("prebuilt candidate returned an invalid archive version")
+	}
 
 	tempDir := t.TempDir()
 	candidateDir := filepath.Join(tempDir, "candidate")
@@ -556,7 +610,7 @@ func TestLocalAICandidatePublicInstallUsesPrebuiltArtifact(t *testing.T) {
 	}
 	stagedBinary := filepath.Join(stageDir, "you.exe")
 	copyLocalAICandidateFile(t, binaryPath, stagedBinary)
-	archiveName := "you_" + version + "_windows_amd64.zip"
+	archiveName := "you_" + archiveVersion + "_windows_amd64.zip"
 	archivePath := filepath.Join(candidateDir, archiveName)
 	writeLocalAICandidateZip(t, archivePath, stagedBinary)
 	archiveBytes, err := os.ReadFile(archivePath)
@@ -564,7 +618,7 @@ func TestLocalAICandidatePublicInstallUsesPrebuiltArtifact(t *testing.T) {
 		t.Fatalf("read candidate archive: %v", err)
 	}
 	archiveDigest := sha256.Sum256(archiveBytes)
-	checksumPath := filepath.Join(candidateDir, "you_"+version+"_checksums.txt")
+	checksumPath := filepath.Join(candidateDir, "you_"+archiveVersion+"_checksums.txt")
 	checksum := fmt.Sprintf("%x  %s\n", archiveDigest, archiveName)
 	if err := os.WriteFile(checksumPath, []byte(checksum), 0o600); err != nil {
 		t.Fatalf("write candidate checksums: %v", err)
@@ -576,7 +630,7 @@ func TestLocalAICandidatePublicInstallUsesPrebuiltArtifact(t *testing.T) {
 	harnessPath := filepath.Join(tempDir, "install.ps1")
 	harness := fmt.Sprintf(`
 . %s -InstallDir %s
-$result = Invoke-InstalledCandidateSmoke -CandidateDirectory %s -ArchivePath %s -ChecksumPath %s -InstallerPath %s -ArchiveExecutablePath %s -Version %s -ExpectedSourceCommit %s -GoExecutablePath %s -RequestedInstallDir %s -WorkDirectory %s
+$result = Invoke-InstalledCandidateSmoke -CandidateDirectory %s -ArchivePath %s -ChecksumPath %s -InstallerPath %s -ArchiveExecutablePath %s -Version %s -ExpectedExecutableVersion %s -ExpectedSourceCommit %s -GoExecutablePath %s -RequestedInstallDir %s -WorkDirectory %s
 $result | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath %s -Encoding UTF8
 `,
 		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
@@ -586,6 +640,7 @@ $result | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath %s -Encoding UTF8
 		localAICandidatePowerShellLiteral(checksumPath),
 		localAICandidatePowerShellLiteral(installerPath),
 		localAICandidatePowerShellLiteral(stagedBinary),
+		localAICandidatePowerShellLiteral(archiveVersion),
 		localAICandidatePowerShellLiteral(version),
 		localAICandidatePowerShellLiteral(localAICandidateSourceCommit),
 		localAICandidatePowerShellLiteral(goPath),
@@ -599,11 +654,18 @@ $result | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath %s -Encoding UTF8
 	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
 		t.Fatalf("run public candidate install smoke: %v\n%s", err, output)
 	}
+	assertLocalAICandidatePublicInstallResult(t, resultPath, installDir, version)
+}
+
+func assertLocalAICandidatePublicInstallResult(t *testing.T, resultPath, installDir, version string) {
+	t.Helper()
 	var result struct {
 		Status                    string `json:"status"`
 		ModelCalls                int    `json:"modelCalls"`
 		ModelBackendDownloadBytes int64  `json:"modelBackendDownloadBytes"`
 		PathResolution            string `json:"pathResolution"`
+		Version                   string `json:"version"`
+		ExpectedVersion           string `json:"expectedVersion"`
 		ExecutableBuildInfo       struct {
 			SourceRevision string `json:"sourceRevision"`
 			VCSModified    bool   `json:"vcsModified"`
@@ -617,8 +679,8 @@ $result | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath %s -Encoding UTF8
 	if result.Status != "PASS" || result.ModelCalls != 0 || result.ModelBackendDownloadBytes != 0 {
 		t.Fatalf("public candidate install result = %#v", result)
 	}
-	if result.PathResolution == "" || !strings.EqualFold(filepath.Clean(result.PathResolution), filepath.Clean(filepath.Join(installDir, "you.exe"))) {
-		t.Fatalf("public candidate PATH resolution = %q, want installed executable", result.PathResolution)
+	if result.Version != version || result.ExpectedVersion != version || result.PathResolution == "" || !strings.EqualFold(filepath.Clean(result.PathResolution), filepath.Clean(filepath.Join(installDir, "you.exe"))) {
+		t.Fatalf("public candidate version/PATH = %q/%q/%q, want version %q and installed executable", result.Version, result.ExpectedVersion, result.PathResolution, version)
 	}
 	if result.ExecutableBuildInfo.SourceRevision != localAICandidateSourceCommit || result.ExecutableBuildInfo.VCSModified {
 		t.Fatalf("public candidate executable build info = %#v", result.ExecutableBuildInfo)

--- a/tests/release/localai_install_candidate_test.go
+++ b/tests/release/localai_install_candidate_test.go
@@ -269,6 +269,9 @@ func TestLocalAICandidateModelActivityFailsClosed(t *testing.T) {
 . %s -InstallDir %s
 $modelPaths = @(%s, %s, %s); $modelBefore = @(
     Get-SmokeActivitySnapshot models $modelPaths[0]; Get-SmokeActivitySnapshot hf $modelPaths[1]; Get-SmokeActivitySnapshot cache $modelPaths[2])
+$missingActivity = Get-SmokeModelActivity -Before $modelBefore -After $modelBefore -Commands @() -RuntimeEvidencePath %s; $missingRejected = $false
+try { Assert-SmokeNoModelActivity $missingActivity } catch { $missingRejected = $true }
+if ($missingActivity.runtimeEvidenceObserved -or -not $missingRejected) { exit 4 }
 [System.IO.File]::WriteAllBytes((Join-Path $modelPaths[2] "download.bin"), [byte[]](65, 66, 67)); $modelAfter = @(
     Get-SmokeActivitySnapshot models $modelPaths[0]; Get-SmokeActivitySnapshot hf $modelPaths[1]; Get-SmokeActivitySnapshot cache $modelPaths[2])
 $modelActivity = Get-SmokeModelActivity -Before $modelBefore -After $modelAfter -Commands @([pscustomobject]@{ arguments = @("models", "invoke", "llm") }) -RuntimeEvidencePath %s; $modelRejected = $false
@@ -287,6 +290,7 @@ if ($backendActivity.backendProcessStarts -ne 1 -or -not $backendRejected) { exi
 		localAICandidatePowerShellLiteral(filepath.Join(modelRoot, "models")),
 		localAICandidatePowerShellLiteral(filepath.Join(modelRoot, "hf")),
 		localAICandidatePowerShellLiteral(filepath.Join(modelRoot, "cache")),
+		localAICandidatePowerShellLiteral(modelEvidencePath),
 		localAICandidatePowerShellLiteral(modelEvidencePath),
 		localAICandidatePowerShellLiteral(filepath.Join(backendRoot, "models")),
 		localAICandidatePowerShellLiteral(filepath.Join(backendRoot, "hf")),

--- a/tests/release/localai_install_candidate_test.go
+++ b/tests/release/localai_install_candidate_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/portpowered/infinite-you/internal/testutil"
 )
@@ -129,6 +130,240 @@ if ($result.exitCode -ne 23) { exit 2 }
 	}
 	if len(result.StdoutEvidence.SHA256) != 64 || len(result.StderrEvidence.SHA256) != 64 {
 		t.Fatalf("retained output hashes are missing: %#v", result)
+	}
+}
+
+func TestLocalAICandidateCommandDeadlineKillsChildTree(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell candidate delivery is Windows-only")
+	}
+
+	tempDir := t.TempDir()
+	childPIDPath := filepath.Join(tempDir, "child.pid")
+	childPath := filepath.Join(tempDir, "child.ps1")
+	parentPath := filepath.Join(tempDir, "parent.ps1")
+	if err := os.WriteFile(childPath, []byte(`while ($true) { Start-Sleep -Milliseconds 100 }`), 0o600); err != nil {
+		t.Fatalf("write hanging child: %v", err)
+	}
+	parent := fmt.Sprintf(`
+$child = Start-Process -FilePath %s -ArgumentList @('-NoProfile', '-NonInteractive', '-File', %s) -PassThru
+[System.IO.File]::WriteAllText(%s, [string]$child.Id)
+while ($true) { Start-Sleep -Milliseconds 100 }
+`,
+		localAICandidatePowerShellLiteral(localAICandidatePowerShell(t)),
+		localAICandidatePowerShellLiteral(childPath),
+		localAICandidatePowerShellLiteral(childPIDPath),
+	)
+	if err := os.WriteFile(parentPath, []byte(parent), 0o600); err != nil {
+		t.Fatalf("write hanging parent: %v", err)
+	}
+
+	resultPath := filepath.Join(tempDir, "result.json")
+	harnessPath := filepath.Join(tempDir, "deadline.ps1")
+	harness := fmt.Sprintf(`
+. %s -InstallDir %s
+$result = Invoke-CandidateCommand -FilePath %s -ArgumentList @('-NoProfile', '-NonInteractive', '-File', %s) -WorkingDirectory %s -StdoutPath %s -StderrPath %s -TimeoutSeconds 3 -OutputMaximumBytes 4096
+$result | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath %s -Encoding UTF8
+if (-not $result.timedOut -or $result.exitCode -ne 124) { exit 2 }
+`,
+		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "unused-install")),
+		localAICandidatePowerShellLiteral(localAICandidatePowerShell(t)),
+		localAICandidatePowerShellLiteral(parentPath),
+		localAICandidatePowerShellLiteral(tempDir),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "stdout.log")),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "stderr.log")),
+		localAICandidatePowerShellLiteral(resultPath),
+	)
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
+		t.Fatalf("write deadline harness: %v", err)
+	}
+	started := time.Now()
+	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
+		t.Fatalf("run command deadline harness: %v\n%s", err, output)
+	}
+	if elapsed := time.Since(started); elapsed > 15*time.Second {
+		t.Fatalf("deadline helper took %s, want at most 15s", elapsed)
+	}
+	pidBytes, err := os.ReadFile(childPIDPath)
+	if err != nil {
+		t.Fatalf("read hanging child PID: %v", err)
+	}
+	childPID, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		t.Fatalf("parse hanging child PID: %v", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		check := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-Command",
+			fmt.Sprintf("if (Get-Process -Id %d -ErrorAction SilentlyContinue) { exit 1 }", childPID))
+		if err := check.Run(); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("hanging child process %d survived command deadline", childPID)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func TestLocalAICandidateCommandBoundsRetainedOutput(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell candidate delivery is Windows-only")
+	}
+
+	tempDir := t.TempDir()
+	writerPath := filepath.Join(tempDir, "writer.ps1")
+	if err := os.WriteFile(writerPath, []byte(`[Console]::Out.Write(('token=x ' * 1024)); exit 0`), 0o600); err != nil {
+		t.Fatalf("write output fixture: %v", err)
+	}
+	stdoutPath := filepath.Join(tempDir, "stdout.log")
+	resultPath := filepath.Join(tempDir, "result.json")
+	harnessPath := filepath.Join(tempDir, "output-limit.ps1")
+	harness := fmt.Sprintf(`
+. %s -InstallDir %s
+$result = Invoke-CandidateCommand -FilePath %s -ArgumentList @('-NoProfile', '-NonInteractive', '-File', %s) -WorkingDirectory %s -StdoutPath %s -StderrPath %s -TimeoutSeconds 10 -OutputMaximumBytes 1024
+$result | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath %s -Encoding UTF8
+if (-not $result.outputLimitExceeded -or $result.exitCode -ne 125) { exit 2 }
+`,
+		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "unused-install")),
+		localAICandidatePowerShellLiteral(localAICandidatePowerShell(t)),
+		localAICandidatePowerShellLiteral(writerPath),
+		localAICandidatePowerShellLiteral(tempDir),
+		localAICandidatePowerShellLiteral(stdoutPath),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "stderr.log")),
+		localAICandidatePowerShellLiteral(resultPath),
+	)
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
+		t.Fatalf("write output-limit harness: %v", err)
+	}
+	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
+		t.Fatalf("run output-limit harness: %v\n%s", err, output)
+	}
+	info, err := os.Stat(stdoutPath)
+	if err != nil {
+		t.Fatalf("stat retained output: %v", err)
+	}
+	if info.Size() > 1024 {
+		t.Fatalf("retained output is %d bytes, want at most 1024", info.Size())
+	}
+	var result struct {
+		OutputLimitExceeded bool `json:"outputLimitExceeded"`
+		StdoutEvidence      struct {
+			TotalBytes int64 `json:"totalBytes"`
+			Truncated  bool  `json:"truncated"`
+		} `json:"stdoutEvidence"`
+	}
+	readJSONFile(t, resultPath, &result)
+	if !result.OutputLimitExceeded || !result.StdoutEvidence.Truncated || result.StdoutEvidence.TotalBytes <= 1024 {
+		t.Fatalf("bounded output evidence = %#v", result)
+	}
+}
+
+func TestLocalAICandidateRootsRejectOverlapAndReparseAncestry(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell candidate delivery is Windows-only")
+	}
+
+	tempDir := t.TempDir()
+	sourceDir := filepath.Join(tempDir, "source")
+	dependencyDir := filepath.Join(tempDir, "dependencies")
+	for _, directory := range []string{sourceDir, dependencyDir} {
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			t.Fatalf("create path fixture: %v", err)
+		}
+	}
+	outputDir := filepath.Join(sourceDir, "output")
+	harnessPath := filepath.Join(tempDir, "paths.ps1")
+	harness := fmt.Sprintf(`
+. %s -InstallDir %s
+try {
+    Assert-SmokeCandidateRoots -SourcePath %s -DependencySourcePath %s -OutputDirectory %s -WorkDirectory %s -InstallDirectory %s -ReportPath %s | Out-Null
+    exit 2
+} catch {
+    if (-not $_.Exception.Message.Contains('must not overlap')) { throw }
+}
+$link = %s
+New-Item -ItemType Junction -Path $link -Target %s | Out-Null
+try {
+    Assert-SmokeCandidateRoots -SourcePath $link -DependencySourcePath %s -OutputDirectory %s -WorkDirectory %s -InstallDirectory %s -ReportPath %s | Out-Null
+    exit 3
+} catch {
+    if (-not $_.Exception.Message.Contains('reparse point in its ancestry')) { throw }
+}
+`,
+		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "unused-install")),
+		localAICandidatePowerShellLiteral(sourceDir),
+		localAICandidatePowerShellLiteral(dependencyDir),
+		localAICandidatePowerShellLiteral(outputDir),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "work")),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "install")),
+		localAICandidatePowerShellLiteral(filepath.Join(outputDir, "report.json")),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "source-link")),
+		localAICandidatePowerShellLiteral(sourceDir),
+		localAICandidatePowerShellLiteral(dependencyDir),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "output")),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "work")),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "install")),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "output", "report.json")),
+	)
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
+		t.Fatalf("write path-safety harness: %v", err)
+	}
+	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
+		t.Fatalf("validate candidate roots: %v\n%s", err, output)
+	}
+}
+
+func TestLocalAICandidateCleanupPreservesSharedDependencyCache(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell candidate delivery is Windows-only")
+	}
+
+	tempDir := t.TempDir()
+	workDir := filepath.Join(tempDir, "work")
+	junctionDir := filepath.Join(workDir, "src", "ui", "node_modules")
+	dependencyDir := filepath.Join(tempDir, "dependencies")
+	if err := os.MkdirAll(filepath.Dir(junctionDir), 0o700); err != nil {
+		t.Fatalf("create work fixture: %v", err)
+	}
+	if err := os.MkdirAll(dependencyDir, 0o700); err != nil {
+		t.Fatalf("create dependency fixture: %v", err)
+	}
+	markerPath := filepath.Join(dependencyDir, "keep.txt")
+	if err := os.WriteFile(markerPath, []byte("shared cache"), 0o600); err != nil {
+		t.Fatalf("write shared cache marker: %v", err)
+	}
+	harnessPath := filepath.Join(tempDir, "cleanup.ps1")
+	harness := fmt.Sprintf(`
+. %s -InstallDir %s
+New-Item -ItemType Junction -Path %s -Target %s | Out-Null
+Remove-SmokeCandidateWork -WorkDirectory %s -DependencyJunctionPath %s
+`,
+		localAICandidatePowerShellLiteral(localAICandidateScriptPath(t)),
+		localAICandidatePowerShellLiteral(filepath.Join(tempDir, "unused-install")),
+		localAICandidatePowerShellLiteral(junctionDir),
+		localAICandidatePowerShellLiteral(dependencyDir),
+		localAICandidatePowerShellLiteral(workDir),
+		localAICandidatePowerShellLiteral(junctionDir),
+	)
+	if err := os.WriteFile(harnessPath, []byte(harness), 0o600); err != nil {
+		t.Fatalf("write cleanup harness: %v", err)
+	}
+	if output, err := exec.Command(localAICandidatePowerShell(t), "-NoProfile", "-NonInteractive", "-File", harnessPath).CombinedOutput(); err != nil {
+		t.Fatalf("clean candidate work: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(workDir); !os.IsNotExist(err) {
+		t.Fatalf("candidate work directory remains after cleanup: %v", err)
+	}
+	contents, err := os.ReadFile(markerPath)
+	if err != nil || string(contents) != "shared cache" {
+		t.Fatalf("shared dependency cache was modified: %v %q", err, contents)
 	}
 }
 

--- a/tests/release/localai_install_candidate_test.go
+++ b/tests/release/localai_install_candidate_test.go
@@ -25,10 +25,10 @@ import (
 
 const (
 	localAICandidateManifestEnv, localAICandidateSchemaVersion, localAICandidateProject                                                                                                                                                                                                                                                  = "INFINITE_YOU_LOCALAI_CANDIDATE_MANIFEST", "localai-windows-install-candidate/v1", "localai"
-	localAICandidateCycle, localAICandidateGOFLAGS, localAICandidateGOMAXPROCS                                                                                                                                                                                                                                                           = "067", "-p=4", "4"
+	localAICandidateCycle, localAICandidateGoVersion, localAICandidateGOFLAGS, localAICandidateGOMAXPROCS, localAICandidateObserverQueryMode                                                                                                                                                                                             = "068", "go1.26.8", "-p=4", "4", "one-full-TCP-table-query-per-interval-filtered-to-owned-process-identities"
 	localAICandidateRepository, localAICandidateSourceCommit, localAICandidateSourceTree                                                                                                                                                                                                                                                 = "https://github.com/portpowered/you-agent-factory", "059474b2c00915865306a33ca5e3d02b618bb6f0", "ae5d9c87fbc99a898ad2c11e1409105d78e4a094"
 	localAICandidateGoReleaser, localAICandidateGOOS, localAICandidateGOARCH                                                                                                                                                                                                                                                             = "v2.12.7", "windows", "amd64"
-	localAICandidateTemporaryDiskMaximum, localAICandidateToolDownloadMaximum, localAICandidateModelDownloadMaximum, localAICandidateModelCallsMaximum, localAICandidatePaidUSDMaximum, localAICandidateDescendantMaximum, localAICandidateRerunsMaximum, localAICandidateProcessNetworkGapMaximum, localAICandidateDiskGapMaximum int64 = 4294967296, 0, 0, 0, 0, 36, 1, 2000, 15000
+	localAICandidateTemporaryDiskMaximum, localAICandidateToolDownloadMaximum, localAICandidateModelDownloadMaximum, localAICandidateModelCallsMaximum, localAICandidatePaidUSDMaximum, localAICandidateDescendantMaximum, localAICandidateRerunsMaximum, localAICandidateProcessNetworkGapMaximum, localAICandidateDiskGapMaximum int64 = 4294967296, 0, 0, 0, 0, 36, 1, 2000, 2000
 )
 
 var localAICandidateSHA256Pattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
@@ -41,7 +41,7 @@ type localAICandidateManifest struct {
 	Build         localAICandidateBuild      `json:"build"`
 	Artifacts     []localAICandidateArtifact `json:"artifacts"`
 	Limits        localAICandidateLimits     `json:"limits"`
-	Attempts      map[string]any             `json:"attempts"`
+	Attempts      localAICandidateAttempts   `json:"attempts"`
 }
 type localAICandidateSource struct {
 	Repository string `json:"repository"`
@@ -79,6 +79,15 @@ type localAICandidateLimits struct {
 	GOFLAGS                       string `json:"goflags"`
 	GOMAXPROCS                    string `json:"gomaxprocs"`
 }
+type localAICandidateAttempts struct {
+	PriorCycles          []string `json:"priorCycles"`
+	Cycle063BuildMaximum *int64   `json:"cycle063BuildMaximum"`
+	Cycle063BuildUsed    *int64   `json:"cycle063BuildUsed"`
+	Cycle067BuildMaximum *int64   `json:"cycle067BuildMaximum"`
+	Cycle067BuildUsed    *int64   `json:"cycle067BuildUsed"`
+	Cycle068BuildMaximum *int64   `json:"cycle068BuildMaximum"`
+	Cycle068BuildUsed    *int64   `json:"cycle068BuildUsed"`
+}
 type localAICandidateArtifactEvidence struct {
 	Role   string `json:"role"`
 	File   string `json:"file"`
@@ -106,12 +115,20 @@ type localAICandidateRoot struct {
 	Path string
 }
 type localAICandidateProcessNetworkObserver struct {
-	StartedBeforeRoot              bool   `json:"startedBeforeRoot"`
-	ContinuedThroughDescendantExit bool   `json:"continuedThroughDescendantExit"`
-	MaximumGapMilliseconds         int64  `json:"maximumGapMilliseconds"`
-	Status                         string `json:"status"`
-	NonLoopbackConnections         int    `json:"nonLoopbackConnections"`
-	ExternalTransferBytes          int64  `json:"externalTransferBytes"`
+	StartedBeforeRoot              bool     `json:"startedBeforeRoot"`
+	ContinuedThroughDescendantExit bool     `json:"continuedThroughDescendantExit"`
+	MaximumGapMilliseconds         int64    `json:"maximumGapMilliseconds"`
+	Status                         string   `json:"status"`
+	NonLoopbackConnections         int      `json:"nonLoopbackConnections"`
+	ExternalTransferBytes          int64    `json:"externalTransferBytes"`
+	SampleCount                    int      `json:"sampleCount"`
+	TCPTableQueries                int      `json:"tcpTableQueries"`
+	ZeroConnectionSamples          int      `json:"zeroConnectionSamples"`
+	OwnedConnectionMatches         int      `json:"ownedConnectionMatches"`
+	OwnedProcessIdentityCount      int      `json:"ownedProcessIdentityCount"`
+	QueryMode                      string   `json:"queryMode"`
+	ForbiddenProcesses             []string `json:"forbiddenProcesses"`
+	Error                          string   `json:"error"`
 }
 type localAICandidateDiskObserver struct {
 	Independent            bool   `json:"independent"`
@@ -119,6 +136,7 @@ type localAICandidateDiskObserver struct {
 	MaximumGapMilliseconds int64  `json:"maximumGapMilliseconds"`
 	Status                 string `json:"status"`
 	PeakDeltaBytes         int64  `json:"peakDeltaBytes"`
+	Error                  string `json:"error"`
 }
 type localAICandidateObserverEvidence struct {
 	Environment            map[string]string                      `json:"environment"`
@@ -131,12 +149,18 @@ type localAICandidateObserverEvidence struct {
 	ModelBackendBytes      int64                                  `json:"modelBackendBytes"`
 	ModelBackendCalls      int64                                  `json:"modelBackendCalls"`
 }
+type localAICandidateObserverCleanup struct {
+	Status             string   `json:"status"`
+	RemainingTaskPaths []string `json:"remainingTaskPaths"`
+	Errors             []string `json:"errors"`
+}
 type localAICandidateObserverReport struct {
 	SchemaVersion string                           `json:"schemaVersion"`
 	Status        string                           `json:"status"`
 	Cycle         string                           `json:"cycle"`
 	ReleaseStatus string                           `json:"releaseStatus"`
 	Observation   localAICandidateObserverEvidence `json:"observation"`
+	Cleanup       localAICandidateObserverCleanup  `json:"cleanup"`
 }
 
 func localAICandidateManifestPath(t *testing.T, purpose string) string {
@@ -321,6 +345,10 @@ func TestLocalAICandidateManifestValidationRejectsDriftAndAmbiguity(t *testing.T
 			fixture.manifest.Limits.GOMAXPROCS = "8"
 			fixture.writeManifest(t)
 		}, want: "candidate Go controls"},
+		{name: "changed Go version", edit: func(fixture *localAICandidateFixture) {
+			fixture.manifest.Build.GoVersion = "go1.25.0"
+			fixture.writeManifest(t)
+		}, want: "candidate Go version"},
 	}
 	for _, test := range tests {
 		test := test
@@ -333,7 +361,7 @@ func TestLocalAICandidateManifestValidationRejectsDriftAndAmbiguity(t *testing.T
 			}
 		})
 	}
-	for _, cycle := range []string{"030", "040", "042", "045", "048"} {
+	for _, cycle := range []string{"030", "040", "042", "045", "048", "050", "063", "067"} {
 		cycle := cycle
 		t.Run("historical cycle "+cycle, func(t *testing.T) {
 			fixture := newLocalAICandidateFixture(t)
@@ -562,15 +590,18 @@ func TestLocalAICandidateObserverEnvelopeFixture(t *testing.T) {
 	if err := validateLocalAICandidateObserverEvidence(report.Observation); err != nil {
 		t.Fatalf("observer report evidence: %v", err)
 	}
+	if report.Cleanup.Status != "PASS" || len(report.Cleanup.RemainingTaskPaths) != 0 || len(report.Cleanup.Errors) != 0 {
+		t.Fatalf("observer cleanup evidence = %#v, want complete cleanup", report.Cleanup)
+	}
 	t.Logf("LOCALAI-OBSERVER status=PASS evidence=%s", raw)
 }
 func validateLocalAICandidateObserverEvidence(observation localAICandidateObserverEvidence) error {
 	process := observation.ProcessNetworkObserver
-	if process.Status != "PASS" || !process.StartedBeforeRoot || !process.ContinuedThroughDescendantExit || process.MaximumGapMilliseconds < 0 || process.MaximumGapMilliseconds > localAICandidateProcessNetworkGapMaximum || process.NonLoopbackConnections != 0 || process.ExternalTransferBytes != 0 {
+	if process.Status != "PASS" || !process.StartedBeforeRoot || !process.ContinuedThroughDescendantExit || process.MaximumGapMilliseconds < 0 || process.MaximumGapMilliseconds > localAICandidateProcessNetworkGapMaximum || process.NonLoopbackConnections != 0 || process.ExternalTransferBytes != 0 || process.SampleCount <= 0 || process.TCPTableQueries != process.SampleCount || process.ZeroConnectionSamples <= 0 || process.OwnedConnectionMatches < 0 || process.OwnedProcessIdentityCount <= 0 || process.QueryMode != localAICandidateObserverQueryMode || len(process.ForbiddenProcesses) != 0 || process.Error != "" {
 		return fmt.Errorf("invalid process/network observer evidence: %#v", process)
 	}
 	disk := observation.DiskObserver
-	if disk.Status != "PASS" || !disk.Independent || !disk.StartPeriodicFinal || disk.MaximumGapMilliseconds < 0 || disk.MaximumGapMilliseconds > localAICandidateDiskGapMaximum || disk.PeakDeltaBytes < 0 || disk.PeakDeltaBytes > localAICandidateTemporaryDiskMaximum {
+	if disk.Status != "PASS" || !disk.Independent || !disk.StartPeriodicFinal || disk.MaximumGapMilliseconds < 0 || disk.MaximumGapMilliseconds > localAICandidateDiskGapMaximum || disk.PeakDeltaBytes < 0 || disk.PeakDeltaBytes > localAICandidateTemporaryDiskMaximum || disk.Error != "" {
 		return fmt.Errorf("invalid disk observer evidence: %#v", disk)
 	}
 	if observation.DescendantMaximum != localAICandidateDescendantMaximum || observation.DescendantHighWater < 1 || observation.DescendantHighWater > observation.DescendantMaximum {
@@ -583,6 +614,54 @@ func validateLocalAICandidateObserverEvidence(observation localAICandidateObserv
 		return fmt.Errorf("invalid observer completion evidence: %#v", observation)
 	}
 	return nil
+}
+func TestLocalAICandidateObserverEvidenceRejectsUnprovenSamples(t *testing.T) {
+	rootExitCode := int64(0)
+	base := localAICandidateObserverEvidence{
+		ProcessNetworkObserver: localAICandidateProcessNetworkObserver{
+			StartedBeforeRoot: true, ContinuedThroughDescendantExit: true, MaximumGapMilliseconds: 1,
+			Status: "PASS", SampleCount: 3, TCPTableQueries: 3, ZeroConnectionSamples: 3,
+			OwnedProcessIdentityCount: 3, QueryMode: localAICandidateObserverQueryMode,
+		},
+		DiskObserver:        localAICandidateDiskObserver{Independent: true, StartPeriodicFinal: true, MaximumGapMilliseconds: 1, Status: "PASS"},
+		DescendantMaximum:   localAICandidateDescendantMaximum,
+		DescendantHighWater: 1,
+		RootExitCode:        &rootExitCode,
+		FailurePropagation:  "PASS",
+	}
+	tests := []struct {
+		name string
+		edit func(*localAICandidateObserverEvidence)
+	}{
+		{name: "query count drift", edit: func(evidence *localAICandidateObserverEvidence) { evidence.ProcessNetworkObserver.TCPTableQueries = 2 }},
+		{name: "zero row not recorded", edit: func(evidence *localAICandidateObserverEvidence) {
+			evidence.ProcessNetworkObserver.ZeroConnectionSamples = 0
+		}},
+		{name: "identity count missing", edit: func(evidence *localAICandidateObserverEvidence) {
+			evidence.ProcessNetworkObserver.OwnedProcessIdentityCount = 0
+		}},
+		{name: "query mode missing", edit: func(evidence *localAICandidateObserverEvidence) {
+			evidence.ProcessNetworkObserver.QueryMode = "per-pid"
+		}},
+		{name: "query error", edit: func(evidence *localAICandidateObserverEvidence) {
+			evidence.ProcessNetworkObserver.Error = "query failed"
+		}},
+		{name: "disk gap over limit", edit: func(evidence *localAICandidateObserverEvidence) {
+			evidence.DiskObserver.MaximumGapMilliseconds = localAICandidateDiskGapMaximum + 1
+		}},
+		{name: "disk error", edit: func(evidence *localAICandidateObserverEvidence) { evidence.DiskObserver.Error = "disk sample failed" }},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			evidence := base
+			test.edit(&evidence)
+			if err := validateLocalAICandidateObserverEvidence(evidence); err == nil {
+				t.Fatal("observer evidence unexpectedly passed")
+			}
+		})
+	}
 }
 func validateLocalAICandidate(manifestPath string) (localAICandidateValidationEvidence, error) {
 	return validateLocalAICandidateWithBuildInfoReader(manifestPath, buildinfo.ReadFile)
@@ -778,6 +857,9 @@ func validateLocalAICandidateIdentity(manifest localAICandidateManifest) error {
 			return fmt.Errorf("candidate build.%s is required", name)
 		}
 	}
+	if manifest.Build.GoVersion != localAICandidateGoVersion {
+		return fmt.Errorf("candidate Go version = %q, want %q", manifest.Build.GoVersion, localAICandidateGoVersion)
+	}
 	if manifest.Build.GoReleaserVersion != localAICandidateGoReleaser {
 		return fmt.Errorf("candidate goreleaserVersion = %q, want %q", manifest.Build.GoReleaserVersion, localAICandidateGoReleaser)
 	}
@@ -821,7 +903,38 @@ func validateLocalAICandidateIdentity(manifest localAICandidateManifest) error {
 	if strings.TrimSpace(manifest.Limits.GOFLAGS) == "" || manifest.Limits.GOFLAGS != localAICandidateGOFLAGS || strings.TrimSpace(manifest.Limits.GOMAXPROCS) == "" || manifest.Limits.GOMAXPROCS != localAICandidateGOMAXPROCS {
 		return fmt.Errorf("candidate Go controls = GOFLAGS=%q GOMAXPROCS=%q, want GOFLAGS=%q GOMAXPROCS=%q", manifest.Limits.GOFLAGS, manifest.Limits.GOMAXPROCS, localAICandidateGOFLAGS, localAICandidateGOMAXPROCS)
 	}
+	if err := validateLocalAICandidateAttempts(manifest.Attempts); err != nil {
+		return err
+	}
 	return nil
+}
+func validateLocalAICandidateAttempts(attempts localAICandidateAttempts) error {
+	wantPriorCycles := []string{"030", "040", "042", "045", "048", "050", "063", "067"}
+	if !slices.Equal(attempts.PriorCycles, wantPriorCycles) {
+		return fmt.Errorf("candidate attempts priorCycles = %v, want %v", attempts.PriorCycles, wantPriorCycles)
+	}
+	for _, attempt := range []struct {
+		name    string
+		maximum *int64
+		used    *int64
+		wantMax int64
+		wantUse int64
+	}{
+		{name: "cycle063", maximum: attempts.Cycle063BuildMaximum, used: attempts.Cycle063BuildUsed, wantMax: 1, wantUse: 1},
+		{name: "cycle067", maximum: attempts.Cycle067BuildMaximum, used: attempts.Cycle067BuildUsed, wantMax: 2, wantUse: 2},
+		{name: "cycle068", maximum: attempts.Cycle068BuildMaximum, used: attempts.Cycle068BuildUsed, wantMax: 1, wantUse: 1},
+	} {
+		if attempt.maximum == nil || attempt.used == nil || *attempt.maximum != attempt.wantMax || *attempt.used != attempt.wantUse {
+			return fmt.Errorf("candidate attempts %sBuildMaximum/Used = %v/%v, want %d/%d", attempt.name, valueOrZero(attempt.maximum), valueOrZero(attempt.used), attempt.wantMax, attempt.wantUse)
+		}
+	}
+	return nil
+}
+func valueOrZero(value *int64) int64 {
+	if value == nil {
+		return 0
+	}
+	return *value
 }
 func validateLocalAICandidateLimit(name string, actual *int64, want int64) error {
 	if actual == nil {
@@ -1064,7 +1177,7 @@ func newLocalAICandidateFixture(t *testing.T) *localAICandidateFixture {
 		Source:        localAICandidateSource{Repository: localAICandidateRepository, Commit: localAICandidateSourceCommit, Tree: localAICandidateSourceTree},
 		Build: localAICandidateBuild{
 			CandidateVersion: "1.2.3-snapshot-test", CLIVersion: "1.2.3-snapshot-test",
-			GoVersion: "go1.25.0", GoReleaserVersion: localAICandidateGoReleaser,
+			GoVersion: localAICandidateGoVersion, GoReleaserVersion: localAICandidateGoReleaser,
 			GoReleaserConfigSHA256: strings.Repeat("c", sha256.Size*2),
 			Target: localAICandidateTarget{
 				GOOS: localAICandidateGOOS, GOARCH: localAICandidateGOARCH,
@@ -1087,7 +1200,12 @@ func newLocalAICandidateFixture(t *testing.T) *localAICandidateFixture {
 			PackagingOrSmokeRerunsMaximum: candidateInt64Pointer(localAICandidateRerunsMaximum),
 			GOFLAGS:                       localAICandidateGOFLAGS, GOMAXPROCS: localAICandidateGOMAXPROCS,
 		},
-		Attempts: map[string]any{"priorCycles": []string{"030", "040", "042", "045", "048", "050"}, "cycle063BuildMaximum": 1, "cycle063BuildUsed": 1},
+		Attempts: localAICandidateAttempts{
+			PriorCycles:          []string{"030", "040", "042", "045", "048", "050", "063", "067"},
+			Cycle063BuildMaximum: candidateInt64Pointer(1), Cycle063BuildUsed: candidateInt64Pointer(1),
+			Cycle067BuildMaximum: candidateInt64Pointer(2), Cycle067BuildUsed: candidateInt64Pointer(2),
+			Cycle068BuildMaximum: candidateInt64Pointer(1), Cycle068BuildUsed: candidateInt64Pointer(1),
+		},
 	}
 	roots := make([]localAICandidateRoot, 0, 8)
 	for _, name := range []string{"HOME", "USERPROFILE", "install", "config", "state", "models", "backend", "HF"} {

--- a/tests/release/localai_install_candidate_test.go
+++ b/tests/release/localai_install_candidate_test.go
@@ -28,10 +28,12 @@ import (
 
 const (
 	localAICandidateManifestEnv, localAICandidateSchemaVersion, localAICandidateProject                                                                                                                                                                                                                                                  = "INFINITE_YOU_LOCALAI_CANDIDATE_MANIFEST", "localai-windows-install-candidate/v1", "localai"
-	localAICandidateCycle, localAICandidateGoVersion, localAICandidateGOFLAGS, localAICandidateGOMAXPROCS, localAICandidateObserverQueryMode                                                                                                                                                                                             = "070", "go1.26.8", "-p=4", "4", "one-full-TCP-table-query-per-interval-filtered-to-owned-process-identities"
+	localAICandidateCycle, localAICandidateGoVersion, localAICandidateGOFLAGS, localAICandidateGOMAXPROCS, localAICandidateObserverQueryMode                                                                                                                                                                                             = "076", "go1.26.8", "-p=4", "4", "one-full-TCP-table-query-per-interval-filtered-to-owned-process-identities"
 	localAICandidateRepository, localAICandidateSourceCommit, localAICandidateSourceTree                                                                                                                                                                                                                                                 = "https://github.com/portpowered/you-agent-factory", "059474b2c00915865306a33ca5e3d02b618bb6f0", "ae5d9c87fbc99a898ad2c11e1409105d78e4a094"
 	localAICandidateGoReleaser, localAICandidateGOOS, localAICandidateGOARCH                                                                                                                                                                                                                                                             = "v2.12.7", "windows", "amd64"
+	localAICandidateNativeToolVersion, localAICandidateNativeToolSHA256                                                                                                                                                                                                                                                                  = "0.27.7", "44ce6728d54c891b1c5a6d7dbfb1a0f13419884cca0b090f1fbcf0dcd8bee0e9"
 	localAICandidateTemporaryDiskMaximum, localAICandidateToolDownloadMaximum, localAICandidateModelDownloadMaximum, localAICandidateModelCallsMaximum, localAICandidatePaidUSDMaximum, localAICandidateDescendantMaximum, localAICandidateRerunsMaximum, localAICandidateProcessNetworkGapMaximum, localAICandidateDiskGapMaximum int64 = 4294967296, 0, 0, 0, 0, 36, 1, 2000, 2000
+	localAICandidateNativeToolBytes                                                                                                                                                                                                                                                                                                int64 = 11386368
 )
 
 var localAICandidateSHA256Pattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
@@ -92,6 +94,8 @@ type localAICandidateAttempts struct {
 	Cycle068BuildUsed    *int64   `json:"cycle068BuildUsed"`
 	Cycle070BuildMaximum *int64   `json:"cycle070BuildMaximum"`
 	Cycle070BuildUsed    *int64   `json:"cycle070BuildUsed"`
+	Cycle076BuildMaximum *int64   `json:"cycle076BuildMaximum"`
+	Cycle076BuildUsed    *int64   `json:"cycle076BuildUsed"`
 }
 type localAICandidateArtifactEvidence struct {
 	Role   string `json:"role"`
@@ -239,6 +243,38 @@ type localAICandidateObserverReport struct {
 	Observation     localAICandidateObserverEvidence         `json:"observation"`
 	Cleanup         localAICandidateObserverCleanup          `json:"cleanup"`
 	ReleaseCheckout *localAICandidateReleaseCheckoutEvidence `json:"releaseCheckout"`
+}
+type localAICandidateNativeToolLaunch struct {
+	Status   string `json:"status"`
+	Path     string `json:"path"`
+	ExitCode *int64 `json:"exitCode"`
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+	Error    string `json:"error"`
+}
+type localAICandidateNativeToolFile struct {
+	Path       string                           `json:"path"`
+	PathLength int                              `json:"pathLength"`
+	Bytes      int64                            `json:"bytes"`
+	SHA256     string                           `json:"sha256"`
+	Launch     localAICandidateNativeToolLaunch `json:"launch"`
+}
+type localAICandidateNativeToolReport struct {
+	SchemaVersion string `json:"schemaVersion"`
+	Status        string `json:"status"`
+	Cycle         string `json:"cycle"`
+	Property      string `json:"property"`
+	ShortRoot     struct {
+		Status     string `json:"status"`
+		Path       string `json:"path"`
+		Parent     string `json:"parent"`
+		PathLength int    `json:"pathLength"`
+		Present    bool   `json:"present"`
+		Empty      bool   `json:"empty"`
+	} `json:"shortRoot"`
+	LongPath  localAICandidateNativeToolFile  `json:"longPath"`
+	ShortPath localAICandidateNativeToolFile  `json:"shortPath"`
+	Cleanup   localAICandidateObserverCleanup `json:"cleanup"`
 }
 
 func localAICandidateManifestPath(t *testing.T, purpose string) string {
@@ -471,7 +507,7 @@ func TestLocalAICandidateManifestValidationRejectsDriftAndAmbiguity(t *testing.T
 			}
 		})
 	}
-	for _, cycle := range []string{"030", "040", "042", "045", "048", "050", "063", "067", "068"} {
+	for _, cycle := range []string{"030", "040", "042", "045", "048", "050", "063", "067", "068", "070", "074"} {
 		cycle := cycle
 		t.Run("historical cycle "+cycle, func(t *testing.T) {
 			fixture := newLocalAICandidateFixture(t)
@@ -670,6 +706,129 @@ func TestLocalAICandidatePreconditionsFailClosedBeforeInstallation(t *testing.T)
 	if err := validateLocalAICandidatePreconditions(fixture.taskPath, fixture.roots); err != nil {
 		t.Fatalf("validate empty roots: %v", err)
 	}
+}
+func TestLocalAICandidateShortRootValidation(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows short-root validation is only available on Windows")
+	}
+	parent := t.TempDir()
+	run := func(name, rootPath, wantError string) {
+		t.Run(name, func(t *testing.T) {
+			reportPath := filepath.Join(t.TempDir(), "short-root-report.json")
+			command := localAICandidatePowerShellCommand(t,
+				"-InstallDir", t.TempDir(),
+				"-ValidateShortRoot",
+				"-ShortRootParent", parent,
+				"-ShortRootPath", rootPath,
+				"-ShortRootReportPath", reportPath,
+				"-ShortRootMaximumPathLength", "220",
+			)
+			output, err := command.CombinedOutput()
+			raw, readErr := os.ReadFile(reportPath)
+			if readErr != nil {
+				t.Fatalf("read short-root report: %v\n%s", readErr, output)
+			}
+			var report struct {
+				SchemaVersion string `json:"schemaVersion"`
+				Status        string `json:"status"`
+				Cycle         string `json:"cycle"`
+				Property      string `json:"property"`
+				Root          struct {
+					Status       string `json:"status"`
+					Path         string `json:"path"`
+					Parent       string `json:"parent"`
+					RelativePath string `json:"relativePath"`
+					PathLength   int    `json:"pathLength"`
+					Present      bool   `json:"present"`
+					Empty        bool   `json:"empty"`
+				} `json:"root"`
+				Cleanup localAICandidateObserverCleanup `json:"cleanup"`
+				Error   string                          `json:"error"`
+			}
+			if decodeErr := decodeLocalAICandidateJSON(raw, &report); decodeErr != nil {
+				t.Fatalf("decode short-root report: %v", decodeErr)
+			}
+			if wantError == "" {
+				if err != nil || report.Status != "PASS" || report.Cycle != localAICandidateCycle || report.Root.Status != "PASS" || report.Root.PathLength > 220 || !report.Root.Empty {
+					t.Fatalf("short-root success = err=%v report=%#v output=%s, want PASS contained empty root", err, report, output)
+				}
+				return
+			}
+			if err == nil || report.Status != "FAIL" || !strings.Contains(report.Error, wantError) {
+				t.Fatalf("short-root failure = err=%v report=%#v output=%s, want %q", err, report, output, wantError)
+			}
+		})
+	}
+
+	run("absent root", filepath.Join(parent, "localai-c076-absent"), "")
+	emptyRoot := filepath.Join(parent, "localai-c076-empty")
+	if err := os.Mkdir(emptyRoot, 0o700); err != nil {
+		t.Fatalf("create empty short root: %v", err)
+	}
+	run("empty root", emptyRoot, "")
+	nonemptyRoot := filepath.Join(parent, "localai-c076-nonempty")
+	if err := os.Mkdir(nonemptyRoot, 0o700); err != nil {
+		t.Fatalf("create nonempty short root: %v", err)
+	}
+	markerPath := filepath.Join(nonemptyRoot, "ambient-marker.txt")
+	if err := os.WriteFile(markerPath, []byte("must remain"), 0o600); err != nil {
+		t.Fatalf("write short-root marker: %v", err)
+	}
+	run("nonempty collision", nonemptyRoot, "not empty")
+	longRoot := filepath.Join(parent, strings.Repeat("r", 230))
+	run("path length", longRoot, "path length")
+	run("outside parent", filepath.Join(t.TempDir(), "outside"), "outside the contained root")
+
+	reparseTarget := filepath.Join(t.TempDir(), "reparse-target")
+	if err := os.Mkdir(reparseTarget, 0o700); err != nil {
+		t.Fatalf("create reparse target: %v", err)
+	}
+	reparseRoot := filepath.Join(parent, "localai-c076-reparse")
+	linkCommand := exec.Command("cmd.exe", "/c", "mklink", "/J", reparseRoot, reparseTarget)
+	if output, err := linkCommand.CombinedOutput(); err != nil {
+		t.Skipf("short-root reparse fixture unavailable: %v (%s)", err, output)
+	}
+	t.Cleanup(func() { _ = os.Remove(reparseRoot) })
+	run("reparse collision", reparseRoot, "reparse point")
+}
+func TestLocalAICandidateNativeToolPath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows native-tool readiness is only available on Windows")
+	}
+	longPath := strings.TrimSpace(os.Getenv("INFINITE_YOU_LOCALAI_NATIVE_LONG_PATH"))
+	shortPath := strings.TrimSpace(os.Getenv("INFINITE_YOU_LOCALAI_NATIVE_SHORT_PATH"))
+	shortRoot := strings.TrimSpace(os.Getenv("INFINITE_YOU_LOCALAI_NATIVE_SHORT_ROOT"))
+	shortParent := strings.TrimSpace(os.Getenv("INFINITE_YOU_LOCALAI_NATIVE_SHORT_PARENT"))
+	if longPath == "" || shortPath == "" || shortRoot == "" || shortParent == "" {
+		t.Skip("set INFINITE_YOU_LOCALAI_NATIVE_LONG_PATH, INFINITE_YOU_LOCALAI_NATIVE_SHORT_PATH, INFINITE_YOU_LOCALAI_NATIVE_SHORT_ROOT, and INFINITE_YOU_LOCALAI_NATIVE_SHORT_PARENT for the local-real native-tool witness")
+	}
+	reportPath := strings.TrimSpace(os.Getenv("INFINITE_YOU_LOCALAI_NATIVE_REPORT_PATH"))
+	if reportPath == "" {
+		reportPath = filepath.Join(t.TempDir(), "native-tool-report.json")
+	}
+	command := localAICandidatePowerShellCommand(t,
+		"-InstallDir", t.TempDir(),
+		"-NativeToolFixture",
+		"-NativeToolLongPath", longPath,
+		"-NativeToolShortPath", shortPath,
+		"-NativeToolRoot", shortRoot,
+		"-NativeToolParent", shortParent,
+		"-NativeToolReportPath", reportPath,
+		"-NativeToolTimeoutMilliseconds", "10000",
+	)
+	output, err := command.CombinedOutput()
+	raw, readErr := os.ReadFile(reportPath)
+	if readErr != nil {
+		t.Fatalf("read native-tool report: %v\n%s", readErr, output)
+	}
+	var report localAICandidateNativeToolReport
+	if decodeErr := decodeLocalAICandidateJSON(raw, &report); decodeErr != nil {
+		t.Fatalf("decode native-tool report: %v", decodeErr)
+	}
+	if err != nil || report.SchemaVersion != "localai-windows-install-candidate-native-tool/v1" || report.Status != "PASS" || report.Cycle != localAICandidateCycle || report.Property == "" || report.LongPath.PathLength != 280 || report.LongPath.Bytes != localAICandidateNativeToolBytes || report.LongPath.SHA256 != localAICandidateNativeToolSHA256 || report.LongPath.Launch.Status == "PASS" || report.ShortRoot.PathLength > 220 || report.ShortPath.PathLength > 220 || report.ShortPath.Bytes != localAICandidateNativeToolBytes || report.ShortPath.SHA256 != localAICandidateNativeToolSHA256 || report.ShortPath.Launch.Status != "PASS" || report.ShortPath.Launch.ExitCode == nil || *report.ShortPath.Launch.ExitCode != 0 || strings.TrimSpace(report.ShortPath.Launch.Stdout) != localAICandidateNativeToolVersion || report.Cleanup.Status != "PASS" {
+		t.Fatalf("native-tool witness = err=%v report=%#v output=%s, want exact long failure and short 0.27.7/exit0", err, report, output)
+	}
+	t.Logf("LOCALAI-NATIVE status=PASS evidence=%s", raw)
 }
 func TestLocalAICandidateObserverEnvelopeFixture(t *testing.T) {
 	if runtime.GOOS != "windows" {
@@ -1657,6 +1816,7 @@ func validateLocalAICandidateAttempts(attempts localAICandidateAttempts) error {
 		{name: "cycle067", maximum: attempts.Cycle067BuildMaximum, used: attempts.Cycle067BuildUsed, wantMax: 2, wantUse: 2},
 		{name: "cycle068", maximum: attempts.Cycle068BuildMaximum, used: attempts.Cycle068BuildUsed, wantMax: 1, wantUse: 1},
 		{name: "cycle070", maximum: attempts.Cycle070BuildMaximum, used: attempts.Cycle070BuildUsed, wantMax: 1, wantUse: 1},
+		{name: "cycle076", maximum: attempts.Cycle076BuildMaximum, used: attempts.Cycle076BuildUsed, wantMax: 1, wantUse: 1},
 	} {
 		if attempt.maximum == nil || attempt.used == nil || *attempt.maximum != attempt.wantMax || *attempt.used != attempt.wantUse {
 			return fmt.Errorf("candidate attempts %sBuildMaximum/Used = %v/%v, want %d/%d", attempt.name, valueOrZero(attempt.maximum), valueOrZero(attempt.used), attempt.wantMax, attempt.wantUse)
@@ -1940,6 +2100,7 @@ func newLocalAICandidateFixture(t *testing.T) *localAICandidateFixture {
 			Cycle067BuildMaximum: candidateInt64Pointer(2), Cycle067BuildUsed: candidateInt64Pointer(2),
 			Cycle068BuildMaximum: candidateInt64Pointer(1), Cycle068BuildUsed: candidateInt64Pointer(1),
 			Cycle070BuildMaximum: candidateInt64Pointer(1), Cycle070BuildUsed: candidateInt64Pointer(1),
+			Cycle076BuildMaximum: candidateInt64Pointer(1), Cycle076BuildUsed: candidateInt64Pointer(1),
 		},
 	}
 	roots := make([]localAICandidateRoot, 0, 8)

--- a/tests/release/localai_install_candidate_test.go
+++ b/tests/release/localai_install_candidate_test.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	localAICandidateManifestEnv, localAICandidateSchemaVersion, localAICandidateProject                                                                                                                                                                                                                                                  = "INFINITE_YOU_LOCALAI_CANDIDATE_MANIFEST", "localai-windows-install-candidate/v1", "localai"
-	localAICandidateCycle, localAICandidateGoVersion, localAICandidateGOFLAGS, localAICandidateGOMAXPROCS, localAICandidateObserverQueryMode                                                                                                                                                                                             = "068", "go1.26.8", "-p=4", "4", "one-full-TCP-table-query-per-interval-filtered-to-owned-process-identities"
+	localAICandidateCycle, localAICandidateGoVersion, localAICandidateGOFLAGS, localAICandidateGOMAXPROCS, localAICandidateObserverQueryMode                                                                                                                                                                                             = "070", "go1.26.8", "-p=4", "4", "one-full-TCP-table-query-per-interval-filtered-to-owned-process-identities"
 	localAICandidateRepository, localAICandidateSourceCommit, localAICandidateSourceTree                                                                                                                                                                                                                                                 = "https://github.com/portpowered/you-agent-factory", "059474b2c00915865306a33ca5e3d02b618bb6f0", "ae5d9c87fbc99a898ad2c11e1409105d78e4a094"
 	localAICandidateGoReleaser, localAICandidateGOOS, localAICandidateGOARCH                                                                                                                                                                                                                                                             = "v2.12.7", "windows", "amd64"
 	localAICandidateTemporaryDiskMaximum, localAICandidateToolDownloadMaximum, localAICandidateModelDownloadMaximum, localAICandidateModelCallsMaximum, localAICandidatePaidUSDMaximum, localAICandidateDescendantMaximum, localAICandidateRerunsMaximum, localAICandidateProcessNetworkGapMaximum, localAICandidateDiskGapMaximum int64 = 4294967296, 0, 0, 0, 0, 36, 1, 2000, 2000
@@ -87,6 +87,8 @@ type localAICandidateAttempts struct {
 	Cycle067BuildUsed    *int64   `json:"cycle067BuildUsed"`
 	Cycle068BuildMaximum *int64   `json:"cycle068BuildMaximum"`
 	Cycle068BuildUsed    *int64   `json:"cycle068BuildUsed"`
+	Cycle070BuildMaximum *int64   `json:"cycle070BuildMaximum"`
+	Cycle070BuildUsed    *int64   `json:"cycle070BuildUsed"`
 }
 type localAICandidateArtifactEvidence struct {
 	Role   string `json:"role"`
@@ -129,6 +131,10 @@ type localAICandidateProcessNetworkObserver struct {
 	QueryMode                      string   `json:"queryMode"`
 	ForbiddenProcesses             []string `json:"forbiddenProcesses"`
 	Error                          string   `json:"error"`
+	ReleaseStatusCleanBeforeRoot   bool     `json:"releaseStatusCleanBeforeRoot"`
+	ReleaseStatusCleanDuringRoot   bool     `json:"releaseStatusCleanDuringRoot"`
+	ReleaseStatusCleanAfterOutput  bool     `json:"releaseStatusCleanAfterOutput"`
+	ReleaseStatusChecks            int      `json:"releaseStatusChecks"`
 }
 type localAICandidateDiskObserver struct {
 	Independent            bool   `json:"independent"`
@@ -154,13 +160,32 @@ type localAICandidateObserverCleanup struct {
 	RemainingTaskPaths []string `json:"remainingTaskPaths"`
 	Errors             []string `json:"errors"`
 }
+type localAICandidateReleaseCheckoutEvidence struct {
+	Status                      string   `json:"status"`
+	GitDirIsDirectory           bool     `json:"gitDirIsDirectory"`
+	CheckoutPath                string   `json:"checkoutPath"`
+	DetachedHead                bool     `json:"detachedHead"`
+	Head                        string   `json:"head"`
+	Tree                        string   `json:"tree"`
+	Origin                      string   `json:"origin"`
+	PrivateExcludePath          string   `json:"privateExcludePath"`
+	PrivateExcludeBefore        []string `json:"privateExcludeBefore"`
+	PrivateExcludeAfter         []string `json:"privateExcludeAfter"`
+	PrivateExcludeAdded         []string `json:"privateExcludeAdded"`
+	StatusCleanBefore           bool     `json:"statusCleanBefore"`
+	StatusCleanAfterPreparation bool     `json:"statusCleanAfterPreparation"`
+	StatusCleanDuringOutput     bool     `json:"statusCleanDuringOutput"`
+	StatusCleanAfterOutput      bool     `json:"statusCleanAfterOutput"`
+	StatusChecks                int      `json:"statusChecks"`
+}
 type localAICandidateObserverReport struct {
-	SchemaVersion string                           `json:"schemaVersion"`
-	Status        string                           `json:"status"`
-	Cycle         string                           `json:"cycle"`
-	ReleaseStatus string                           `json:"releaseStatus"`
-	Observation   localAICandidateObserverEvidence `json:"observation"`
-	Cleanup       localAICandidateObserverCleanup  `json:"cleanup"`
+	SchemaVersion   string                                   `json:"schemaVersion"`
+	Status          string                                   `json:"status"`
+	Cycle           string                                   `json:"cycle"`
+	ReleaseStatus   string                                   `json:"releaseStatus"`
+	Observation     localAICandidateObserverEvidence         `json:"observation"`
+	Cleanup         localAICandidateObserverCleanup          `json:"cleanup"`
+	ReleaseCheckout *localAICandidateReleaseCheckoutEvidence `json:"releaseCheckout"`
 }
 
 func localAICandidateManifestPath(t *testing.T, purpose string) string {
@@ -284,6 +309,27 @@ func localAICandidateSmokeCommand(t *testing.T, manifestPath, installDir, report
 	command.Dir = root
 	return command
 }
+func localAICandidatePowerShellCommand(t *testing.T, arguments ...string) *exec.Cmd {
+	t.Helper()
+	pwsh, err := exec.LookPath("powershell.exe")
+	if err != nil {
+		t.Fatalf("candidate release smoke requires Windows PowerShell (powershell.exe): %v", err)
+	}
+	root := testutil.MustRepoRoot(t)
+	commandArguments := append([]string{"-NoProfile", "-NonInteractive", "-File", filepath.Join(root, "scripts", "release", "smoke-install.ps1")}, arguments...)
+	command := exec.Command(pwsh, commandArguments...)
+	command.Dir = root
+	return command
+}
+func localAICandidateRunGit(t *testing.T, directory string, arguments ...string) string {
+	t.Helper()
+	commandArguments := append([]string{"-C", directory}, arguments...)
+	output, err := exec.Command("git", commandArguments...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git -C %s %s: %v\n%s", directory, strings.Join(arguments, " "), err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
 func TestLocalAICandidateManifestValidationRejectsDriftAndAmbiguity(t *testing.T) {
 	tests := []struct {
 		name string
@@ -361,7 +407,7 @@ func TestLocalAICandidateManifestValidationRejectsDriftAndAmbiguity(t *testing.T
 			}
 		})
 	}
-	for _, cycle := range []string{"030", "040", "042", "045", "048", "050", "063", "067"} {
+	for _, cycle := range []string{"030", "040", "042", "045", "048", "050", "063", "067", "068"} {
 		cycle := cycle
 		t.Run("historical cycle "+cycle, func(t *testing.T) {
 			fixture := newLocalAICandidateFixture(t)
@@ -594,6 +640,128 @@ func TestLocalAICandidateObserverEnvelopeFixture(t *testing.T) {
 		t.Fatalf("observer cleanup evidence = %#v, want complete cleanup", report.Cleanup)
 	}
 	t.Logf("LOCALAI-OBSERVER status=PASS evidence=%s", raw)
+}
+func TestLocalAICandidateObserverIdentityFixture(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows observer identity fixture is only available on Windows")
+	}
+	reportPath := filepath.Join(t.TempDir(), "observer-identity-report.json")
+	command := localAICandidatePowerShellCommand(t, "-InstallDir", t.TempDir(), "-ObserverIdentityFixture", "-ObserverReportPath", reportPath)
+	command.Env = append(os.Environ(), "GOFLAGS="+localAICandidateGOFLAGS, "GOMAXPROCS="+localAICandidateGOMAXPROCS)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("observer identity fixture: %v\n%s", err, output)
+	}
+	var report struct {
+		SchemaVersion string `json:"schemaVersion"`
+		Status        string `json:"status"`
+		Cycle         string `json:"cycle"`
+		ReleaseStatus string `json:"releaseStatus"`
+		CrossInterval struct {
+			Status               string   `json:"status"`
+			ActiveIdentity       string   `json:"activeIdentity"`
+			HistoricalIdentities []string `json:"historicalIdentities"`
+			Continued            bool     `json:"continued"`
+		} `json:"crossInterval"`
+		WithinSample struct {
+			Status   string `json:"status"`
+			Rejected bool   `json:"rejected"`
+			Error    string `json:"error"`
+		} `json:"withinSample"`
+		EmptyTCP struct {
+			Status   string `json:"status"`
+			RowCount int    `json:"rowCount"`
+		} `json:"emptyTCP"`
+		QueryError struct {
+			Status string `json:"status"`
+			Error  string `json:"error"`
+		} `json:"queryError"`
+	}
+	raw, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("read observer identity report: %v", err)
+	}
+	if err := decodeLocalAICandidateJSON(raw, &report); err != nil {
+		t.Fatalf("decode observer identity report: %v", err)
+	}
+	if report.SchemaVersion != "localai-windows-install-candidate-observer-identity/v1" || report.Status != "PASS" || report.Cycle != localAICandidateCycle || report.ReleaseStatus != "observer-identity-fixture" {
+		t.Fatalf("observer identity report identity/status = %#v, want cycle-%s PASS observer-identity-fixture", report, localAICandidateCycle)
+	}
+	if report.CrossInterval.Status != "PASS" || report.CrossInterval.ActiveIdentity != "42/B" || !report.CrossInterval.Continued || !slices.Equal(report.CrossInterval.HistoricalIdentities, []string{"100/root", "42/A", "42/B"}) {
+		t.Fatalf("cross-interval identity evidence = %#v, want retired 42/A with historical 42/A and 42/B", report.CrossInterval)
+	}
+	if report.WithinSample.Status != "PASS" || !report.WithinSample.Rejected || !strings.Contains(report.WithinSample.Error, "changed identity") {
+		t.Fatalf("within-sample identity evidence = %#v, want fail-closed PID reuse", report.WithinSample)
+	}
+	if report.EmptyTCP.Status != "PASS" || report.EmptyTCP.RowCount != 0 {
+		t.Fatalf("empty TCP evidence = %#v, want valid zero-row sample", report.EmptyTCP)
+	}
+	if report.QueryError.Status != "PASS" || !strings.Contains(report.QueryError.Error, "synthetic query error") {
+		t.Fatalf("query-error evidence = %#v, want preserved query failure", report.QueryError)
+	}
+	t.Logf("LOCALAI-OBSERVER-IDENTITY status=PASS evidence=%s", raw)
+}
+func TestLocalAICandidateReleaseCheckoutPreparation(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows release checkout preparation is only available on Windows")
+	}
+	repoRoot := testutil.MustRepoRoot(t)
+	clonePath := filepath.Join(t.TempDir(), "source-clone")
+	cloneOutput, err := exec.Command("git", "clone", "--no-local", "--no-checkout", repoRoot, clonePath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("clone exact-source fixture: %v\n%s", err, cloneOutput)
+	}
+	localAICandidateRunGit(t, clonePath, "checkout", "--detach", localAICandidateSourceCommit)
+	reportPath := filepath.Join(t.TempDir(), "release-checkout-report.json")
+	command := localAICandidatePowerShellCommand(t, "-InstallDir", t.TempDir(), "-PrepareReleaseCheckout", "-ReleaseCheckoutPath", clonePath, "-ReleaseCheckoutReportPath", reportPath)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("prepare release checkout: %v\n%s", err, output)
+	}
+	var report localAICandidateReleaseCheckoutEvidence
+	raw, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("read release checkout report: %v", err)
+	}
+	if err := decodeLocalAICandidateJSON(raw, &report); err != nil {
+		t.Fatalf("decode release checkout report: %v", err)
+	}
+	distEntryCount := 0
+	for _, line := range report.PrivateExcludeAfter {
+		if line == "/dist/" {
+			distEntryCount++
+		}
+	}
+	remoteIsNonLocal := strings.Contains(report.Origin, "://") && !strings.HasPrefix(report.Origin, "file://") || strings.HasPrefix(report.Origin, "git@")
+	if report.Status != "PASS" || !report.GitDirIsDirectory || !report.DetachedHead || report.Head != localAICandidateSourceCommit || report.Tree != localAICandidateSourceTree || report.Origin == "" || remoteIsNonLocal || !report.StatusCleanBefore || !report.StatusCleanAfterPreparation || !slices.Equal(report.PrivateExcludeAdded, []string{"/dist/"}) || distEntryCount != 1 {
+		t.Fatalf("release checkout preparation evidence = %#v, want exact detached clean local clone and /dist/ addition", report)
+	}
+	distPath := filepath.Join(clonePath, "dist")
+	if err := os.MkdirAll(distPath, 0o700); err != nil {
+		t.Fatalf("create representative dist root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(distPath, "representative-output.txt"), []byte("ignored release output"), 0o600); err != nil {
+		t.Fatalf("write representative dist output: %v", err)
+	}
+	if status := localAICandidateRunGit(t, clonePath, "status", "--porcelain=v1", "--untracked-files=all"); status != "" {
+		t.Fatalf("status after ignored dist output = %q, want clean", status)
+	}
+	trackedPath := filepath.Join(clonePath, ".goreleaser.yml")
+	trackedFile, err := os.OpenFile(trackedPath, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open tracked fixture: %v", err)
+	}
+	if _, err := trackedFile.WriteString("\n# controlled dirty fixture\n"); err != nil {
+		trackedFile.Close()
+		t.Fatalf("modify tracked fixture: %v", err)
+	}
+	if err := trackedFile.Close(); err != nil {
+		t.Fatalf("close tracked fixture: %v", err)
+	}
+	if status := localAICandidateRunGit(t, clonePath, "status", "--porcelain=v1", "--untracked-files=all"); !strings.Contains(status, ".goreleaser.yml") {
+		t.Fatalf("status after tracked source modification = %q, want tracked modification", status)
+	}
+	t.Logf("LOCALAI-CLONE status=PASS evidence=%s", raw)
 }
 func validateLocalAICandidateObserverEvidence(observation localAICandidateObserverEvidence) error {
 	process := observation.ProcessNetworkObserver
@@ -909,7 +1077,7 @@ func validateLocalAICandidateIdentity(manifest localAICandidateManifest) error {
 	return nil
 }
 func validateLocalAICandidateAttempts(attempts localAICandidateAttempts) error {
-	wantPriorCycles := []string{"030", "040", "042", "045", "048", "050", "063", "067"}
+	wantPriorCycles := []string{"030", "040", "042", "045", "048", "050", "063", "067", "068"}
 	if !slices.Equal(attempts.PriorCycles, wantPriorCycles) {
 		return fmt.Errorf("candidate attempts priorCycles = %v, want %v", attempts.PriorCycles, wantPriorCycles)
 	}
@@ -923,6 +1091,7 @@ func validateLocalAICandidateAttempts(attempts localAICandidateAttempts) error {
 		{name: "cycle063", maximum: attempts.Cycle063BuildMaximum, used: attempts.Cycle063BuildUsed, wantMax: 1, wantUse: 1},
 		{name: "cycle067", maximum: attempts.Cycle067BuildMaximum, used: attempts.Cycle067BuildUsed, wantMax: 2, wantUse: 2},
 		{name: "cycle068", maximum: attempts.Cycle068BuildMaximum, used: attempts.Cycle068BuildUsed, wantMax: 1, wantUse: 1},
+		{name: "cycle070", maximum: attempts.Cycle070BuildMaximum, used: attempts.Cycle070BuildUsed, wantMax: 1, wantUse: 1},
 	} {
 		if attempt.maximum == nil || attempt.used == nil || *attempt.maximum != attempt.wantMax || *attempt.used != attempt.wantUse {
 			return fmt.Errorf("candidate attempts %sBuildMaximum/Used = %v/%v, want %d/%d", attempt.name, valueOrZero(attempt.maximum), valueOrZero(attempt.used), attempt.wantMax, attempt.wantUse)
@@ -1201,10 +1370,11 @@ func newLocalAICandidateFixture(t *testing.T) *localAICandidateFixture {
 			GOFLAGS:                       localAICandidateGOFLAGS, GOMAXPROCS: localAICandidateGOMAXPROCS,
 		},
 		Attempts: localAICandidateAttempts{
-			PriorCycles:          []string{"030", "040", "042", "045", "048", "050", "063", "067"},
+			PriorCycles:          []string{"030", "040", "042", "045", "048", "050", "063", "067", "068"},
 			Cycle063BuildMaximum: candidateInt64Pointer(1), Cycle063BuildUsed: candidateInt64Pointer(1),
 			Cycle067BuildMaximum: candidateInt64Pointer(2), Cycle067BuildUsed: candidateInt64Pointer(2),
 			Cycle068BuildMaximum: candidateInt64Pointer(1), Cycle068BuildUsed: candidateInt64Pointer(1),
+			Cycle070BuildMaximum: candidateInt64Pointer(1), Cycle070BuildUsed: candidateInt64Pointer(1),
 		},
 	}
 	roots := make([]localAICandidateRoot, 0, 8)

--- a/tests/release/localai_install_candidate_test.go
+++ b/tests/release/localai_install_candidate_test.go
@@ -4,26 +4,29 @@ import (
 	"archive/zip"
 	"bytes"
 	"crypto/sha256"
+	"debug/buildinfo"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/portpowered/infinite-you/internal/testutil"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"runtime/debug"
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/portpowered/infinite-you/internal/testutil"
 )
 
 const (
 	localAICandidateManifestEnv, localAICandidateSchemaVersion, localAICandidateProject                                                                                                                                                                                                                                                  = "INFINITE_YOU_LOCALAI_CANDIDATE_MANIFEST", "localai-windows-install-candidate/v1", "localai"
-	localAICandidateCycle, localAICandidateGOFLAGS, localAICandidateGOMAXPROCS                                                                                                                                                                                                                                                           = "063", "-p=4", "4"
-	localAICandidateRepository, localAICandidateSourceCommit, localAICandidateSourceTree                                                                                                                                                                                                                                                 = "https://github.com/portpowered/you-agent-factory", "f0092a8bebfb50d70fa2dff7dbb6d720eb28e3bc", "2c00a0d213fbf878402b66895466053a832a9583"
+	localAICandidateCycle, localAICandidateGOFLAGS, localAICandidateGOMAXPROCS                                                                                                                                                                                                                                                           = "067", "-p=4", "4"
+	localAICandidateRepository, localAICandidateSourceCommit, localAICandidateSourceTree                                                                                                                                                                                                                                                 = "https://github.com/portpowered/you-agent-factory", "059474b2c00915865306a33ca5e3d02b618bb6f0", "ae5d9c87fbc99a898ad2c11e1409105d78e4a094"
 	localAICandidateGoReleaser, localAICandidateGOOS, localAICandidateGOARCH                                                                                                                                                                                                                                                             = "v2.12.7", "windows", "amd64"
 	localAICandidateTemporaryDiskMaximum, localAICandidateToolDownloadMaximum, localAICandidateModelDownloadMaximum, localAICandidateModelCallsMaximum, localAICandidatePaidUSDMaximum, localAICandidateDescendantMaximum, localAICandidateRerunsMaximum, localAICandidateProcessNetworkGapMaximum, localAICandidateDiskGapMaximum int64 = 4294967296, 0, 0, 0, 0, 36, 1, 2000, 15000
 )
@@ -83,18 +86,20 @@ type localAICandidateArtifactEvidence struct {
 	SHA256 string `json:"sha256"`
 }
 type localAICandidateValidationEvidence struct {
-	Status           string                           `json:"status"`
-	Property         string                           `json:"property"`
-	SchemaVersion    string                           `json:"schemaVersion"`
-	SourceCommit     string                           `json:"sourceCommit"`
-	SourceTree       string                           `json:"sourceTree"`
-	CandidateVersion string                           `json:"candidateVersion"`
-	CLIVersion       string                           `json:"cliVersion"`
-	Target           string                           `json:"target"`
-	Archive          localAICandidateArtifactEvidence `json:"archive"`
-	Installer        localAICandidateArtifactEvidence `json:"installer"`
-	Manifest         localAICandidateArtifactEvidence `json:"manifest"`
-	Preconditions    string                           `json:"preconditions"`
+	Status                 string                           `json:"status"`
+	Property               string                           `json:"property"`
+	SchemaVersion          string                           `json:"schemaVersion"`
+	SourceCommit           string                           `json:"sourceCommit"`
+	SourceTree             string                           `json:"sourceTree"`
+	EmbeddedSourceRevision string                           `json:"embeddedSourceRevision"`
+	EmbeddedVCSModified    bool                             `json:"embeddedVCSModified"`
+	CandidateVersion       string                           `json:"candidateVersion"`
+	CLIVersion             string                           `json:"cliVersion"`
+	Target                 string                           `json:"target"`
+	Archive                localAICandidateArtifactEvidence `json:"archive"`
+	Installer              localAICandidateArtifactEvidence `json:"installer"`
+	Manifest               localAICandidateArtifactEvidence `json:"manifest"`
+	Preconditions          string                           `json:"preconditions"`
 }
 type localAICandidateRoot struct {
 	Name string
@@ -334,7 +339,7 @@ func TestLocalAICandidateManifestValidationRejectsDriftAndAmbiguity(t *testing.T
 			fixture := newLocalAICandidateFixture(t)
 			fixture.manifest.Cycle = cycle
 			fixture.writeManifest(t)
-			if _, err := validateLocalAICandidate(fixture.manifestPath); err == nil || !strings.Contains(err.Error(), `candidate cycle = "`+cycle+`", want "063"`) {
+			if _, err := validateLocalAICandidate(fixture.manifestPath); err == nil || !strings.Contains(err.Error(), `candidate cycle = "`+cycle+`", want "`+localAICandidateCycle+`"`) {
 				t.Fatalf("validate historical cycle error = %v, want cycle %s rejection", err, cycle)
 			}
 		})
@@ -373,12 +378,103 @@ func TestLocalAICandidateManifestValidationRejectsReparseCandidateDirectory(t *t
 }
 func TestLocalAICandidateManifestValidationAcceptsMatchingArtifacts(t *testing.T) {
 	fixture := newLocalAICandidateFixture(t)
-	evidence, err := validateLocalAICandidate(fixture.manifestPath)
+	evidence, err := validateLocalAICandidateWithBuildInfoReader(fixture.manifestPath, func(string) (*debug.BuildInfo, error) {
+		return localAICandidateCleanBuildInfo(), nil
+	})
 	if err != nil {
 		t.Fatalf("validate matching candidate: %v", err)
 	}
-	if evidence.Status != "PASS" || evidence.Property == "" || evidence.Archive.File != "you_1.2.3-snapshot-test_windows_amd64.zip" || evidence.Archive.Bytes != int64(len(fixture.archiveBytes)) || evidence.Installer.File != "install.ps1" || evidence.Installer.Bytes <= 0 {
-		t.Fatalf("candidate evidence = %#v, want PASS with matching archive, executable, and installer identity", evidence)
+	if evidence.Status != "PASS" || evidence.Property == "" || evidence.SourceCommit != localAICandidateSourceCommit || evidence.SourceTree != localAICandidateSourceTree || evidence.EmbeddedSourceRevision != localAICandidateSourceCommit || evidence.EmbeddedVCSModified || evidence.Archive.File != "you_1.2.3-snapshot-test_windows_amd64.zip" || evidence.Archive.Bytes != int64(len(fixture.archiveBytes)) || evidence.Installer.File != "install.ps1" || evidence.Installer.Bytes <= 0 {
+		t.Fatalf("candidate evidence = %#v, want PASS with matching archive, executable, and clean embedded revision", evidence)
+	}
+}
+func TestLocalAICandidateBuildInfoValidationRejectsDriftAndAmbiguity(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings []debug.BuildSetting
+		readErr  error
+		want     string
+	}{
+		{
+			name: "clean revision and VCS state",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: localAICandidateSourceCommit},
+				{Key: "vcs.modified", Value: "false"},
+			},
+		},
+		{
+			name:     "missing revision",
+			settings: []debug.BuildSetting{{Key: "vcs.modified", Value: "false"}},
+			want:     "vcs.revision is missing",
+		},
+		{
+			name: "mismatched revision",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: strings.Repeat("d", 40)},
+				{Key: "vcs.modified", Value: "false"},
+			},
+			want: "vcs.revision =",
+		},
+		{
+			name:     "missing modified state",
+			settings: []debug.BuildSetting{{Key: "vcs.revision", Value: localAICandidateSourceCommit}},
+			want:     "vcs.modified is missing",
+		},
+		{
+			name: "dirty modified state",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: localAICandidateSourceCommit},
+				{Key: "vcs.modified", Value: "true"},
+			},
+			want: "vcs.modified =",
+		},
+		{
+			name: "duplicate revision settings",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: localAICandidateSourceCommit},
+				{Key: "vcs.revision", Value: localAICandidateSourceCommit},
+				{Key: "vcs.modified", Value: "false"},
+			},
+			want: "duplicate \"vcs.revision\" settings",
+		},
+		{
+			name: "duplicate modified settings",
+			settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: localAICandidateSourceCommit},
+				{Key: "vcs.modified", Value: "false"},
+				{Key: "vcs.modified", Value: "true"},
+			},
+			want: "duplicate \"vcs.modified\" settings",
+		},
+		{
+			name:    "unreadable executable metadata",
+			readErr: errors.New("not a Go executable"),
+			want:    "read executable build info",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			build := &debug.BuildInfo{Settings: test.settings}
+			revision, modified, err := readAndValidateLocalAICandidateBuildInfo("candidate.exe", func(string) (*debug.BuildInfo, error) {
+				return build, test.readErr
+			})
+			if test.want == "" {
+				if err != nil || revision != localAICandidateSourceCommit || modified {
+					t.Fatalf("build-info validation = revision=%q modified=%v error=%v, want clean protected revision", revision, modified, err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("build-info validation error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+func TestLocalAICandidateBuildInfoReadFailureFailsClosed(t *testing.T) {
+	fixture := newLocalAICandidateFixture(t)
+	if _, err := validateLocalAICandidate(fixture.manifestPath); err == nil || !strings.Contains(err.Error(), "read executable build info") {
+		t.Fatalf("candidate build-info read error = %v, want fail-closed metadata evidence", err)
 	}
 }
 func TestLocalAICandidatePreconditionsFailClosedBeforeInstallation(t *testing.T) {
@@ -461,7 +557,7 @@ func TestLocalAICandidateObserverEnvelopeFixture(t *testing.T) {
 		t.Fatalf("decode observer report: %v", err)
 	}
 	if report.SchemaVersion != "localai-windows-install-candidate-observer/v1" || report.Status != "PASS" || report.Cycle != localAICandidateCycle || report.ReleaseStatus != "observer-fixture" {
-		t.Fatalf("observer report identity/status = %#v, want cycle-063 PASS observer-fixture", report)
+		t.Fatalf("observer report identity/status = %#v, want cycle-%s PASS observer-fixture", report, localAICandidateCycle)
 	}
 	if err := validateLocalAICandidateObserverEvidence(report.Observation); err != nil {
 		t.Fatalf("observer report evidence: %v", err)
@@ -489,6 +585,9 @@ func validateLocalAICandidateObserverEvidence(observation localAICandidateObserv
 	return nil
 }
 func validateLocalAICandidate(manifestPath string) (localAICandidateValidationEvidence, error) {
+	return validateLocalAICandidateWithBuildInfoReader(manifestPath, buildinfo.ReadFile)
+}
+func validateLocalAICandidateWithBuildInfoReader(manifestPath string, readBuildInfo func(string) (*debug.BuildInfo, error)) (localAICandidateValidationEvidence, error) {
 	if !filepath.IsAbs(manifestPath) {
 		return localAICandidateValidationEvidence{}, fmt.Errorf("candidate manifest path %q must be absolute", manifestPath)
 	}
@@ -532,6 +631,10 @@ func validateLocalAICandidate(manifestPath string) (localAICandidateValidationEv
 	if !ok {
 		return localAICandidateValidationEvidence{}, errors.New("candidate manifest is missing windows-installer artifact")
 	}
+	executable, ok := artifactByRole["windows-amd64-executable"]
+	if !ok {
+		return localAICandidateValidationEvidence{}, errors.New("candidate manifest is missing windows-amd64-executable artifact")
+	}
 	archiveCandidates, err := localAICandidateArchiveCandidates(candidateDir)
 	if err != nil {
 		return localAICandidateValidationEvidence{}, err
@@ -550,17 +653,23 @@ func validateLocalAICandidate(manifestPath string) (localAICandidateValidationEv
 	if err != nil {
 		return localAICandidateValidationEvidence{}, fmt.Errorf("validate windows installer: %w", err)
 	}
+	embeddedSourceRevision, embeddedVCSModified, err := readAndValidateLocalAICandidateBuildInfo(filepath.Join(candidateDir, filepath.FromSlash(executable.File)), readBuildInfo)
+	if err != nil {
+		return localAICandidateValidationEvidence{}, err
+	}
 	return localAICandidateValidationEvidence{
-		Status:           "PASS",
-		Property:         "prebuilt-candidate-schema-source-target-artifact-and-detached-digest-identity",
-		SchemaVersion:    manifest.SchemaVersion,
-		SourceCommit:     manifest.Source.Commit,
-		SourceTree:       manifest.Source.Tree,
-		CandidateVersion: manifest.Build.CandidateVersion,
-		CLIVersion:       manifest.Build.CLIVersion,
-		Target:           manifest.Build.Target.GOOS + "/" + manifest.Build.Target.GOARCH,
-		Archive:          archiveEvidence,
-		Installer:        installerEvidence,
+		Status:                 "PASS",
+		Property:               "prebuilt-candidate-schema-source-target-artifact-and-detached-digest-identity",
+		SchemaVersion:          manifest.SchemaVersion,
+		SourceCommit:           manifest.Source.Commit,
+		SourceTree:             manifest.Source.Tree,
+		EmbeddedSourceRevision: embeddedSourceRevision,
+		EmbeddedVCSModified:    embeddedVCSModified,
+		CandidateVersion:       manifest.Build.CandidateVersion,
+		CLIVersion:             manifest.Build.CLIVersion,
+		Target:                 manifest.Build.Target.GOOS + "/" + manifest.Build.Target.GOARCH,
+		Archive:                archiveEvidence,
+		Installer:              installerEvidence,
 		Manifest: localAICandidateArtifactEvidence{
 			Role:   "candidate-manifest",
 			File:   filepath.Base(manifestPath),
@@ -569,6 +678,51 @@ func validateLocalAICandidate(manifestPath string) (localAICandidateValidationEv
 		},
 		Preconditions: "not-run-by-schema-cell; install cell must supply task-owned PATH and roots",
 	}, nil
+}
+func readAndValidateLocalAICandidateBuildInfo(path string, readBuildInfo func(string) (*debug.BuildInfo, error)) (string, bool, error) {
+	if readBuildInfo == nil {
+		return "", false, errors.New("read executable build info: reader is nil")
+	}
+	build, err := readBuildInfo(path)
+	if err != nil {
+		return "", false, fmt.Errorf("read executable build info %q: %w", path, err)
+	}
+	if build == nil {
+		return "", false, fmt.Errorf("read executable build info %q: returned no metadata", path)
+	}
+	revision, err := localAICandidateBuildSetting(build, "vcs.revision")
+	if err != nil {
+		return "", false, err
+	}
+	if revision != localAICandidateSourceCommit {
+		return "", false, fmt.Errorf("candidate executable build info vcs.revision = %q, want %q", revision, localAICandidateSourceCommit)
+	}
+	modified, err := localAICandidateBuildSetting(build, "vcs.modified")
+	if err != nil {
+		return "", false, err
+	}
+	if modified != "false" {
+		return "", false, fmt.Errorf("candidate executable build info vcs.modified = %q, want %q", modified, "false")
+	}
+	return revision, false, nil
+}
+func localAICandidateBuildSetting(build *debug.BuildInfo, key string) (string, error) {
+	var value string
+	found := false
+	for _, setting := range build.Settings {
+		if setting.Key != key {
+			continue
+		}
+		if found {
+			return "", fmt.Errorf("candidate executable build info contains duplicate %q settings", key)
+		}
+		found = true
+		value = strings.TrimSpace(setting.Value)
+	}
+	if !found || value == "" {
+		return "", fmt.Errorf("candidate executable build info %s is missing", key)
+	}
+	return value, nil
 }
 func readLocalAICandidateManifest(manifestPath string) ([]byte, localAICandidateManifest, error) {
 	manifestBytes, err := os.ReadFile(manifestPath)
@@ -995,5 +1149,11 @@ func localAICandidateSHA256(t *testing.T, path string) string {
 		t.Fatalf("hash candidate fixture %q: %v", path, err)
 	}
 	return digest
+}
+func localAICandidateCleanBuildInfo() *debug.BuildInfo {
+	return &debug.BuildInfo{Settings: []debug.BuildSetting{
+		{Key: "vcs.revision", Value: localAICandidateSourceCommit},
+		{Key: "vcs.modified", Value: "false"},
+	}}
 }
 func candidateInt64Pointer(value int64) *int64 { return &value }


### PR DESCRIPTION
Local Windows candidate builds repeatedly failed in cycle-specific preparation and observer checks, including a successful release rejected for sampling gaps. Replace that machinery with a parameterized short-path build and public-install smoke route. Preserve source/artifact identity, verified native-tool launch, bounded execution/output, and safe cleanup while removing dependency-tree copying and per-cycle ledgers.

Validation: PowerShell parse; release Go tests and vet; race-enabled candidate tests; argument/error/redaction, hanging-child termination, output bounds, path overlap/reparse and shared-cache preservation tests; local loopback public-install smoke using an existing binary. Integration preserves both retained branch histories. A full new GoReleaser candidate build and LocalAI semantic/blind acceptance have not run on this head.
