### PR TITLE
ci: prefetch complete Go dependency cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,10 +273,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
-          key: go-modules-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}
+          key: go-modules-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}
           restore-keys: |
+            go-modules-v2-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-
             go-modules-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-
-            functional-modules-${{ runner.os }}-${{ runner.arch }}-go-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}
+      - name: Prefetch complete Go dependency graph
+        run: go list -deps -test -mod=readonly ./... > /dev/null
       - name: Restore unit coverage Go build and test cache
         if: matrix.suite == 'unit'
         id: unit-go-build-cache

--- a/cmd/gocoveragecheck/coverage_invocation.go
+++ b/cmd/gocoveragecheck/coverage_invocation.go
@@ -811,7 +811,7 @@ func mergeGoTestFailureDetail(stderr string, stdout string) string {
 		return stderr
 	case stderr == "":
 		return stdout
-	case strings.Contains(stdout, "\nFAIL") || strings.Contains(stdout, "--- FAIL:"):
+	case strings.HasPrefix(stdout, "functional test failure:") || strings.Contains(stdout, "\nFAIL") || strings.Contains(stdout, "--- FAIL:"):
 		return stdout + "\n" + stderr
 	default:
 		return stderr + "\n" + stdout

--- a/cmd/gocoveragecheck/functional_failure_test.go
+++ b/cmd/gocoveragecheck/functional_failure_test.go
@@ -92,6 +92,28 @@ func TestFunctionalFailureUsesTerminalReasonForDetailAndTiming(t *testing.T) {
 	}
 }
 
+func TestFunctionalFailureDetailPrecedesToolchainStderr(t *testing.T) {
+	failingPackage := modulePath + "/tests/functional/quiet/failure"
+	stream := strings.Join([]string{
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: "output", Package: failingPackage, Test: "TestBroken", Output: "=== RUN   TestBroken\nexpected 2 workstations, got 1\n--- FAIL: TestBroken (0.03s)\n"}),
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: timingOutcomeFail, Package: failingPackage, Test: "TestBroken", Elapsed: 0.03}),
+		marshalGoTestEventOrPanic(goTestTimingEvent{Action: timingOutcomeFail, Package: failingPackage, Elapsed: 0.04}),
+	}, "\n")
+	toolchainStderr := "go: downloading example.com/dependency v1.2.3\n# get https://proxy.golang.org/example.com/dependency/@v/v1.2.3.zip: 200 OK"
+
+	detail := coverageFailureDetail(config{suite: functionalCoverageSuite, stream: true}, stream, toolchainStderr)
+	wantPrefix := "functional test failure: package=" + failingPackage + " test=TestBroken reason=expected 2 workstations, got 1"
+	if !strings.HasPrefix(detail, wantPrefix) {
+		t.Fatalf("functional failure detail = %q, want test failure before toolchain stderr", detail)
+	}
+	if !strings.Contains(detail, toolchainStderr) {
+		t.Fatalf("functional failure detail = %q, want retained toolchain stderr", detail)
+	}
+	if compact := compactDiagnosticError(errors.New(detail)); !strings.HasPrefix(compact, wantPrefix) || strings.Index(compact, "TestBroken") > strings.Index(compact, "go: downloading") {
+		t.Fatalf("compact diagnostic = %q, want bounded test failure before download chatter", compact)
+	}
+}
+
 func TestFunctionalRunSuppressesSuccessfulChildChatterAndKeepsArtifacts(t *testing.T) {
 	packageNames := []string{
 		modulePath + "/tests/functional/quiet/alpha",

--- a/scripts/ci/functional-coverage-workflow.test.mjs
+++ b/scripts/ci/functional-coverage-workflow.test.mjs
@@ -26,7 +26,8 @@ test("functional coverage separates module and source-sensitive build caches", (
 	const unitSetup = stepSection(job, "      - uses: actions/setup-go@v5\n        if: matrix.suite == 'unit'", "      - uses: actions/setup-go@v5");
 	const functionalSetup = stepSection(job, "      - uses: actions/setup-go@v5\n        if: matrix.suite == 'functional'", "      - name: Select functional runner parallelism");
 	const functionalParallelism = stepSection(job, "      - name: Select functional runner parallelism", "      - name: Restore Go module cache");
-	const moduleCache = stepSection(job, "      - name: Restore Go module cache", "      - name: Restore unit coverage Go build and test cache");
+	const moduleCache = stepSection(job, "      - name: Restore Go module cache", "      - name: Prefetch complete Go dependency graph");
+	const modulePrefetch = stepSection(job, "      - name: Prefetch complete Go dependency graph", "      - name: Restore unit coverage Go build and test cache");
 	const buildCache = stepSection(job, "      - name: Restore functional coverage Go build cache", "      - uses: actions/setup-node@v4");
 
 	assert.match(unitSetup, /go-version: \$\{\{ env\.GO_VERSION \}\}/);
@@ -44,7 +45,15 @@ test("functional coverage separates module and source-sensitive build caches", (
 	assert.doesNotMatch(moduleCache, /~\/\.cache\/go-build/);
 	assert.match(
 		moduleCache,
-		/key: go-modules-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-go-\$\{\{ env\.GO_VERSION \}\}-\$\{\{ hashFiles\('go\.sum'\) \}\}/,
+		/key: go-modules-v2-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-go-\$\{\{ env\.GO_VERSION \}\}-\$\{\{ hashFiles\('go\.sum'\) \}\}/,
+	);
+	assert.match(moduleCache, /go-modules-v2-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-go-\$\{\{ env\.GO_VERSION \}\}-/);
+	assert.match(moduleCache, /go-modules-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-go-\$\{\{ env\.GO_VERSION \}\}-/);
+	assert.match(modulePrefetch, /run: go list -deps -test -mod=readonly \.\/\.\.\. > \/dev\/null/);
+	assert.ok(
+		job.indexOf("      - name: Restore Go module cache") <
+			job.indexOf("      - name: Prefetch complete Go dependency graph"),
+		"the complete module graph must be prefetched after cache restore",
 	);
 
 	assert.match(buildCache, /if: matrix\.suite == 'functional'/);

--- a/scripts/ci/unit-coverage-workflow.test.mjs
+++ b/scripts/ci/unit-coverage-workflow.test.mjs
@@ -49,11 +49,14 @@ test("unit coverage uses a shallow checkout and an explicit reusable Go cache", 
 	);
 	assert.match(functionalCheckout, /fetch-depth: 0/);
 
-	const moduleCache = stepSection(job, "      - name: Restore Go module cache", "      - name: Restore unit coverage Go build and test cache");
+	const moduleCache = stepSection(job, "      - name: Restore Go module cache", "      - name: Prefetch complete Go dependency graph");
+	const modulePrefetch = stepSection(job, "      - name: Prefetch complete Go dependency graph", "      - name: Restore unit coverage Go build and test cache");
 	assert.match(moduleCache, /uses: actions\/cache@v4/);
 	assert.match(moduleCache, /path: ~\/go\/pkg\/mod/);
-	assert.match(moduleCache, /key: go-modules-/);
-	assert.match(moduleCache, /functional-modules-/);
+	assert.match(moduleCache, /key: go-modules-v2-/);
+	assert.match(moduleCache, /go-modules-v2-/);
+	assert.match(moduleCache, /go-modules-/);
+	assert.match(modulePrefetch, /go list -deps -test -mod=readonly \.\/\.\.\./);
 
 	const buildCache = stepSection(job, "      - name: Restore unit coverage Go build and test cache", "      - name: Restore functional coverage Go build cache");
 	assert.match(buildCache, /if: matrix\.suite == 'unit'/);


### PR DESCRIPTION
The shared immutable Go module cache can be saved by either coverage matrix lane before functional-only dependencies are present, causing the same modules to download again on every exact cache hit. This versions the cache namespace and resolves the complete repository test dependency graph with `-mod=readonly` immediately after restore, so the first v2 cache writer has the complete graph without mutating go.sum or adding retries.

It also keeps curated functional-test failures ahead of successful toolchain download chatter in bounded diagnostics.

Validation:
- `node --test scripts/ci/workflow-lint.test.mjs scripts/ci/functional-coverage-workflow.test.mjs`
- `go test ./cmd/gocoveragecheck -count=1`
- `go list -deps -test -mod=readonly ./...`
- `git diff --check`