### PR TITLE
factory-reliability: finalize dispatch terminal outcomes

### DIFF
--- a/pkg/services/providers/internal/service/execution_conformance_test.go
+++ b/pkg/services/providers/internal/service/execution_conformance_test.go
@@ -19,16 +19,18 @@ import (
 
 func TestStreamingAdapterConformance(t *testing.T) {
 	executiontest.Run(t, executiontest.Subject{
-		NewAdapter:       newStreamingAdapter,
-		NewRoot:          newConformanceRoot,
-		SupportsProgress: true,
+		NewAdapter:                    newStreamingAdapter,
+		NewRoot:                       newConformanceRoot,
+		SupportsProgress:              true,
+		PreservesResultOnParseFailure: true,
 	})
 }
 
 func TestFinalOnlyAdapterConformance(t *testing.T) {
 	executiontest.Run(t, executiontest.Subject{
-		NewAdapter: newFinalOnlyAdapter,
-		NewRoot:    newConformanceRoot,
+		NewAdapter:                    newFinalOnlyAdapter,
+		NewRoot:                       newConformanceRoot,
+		PreservesResultOnParseFailure: true,
 	})
 }
 

--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/adapter.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/adapter.go
@@ -70,48 +70,57 @@ func newContinuationAttempt(effect Effect) execution.ContinuationAttempt {
 		decoder := newDecoder(request.ExecuteRequest.ObserveSession)
 		effectResult, effectErr := effect.Execute(ctx, request, decoder.observe)
 		flushErr := decoder.flush()
-		if failure, failed := collectFailure(decoder, effectErr, flushErr); failed {
-			if failure.SessionRef == nil {
-				failure.SessionRef = decoder.sessionRef()
-			}
-			if failure.Diagnostics == nil {
-				failure.Diagnostics = decoder.diagnostics()
-			}
-			return providers.ExecuteResult{}, failure
-		}
 		content, session, finalErr := decoder.final()
+		failure, failed := collectFailure(decoder, effectErr, flushErr)
 		if finalErr != nil {
-			failure := execution.AttemptFailure{
-				SessionRef:      decoder.sessionRef(),
-				FinalParseError: finalErr,
+			// Preserve an earlier native, decode, flush, declared, or resource
+			// classification when the same attempt also lacks a final message.
+			// A final-parse failure is the primary route only when no other
+			// failure was observed.
+			if !failed {
+				failure.FinalParseError = finalErr
+				// A skipped oversized record only fails the execution when the
+				// stream ends without a recoverable final agent decision. Keep the
+				// pre-existing record-limit classification for that terminal case.
+				if skipped := decoder.skippedRecordFailure(); skipped != nil {
+					failure.Declared = skipped
+					failure.Diagnostics = decoder.diagnostics()
+				}
+				failed = true
 			}
-			// A skipped oversized record only fails the execution when the
-			// stream ends without a recoverable final agent decision. Keep the
-			// pre-existing record-limit classification for that terminal case.
-			if skipped := decoder.skippedRecordFailure(); skipped != nil {
-				failure.Declared = skipped
-				failure.Diagnostics = decoder.diagnostics()
-			}
-			return providers.ExecuteResult{}, failure
 		}
-		metadata := cloneMetadata(effectResult.Metadata)
-		if metadata == nil {
-			metadata = make(map[string]string, 4)
+		if failure.SessionRef == nil {
+			failure.SessionRef = decoder.sessionRef()
 		}
-		for key, value := range decoder.diagnostics().Metadata {
-			metadata[key] = value
+		if failure.Diagnostics == nil {
+			failure.Diagnostics = decoder.diagnostics()
 		}
-		metadata["completion_evidence"] = "agent_message"
-		return providers.ExecuteResult{
+		result := providers.ExecuteResult{
 			Content:    content,
 			SessionRef: session,
 			Diagnostics: &providers.ExecuteDiagnostics{
 				DurationMillis: effectResult.DurationMillis,
 				Progress:       decoder.progressFacts(),
-				Metadata:       metadata,
+				Metadata:       completedMetadata(effectResult.Metadata, decoder.diagnostics().Metadata),
 			},
-		}, nil
+		}
+		if failed {
+			return result, failure
+		}
+		return result, nil
 	}
+}
+
+func completedMetadata(native, decoded map[string]string) map[string]string {
+	metadata := cloneMetadata(native)
+	if metadata == nil {
+		metadata = make(map[string]string, 4)
+	}
+	for key, value := range decoded {
+		metadata[key] = value
+	}
+	metadata["completion_evidence"] = "agent_message"
+	return metadata
 }
 
 func collectFailure(

--- a/pkg/services/providers/internal/services/execution/internal/adapters/codex/failure_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/adapters/codex/failure_test.go
@@ -3,7 +3,6 @@ package codex_test
 import (
 	"context"
 	"errors"
-	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -16,7 +15,7 @@ import (
 
 const codexFailureSecret = "prompt-secret-that-must-not-escape"
 
-func TestCodexRootNormalizesFailureStagesAndSuppressesResults(t *testing.T) {
+func TestCodexRootNormalizesFailureStagesWithoutFabricatingCandidates(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -230,7 +229,7 @@ func TestCodexRootCancellationAndDeadlineReachEffectAndCleanUpOnce(t *testing.T)
 	}
 }
 
-func TestCodexRootFailureSuppressesPreviouslyObservedSuccess(t *testing.T) {
+func TestCodexRootPreservesUsableResultAlongsideFailure(t *testing.T) {
 	t.Parallel()
 
 	effect := codex.EffectFunc(func(
@@ -241,19 +240,39 @@ func TestCodexRootFailureSuppressesPreviouslyObservedSuccess(t *testing.T) {
 		if err := observe(codexSuccessStream()); err != nil {
 			return codex.EffectResult{}, err
 		}
-		return codex.EffectResult{}, providers.ExecuteFailure{
-			Kind:    providers.ExecuteFailureKindAuthentication,
-			Message: "credential " + codexFailureSecret,
-		}
+		return codex.EffectResult{
+				DurationMillis: 29,
+				Metadata: map[string]string{
+					"transport": "jsonl",
+					"stderr":    codexFailureSecret,
+				},
+			}, execution.AttemptFailure{
+				FlushError: errors.New("flush " + codexFailureSecret),
+			}
 	})
 	result, err := newCodexRoot(t, effect).Execute(t.Context(), codexFailureRequest())
-	assertCodexFailure(
-		t,
-		result,
-		err,
-		providers.ExecuteFailureKindAuthentication,
-		"",
-	)
+	if result.Content != "authoritative second answer" {
+		t.Fatalf("Execute() content = %q, want accepted stream result", result.Content)
+	}
+	if result.SessionRef == nil || result.SessionRef.ID != "thread-codex-42" {
+		t.Fatalf("Execute() session = %#v, want parsed Codex session", result.SessionRef)
+	}
+	if result.Diagnostics == nil ||
+		result.Diagnostics.Metadata["completion_evidence"] != "agent_message" {
+		t.Fatalf("Execute() diagnostics = %#v, want completion evidence", result.Diagnostics)
+	}
+	var failure providers.ExecuteFailure
+	if !errors.As(err, &failure) ||
+		failure.Kind != providers.ExecuteFailureKindDependency {
+		t.Fatalf("Execute() error = %#v, want dependency failure", err)
+	}
+	if failure.Diagnostics == nil ||
+		failure.Diagnostics.Metadata["failure_stage"] != "flush" {
+		t.Fatalf("Execute() failure diagnostics = %#v, want flush stage", failure.Diagnostics)
+	}
+	if strings.Contains(err.Error(), codexFailureSecret) {
+		t.Fatalf("Execute() error leaked sensitive native data: %v", err)
+	}
 }
 
 func TestCodexRootCarriesObservedSessionOnParseFailure(t *testing.T) {
@@ -292,8 +311,8 @@ func TestCodexRootCarriesBoundedRecordLimitThroughFailureDiagnostics(t *testing.
 	})
 
 	result, err := newCodexRoot(t, effect).Execute(t.Context(), codexFailureRequest())
-	if !reflect.DeepEqual(result, providers.ExecuteResult{}) {
-		t.Fatalf("Execute() result = %#v, want zero result", result)
+	if result.Content != "" {
+		t.Fatalf("Execute() content = %q, want no candidate", result.Content)
 	}
 	var failure providers.ExecuteFailure
 	if !errors.As(err, &failure) || failure.Kind != providers.ExecuteFailureKindDependency {
@@ -336,8 +355,8 @@ func assertCodexFailure(
 	wantStage string,
 ) {
 	t.Helper()
-	if !reflect.DeepEqual(result, providers.ExecuteResult{}) {
-		t.Fatalf("Execute() result = %#v, want zero result", result)
+	if result.Content != "" {
+		t.Fatalf("Execute() content = %q, want no candidate", result.Content)
 	}
 	if !errors.Is(err, sentinelForKind(wantKind)) {
 		t.Fatalf("Execute() error = %v, want sentinel for %q", err, wantKind)

--- a/pkg/services/providers/internal/services/execution/internal/service/cancellation_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/service/cancellation_test.go
@@ -75,8 +75,8 @@ func TestExecutePropagatesCancellationAndDeadlineAndCleansUpOnce(t *testing.T) {
 			if cleanupCalls != 1 {
 				t.Fatalf("cleanup calls = %d, want 1", cleanupCalls)
 			}
-			if !reflect.DeepEqual(result, providers.ExecuteResult{}) {
-				t.Fatalf("Execute() result = %#v, want zero terminal result", result)
+			if result.Content != "must not escape" {
+				t.Fatalf("Execute() content = %q, want normalized candidate", result.Content)
 			}
 		})
 	}

--- a/pkg/services/providers/internal/services/execution/internal/service/service.go
+++ b/pkg/services/providers/internal/services/execution/internal/service/service.go
@@ -104,7 +104,6 @@ func (s *service) Continue(
 	secret := continuationDiagnosticSecrets(detached.ResumeSession)
 	defer func() {
 		if contextErr := normalizeContextFailureWithExisting(ctx, detached.ExecuteRequest, executeErr, secret...); contextErr != nil {
-			result = providers.ExecuteResult{}
 			executeErr = contextErr
 		}
 	}()
@@ -133,10 +132,14 @@ func (s *service) Continue(
 		detached.ResumeSession.Provider = resolved.Provider.ID
 	}
 	result, err = binding.continueAttempt(ctx, detached)
-	if err != nil {
-		return providers.ExecuteResult{}, normalizeAttemptFailure(ctx, err, detached.ExecuteRequest, secret...)
+	normalizedResult, resultErr := normalizeSuccess(result, resolved.Provider.ID, detached.ExecuteRequest, secret...)
+	if resultErr != nil {
+		return providers.ExecuteResult{}, normalizeAttemptFailure(ctx, resultErr, detached.ExecuteRequest, secret...)
 	}
-	return normalizeSuccess(result, resolved.Provider.ID, detached.ExecuteRequest, secret...)
+	if err != nil {
+		return normalizedResult, normalizeAttemptFailure(ctx, err, detached.ExecuteRequest, secret...)
+	}
+	return normalizedResult, nil
 }
 
 func (s *service) Execute(
@@ -146,7 +149,6 @@ func (s *service) Execute(
 	detached := request.Clone()
 	defer func() {
 		if contextErr := normalizeContextFailureWithExisting(ctx, detached, executeErr); contextErr != nil {
-			result = providers.ExecuteResult{}
 			executeErr = contextErr
 		}
 	}()
@@ -175,10 +177,14 @@ func (s *service) Execute(
 	}
 	detached.Provider = resolved.Provider.ID
 	result, err = binding.attempt(ctx, detached)
-	if err != nil {
-		return providers.ExecuteResult{}, normalizeAttemptFailure(ctx, err, detached)
+	normalizedResult, resultErr := normalizeSuccess(result, resolved.Provider.ID, detached)
+	if resultErr != nil {
+		return providers.ExecuteResult{}, normalizeAttemptFailure(ctx, resultErr, detached)
 	}
-	return normalizeSuccess(result, resolved.Provider.ID, detached)
+	if err != nil {
+		return normalizedResult, normalizeAttemptFailure(ctx, err, detached)
+	}
+	return normalizedResult, nil
 }
 
 func normalizeContextFailureWithExisting(

--- a/pkg/services/providers/internal/services/execution/internal/service/service_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/service/service_test.go
@@ -426,7 +426,7 @@ func TestExecuteNeverFallsBackForUnknownUnavailableOrUnregisteredProvider(t *tes
 	}
 }
 
-func TestExecuteReturnsFirstAdapterFailureWithoutRetry(t *testing.T) {
+func TestExecutePreservesAdapterResultAlongsideFailureWithoutRetry(t *testing.T) {
 	t.Parallel()
 
 	calls := 0
@@ -469,8 +469,8 @@ func TestExecuteReturnsFirstAdapterFailureWithoutRetry(t *testing.T) {
 	if calls != 1 {
 		t.Fatalf("adapter calls = %d, want 1", calls)
 	}
-	if !reflect.DeepEqual(result, providers.ExecuteResult{}) {
-		t.Fatalf("failed Execute() result = %#v, want zero result", result)
+	if result.Content != "must not escape" {
+		t.Fatalf("failed Execute() content = %q, want normalized adapter result", result.Content)
 	}
 }
 

--- a/pkg/services/providers/internal/services/execution/internal/service/terminal_result_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/service/terminal_result_test.go
@@ -158,6 +158,17 @@ func assertNormalizedResultAndError(
 	wantResumeID string,
 ) {
 	t.Helper()
+	assertNormalizedResult(t, result, wantContent, wantResumeID)
+	assertNormalizedFailure(t, executeErr)
+}
+
+func assertNormalizedResult(
+	t *testing.T,
+	result providers.ExecuteResult,
+	wantContent string,
+	wantResumeID string,
+) {
+	t.Helper()
 	if result.Content != wantContent || result.Outcome != providers.ExecuteOutcomeAccepted {
 		t.Fatalf("normalized result = %#v, want accepted content/outcome", result)
 	}
@@ -175,6 +186,13 @@ func assertNormalizedResultAndError(
 		(wantResumeID != "" && strings.Contains(result.Diagnostics.Progress[0].Detail, wantResumeID)) {
 		t.Fatalf("normalized result progress leaked secret: %#v", result.Diagnostics.Progress[0])
 	}
+}
+
+func assertNormalizedFailure(
+	t *testing.T,
+	executeErr error,
+) {
+	t.Helper()
 	if !errors.Is(executeErr, providers.ErrExecuteFailed) {
 		t.Fatalf("execution error = %v, want failed sentinel", executeErr)
 	}

--- a/pkg/services/providers/internal/services/execution/internal/service/terminal_result_test.go
+++ b/pkg/services/providers/internal/services/execution/internal/service/terminal_result_test.go
@@ -1,0 +1,255 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	providers "github.com/portpowered/infinite-you/pkg/services/providers"
+	execution "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution"
+	executionwire "github.com/portpowered/infinite-you/pkg/services/providers/internal/services/execution/wire"
+)
+
+const (
+	terminalResultSecret = "terminal-result-secret"
+	terminalResumeID     = "resume-session-secret"
+)
+
+func TestExecutePreservesNormalizedResultAndError(t *testing.T) {
+	t.Parallel()
+
+	nativeResult := terminalResultFixture(
+		"accepted "+terminalResultSecret,
+		"accepted "+terminalResultSecret,
+		terminalResultSecret,
+	)
+	nativeFailure := terminalFailureFixture(
+		"failure "+terminalResultSecret,
+		terminalResultSecret,
+	)
+	executionService := mustTerminalTupleService(t, nativeResult, nativeFailure)
+
+	result, executeErr := executionService.Execute(context.Background(), providers.ExecuteRequest{
+		Provider:     providers.IDCodex,
+		AttemptID:    "attempt-terminal-result",
+		SystemPrompt: terminalResultSecret,
+		UserMessage:  "accept this result",
+	})
+
+	assertNormalizedResultAndError(t, result, executeErr, "accepted "+terminalResultSecret, "")
+	nativeResult.SessionRef.ID = "mutated-after-return"
+	nativeResult.Diagnostics.Metadata["safe"] = "mutated-after-return"
+	if result.SessionRef.ID != "codex-session-terminal" ||
+		result.Diagnostics.Metadata["safe"] != "result-fact" {
+		t.Fatalf("normalized result retained adapter mutation: %#v", result)
+	}
+}
+
+func TestContinuePreservesNormalizedResultAndError(t *testing.T) {
+	t.Parallel()
+
+	nativeResult := terminalResultFixture(
+		"accepted "+terminalResultSecret+" "+terminalResumeID,
+		"accepted "+terminalResultSecret+" "+terminalResumeID,
+		terminalResultSecret+" "+terminalResumeID,
+	)
+	nativeFailure := terminalFailureFixture(
+		"failure "+terminalResultSecret+" "+terminalResumeID,
+		terminalResultSecret+" "+terminalResumeID,
+	)
+	executionService, err := executionwire.NewService(
+		mustCatalog(t),
+		execution.Registration{
+			Provider: providers.IDCodex,
+			Attempt: func(context.Context, providers.ExecuteRequest) (providers.ExecuteResult, error) {
+				return providers.ExecuteResult{}, nil
+			},
+			Continue: func(context.Context, execution.ContinuationRequest) (providers.ExecuteResult, error) {
+				return nativeResult, nativeFailure
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewService() = %v", err)
+	}
+
+	continuation, ok := executionService.(execution.ContinuationService)
+	if !ok {
+		t.Fatal("NewService() result does not implement ContinuationService")
+	}
+	result, continueErr := continuation.Continue(context.Background(), execution.ContinuationRequest{
+		ExecuteRequest: providers.ExecuteRequest{
+			Provider:     providers.IDCodex,
+			AttemptID:    "attempt-terminal-continuation",
+			SystemPrompt: terminalResultSecret,
+			UserMessage:  "resume this result",
+		},
+		ResumeSession: &providers.SessionRef{
+			Provider: providers.IDCodex,
+			Kind:     providers.SessionIDKind,
+			ID:       terminalResumeID,
+		},
+	})
+
+	assertNormalizedResultAndError(t, result, continueErr,
+		"accepted "+terminalResultSecret+" "+terminalResumeID,
+		terminalResumeID,
+	)
+}
+
+func TestContinuePreservesNormalizedResultWhenContextEndsDuringAttempt(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	nativeResult := terminalResultFixture("accepted before cancellation", "accepted before cancellation", "")
+	executionService, err := executionwire.NewService(
+		mustCatalog(t),
+		execution.Registration{
+			Provider: providers.IDCodex,
+			Attempt: func(context.Context, providers.ExecuteRequest) (providers.ExecuteResult, error) {
+				return providers.ExecuteResult{}, nil
+			},
+			Continue: func(context.Context, execution.ContinuationRequest) (providers.ExecuteResult, error) {
+				cancel()
+				return nativeResult, ctx.Err()
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewService() = %v", err)
+	}
+	defer cancel()
+
+	continuation, ok := executionService.(execution.ContinuationService)
+	if !ok {
+		t.Fatal("NewService() result does not implement ContinuationService")
+	}
+	result, continueErr := continuation.Continue(ctx, execution.ContinuationRequest{
+		ExecuteRequest: providers.ExecuteRequest{
+			Provider:  providers.IDCodex,
+			AttemptID: "attempt-terminal-cancellation",
+		},
+		ResumeSession: &providers.SessionRef{
+			Provider: providers.IDCodex,
+			Kind:     providers.SessionIDKind,
+			ID:       "resume-cancellation",
+		},
+	})
+
+	if result.Content != "accepted before cancellation" {
+		t.Fatalf("Continue() content = %q, want normalized candidate", result.Content)
+	}
+	if !errors.Is(continueErr, providers.ErrExecuteCancelled) {
+		t.Fatalf("Continue() error = %v, want cancellation", continueErr)
+	}
+	var failure providers.ExecuteFailure
+	if !errors.As(continueErr, &failure) ||
+		failure.Kind != providers.ExecuteFailureKindCanceled {
+		t.Fatalf("Continue() error = %#v, want canceled ExecuteFailure", continueErr)
+	}
+}
+
+func assertNormalizedResultAndError(
+	t *testing.T,
+	result providers.ExecuteResult,
+	executeErr error,
+	wantContent string,
+	wantResumeID string,
+) {
+	t.Helper()
+	if result.Content != wantContent || result.Outcome != providers.ExecuteOutcomeAccepted {
+		t.Fatalf("normalized result = %#v, want accepted content/outcome", result)
+	}
+	if result.SessionRef == nil || result.SessionRef.ID != "codex-session-terminal" {
+		t.Fatalf("normalized result session = %#v, want detached Codex session", result.SessionRef)
+	}
+	if result.Diagnostics == nil || result.Diagnostics.DurationMillis != 17 {
+		t.Fatalf("normalized result diagnostics = %#v, want duration", result.Diagnostics)
+	}
+	if result.Diagnostics.Metadata["safe"] != "result-fact" ||
+		result.Diagnostics.Metadata["stdout"] != "<redacted>" {
+		t.Fatalf("normalized result metadata = %#v, want sanitized facts", result.Diagnostics.Metadata)
+	}
+	if strings.Contains(result.Diagnostics.Progress[0].Detail, terminalResultSecret) ||
+		(wantResumeID != "" && strings.Contains(result.Diagnostics.Progress[0].Detail, wantResumeID)) {
+		t.Fatalf("normalized result progress leaked secret: %#v", result.Diagnostics.Progress[0])
+	}
+	if !errors.Is(executeErr, providers.ErrExecuteFailed) {
+		t.Fatalf("execution error = %v, want failed sentinel", executeErr)
+	}
+	var failure providers.ExecuteFailure
+	if !errors.As(executeErr, &failure) ||
+		failure.Kind != providers.ExecuteFailureKindDependency {
+		t.Fatalf("execution error = %#v, want dependency ExecuteFailure", executeErr)
+	}
+	if failure.Diagnostics == nil || failure.Diagnostics.Metadata["stderr"] != "<redacted>" {
+		t.Fatalf("failure diagnostics = %#v, want sanitized stderr", failure.Diagnostics)
+	}
+	if strings.Contains(executeErr.Error(), terminalResultSecret) ||
+		strings.Contains(executeErr.Error(), terminalResumeID) {
+		t.Fatalf("execution error leaked secret: %v", executeErr)
+	}
+}
+
+func terminalResultFixture(content, progressDetail, secret string) providers.ExecuteResult {
+	return providers.ExecuteResult{
+		Content: content,
+		Outcome: providers.ExecuteOutcomeAccepted,
+		SessionRef: &providers.SessionRef{
+			Provider: providers.IDCodex,
+			Kind:     providers.SessionIDKind,
+			ID:       "codex-session-terminal",
+		},
+		Diagnostics: &providers.ExecuteDiagnostics{
+			DurationMillis: 17,
+			Progress: []providers.ExecuteProgress{{
+				Phase:  "message.completed",
+				Detail: progressDetail,
+				Metadata: map[string]string{
+					"safe":  "progress-fact",
+					"token": secret,
+				},
+			}},
+			Metadata: map[string]string{
+				"safe":   "result-fact",
+				"stdout": secret,
+			},
+		},
+	}
+}
+
+func terminalFailureFixture(message, secret string) providers.ExecuteFailure {
+	return providers.ExecuteFailure{
+		Kind:    providers.ExecuteFailureKindDependency,
+		Message: message,
+		Diagnostics: &providers.ExecuteDiagnostics{
+			DurationMillis: 23,
+			Metadata: map[string]string{
+				"safe":   "failure-fact",
+				"stderr": secret,
+			},
+		},
+	}
+}
+
+func mustTerminalTupleService(
+	t *testing.T,
+	nativeResult providers.ExecuteResult,
+	nativeFailure providers.ExecuteFailure,
+) execution.Service {
+	t.Helper()
+	executionService, err := executionwire.NewService(
+		mustCatalog(t),
+		execution.Registration{
+			Provider: providers.IDCodex,
+			Attempt: func(context.Context, providers.ExecuteRequest) (providers.ExecuteResult, error) {
+				return nativeResult, nativeFailure
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewService() = %v", err)
+	}
+	return executionService
+}

--- a/pkg/services/providers/internal/testutil/execution/conformance.go
+++ b/pkg/services/providers/internal/testutil/execution/conformance.go
@@ -65,6 +65,10 @@ type Subject struct {
 	NewAdapter       func(Plan) Adapter
 	NewRoot          func(execution.Attempt) (providers.Service, error)
 	SupportsProgress bool
+	// PreservesResultOnParseFailure identifies subjects whose direct attempt
+	// seam returns a candidate beside the synthetic parse failure used by this
+	// harness. Native protocol adapters may fail before producing that result.
+	PreservesResultOnParseFailure bool
 	// Provider selects the canonical catalog identity exercised by the harness.
 	// It defaults to Codex when unset so existing fixtures stay provider-neutral.
 	Provider providers.ID
@@ -106,7 +110,7 @@ func Run(t *testing.T, subject Subject) {
 	t.Run("pre-expired deadline stops before adapter I/O", func(t *testing.T) {
 		runPreTerminatedContext(t, subject, true)
 	})
-	t.Run("success after cancellation is suppressed", func(t *testing.T) {
+	t.Run("late success follows result and error policy", func(t *testing.T) {
 		runLateSuccessAfterCancellation(t, subject)
 	})
 }
@@ -244,13 +248,25 @@ func runParseFailure(t *testing.T, subject Subject) {
 		},
 	})
 	result, err := executeConformance(t, root, t.Context(), request)
-	failure := assertFailure(
-		t,
-		result,
-		err,
-		providers.ErrExecuteFailed,
-		providers.ExecuteFailureKindDependency,
-	)
+	var failure providers.ExecuteFailure
+	if subject.PreservesResultOnParseFailure {
+		failure = assertFailureWithCandidate(
+			t,
+			result,
+			err,
+			providers.ErrExecuteFailed,
+			providers.ExecuteFailureKindDependency,
+			conformanceContent,
+		)
+	} else {
+		failure = assertFailure(
+			t,
+			result,
+			err,
+			providers.ErrExecuteFailed,
+			providers.ExecuteFailureKindDependency,
+		)
+	}
 	if failure.Diagnostics == nil ||
 		failure.Diagnostics.Metadata["failure_stage"] != "final_parse" {
 		t.Fatalf("parse failure diagnostics = %#v", failure.Diagnostics)
@@ -337,15 +353,16 @@ func runLateSuccessAfterCancellation(t *testing.T, subject Subject) {
 
 	select {
 	case got := <-outcome:
-		assertFailure(
+		assertFailureWithCandidate(
 			t,
 			got.result,
 			got.err,
 			providers.ErrExecuteCancelled,
 			providers.ExecuteFailureKindCanceled,
+			conformanceContent,
 		)
 	case <-time.After(time.Second):
-		t.Fatal("Execute() did not suppress success after cancellation")
+		t.Fatal("Execute() did not finalize the late result after cancellation")
 	}
 	assertObservation(t, adapter, 1, 1, request)
 }
@@ -457,9 +474,20 @@ func assertFailure(
 	wantSentinel error,
 	wantKind providers.ExecuteFailureKind,
 ) providers.ExecuteFailure {
+	return assertFailureWithCandidate(t, result, err, wantSentinel, wantKind, "")
+}
+
+func assertFailureWithCandidate(
+	t *testing.T,
+	result providers.ExecuteResult,
+	err error,
+	wantSentinel error,
+	wantKind providers.ExecuteFailureKind,
+	wantContent string,
+) providers.ExecuteFailure {
 	t.Helper()
-	if !reflect.DeepEqual(result, providers.ExecuteResult{}) {
-		t.Fatalf("failed Execute() result = %#v, want zero result", result)
+	if result.Content != wantContent {
+		t.Fatalf("failed Execute() content = %q, want %q", result.Content, wantContent)
 	}
 	if !errors.Is(err, wantSentinel) {
 		t.Fatalf("Execute() error = %v, want %v", err, wantSentinel)

--- a/pkg/services/providers/internal/testutil/execution/conformance.go
+++ b/pkg/services/providers/internal/testutil/execution/conformance.go
@@ -250,7 +250,7 @@ func runParseFailure(t *testing.T, subject Subject) {
 	result, err := executeConformance(t, root, t.Context(), request)
 	var failure providers.ExecuteFailure
 	if subject.PreservesResultOnParseFailure {
-		failure = assertFailureWithCandidate(
+		failure = assertFailure(
 			t,
 			result,
 			err,
@@ -353,7 +353,7 @@ func runLateSuccessAfterCancellation(t *testing.T, subject Subject) {
 
 	select {
 	case got := <-outcome:
-		assertFailureWithCandidate(
+		assertFailure(
 			t,
 			got.result,
 			got.err,
@@ -473,21 +473,15 @@ func assertFailure(
 	err error,
 	wantSentinel error,
 	wantKind providers.ExecuteFailureKind,
-) providers.ExecuteFailure {
-	return assertFailureWithCandidate(t, result, err, wantSentinel, wantKind, "")
-}
-
-func assertFailureWithCandidate(
-	t *testing.T,
-	result providers.ExecuteResult,
-	err error,
-	wantSentinel error,
-	wantKind providers.ExecuteFailureKind,
-	wantContent string,
+	wantContent ...string,
 ) providers.ExecuteFailure {
 	t.Helper()
-	if result.Content != wantContent {
-		t.Fatalf("failed Execute() content = %q, want %q", result.Content, wantContent)
+	expectedContent := ""
+	if len(wantContent) == 1 {
+		expectedContent = wantContent[0]
+	}
+	if result.Content != expectedContent {
+		t.Fatalf("failed Execute() content = %q, want %q", result.Content, expectedContent)
 	}
 	if !errors.Is(err, wantSentinel) {
 		t.Fatalf("Execute() error = %v, want %v", err, wantSentinel)

--- a/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner.go
+++ b/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner.go
@@ -33,6 +33,51 @@ type progressIdentity struct {
 	dispatchID  string
 }
 
+const (
+	suppressedTerminalErrorKindMetadata = "suppressed_terminal_error_kind"
+	noUsableAgentResultMessage          = "provider returned no usable result"
+)
+
+// terminalPublication is scoped to one runner attempt. It serializes the
+// attempt's observation edge, closes that edge before publishing a terminal
+// fragment, and ignores any provider callback that arrives after terminal
+// selection. The runner service itself is reused concurrently, so this state
+// must never live on service.
+type terminalPublication struct {
+	mu      sync.Mutex
+	closed  bool
+	publish workers.ProgressPublisher
+}
+
+func newTerminalPublication(publish workers.ProgressPublisher) *terminalPublication {
+	return &terminalPublication{publish: publish}
+}
+
+func (publication *terminalPublication) progress(fragment workers.ProgressFragment) {
+	if publication == nil || publication.publish == nil {
+		return
+	}
+	publication.mu.Lock()
+	defer publication.mu.Unlock()
+	if publication.closed {
+		return
+	}
+	publication.publish(fragment)
+}
+
+func (publication *terminalPublication) terminal(fragment workers.ProgressFragment) {
+	if publication == nil || publication.publish == nil {
+		return
+	}
+	publication.mu.Lock()
+	defer publication.mu.Unlock()
+	if publication.closed {
+		return
+	}
+	publication.closed = true
+	publication.publish(fragment)
+}
+
 func progressIdentityForRequest(request workers.RunnerExecutionRequest) progressIdentity {
 	identity := progressIdentity{
 		correlation: request.Correlation,
@@ -93,6 +138,17 @@ func (s *service) execute(
 	ctx context.Context,
 	request workers.RunnerExecutionRequest,
 ) (workers.RunnerExecutionResult, error) {
+	publication := newTerminalPublication(s.publish)
+	effective := *s
+	effective.publish = publication.progress
+	return effective.executeWithTerminalPublication(ctx, request, publication)
+}
+
+func (s *service) executeWithTerminalPublication(
+	ctx context.Context,
+	request workers.RunnerExecutionRequest,
+	publication *terminalPublication,
+) (workers.RunnerExecutionResult, error) {
 	if err := ctx.Err(); err != nil {
 		return workers.RunnerExecutionResult{}, err
 	}
@@ -103,76 +159,43 @@ func (s *service) execute(
 	identity := progressIdentityForRequest(request)
 	provider := providerIDForRequest(request).String()
 	resumeReference := continuationSessionRef(request)
-	result, err := s.executeProviderAttempt(ctx, request, identity)
-	if err != nil {
-		if response, normalizedErr, handled := continuationFailureResult(ctx, request, err); handled {
-			s.publishTerminalFailure(
-				identity,
-				normalizedErr,
-				response.Continuation,
-				resumeReference,
-				"",
-				provider,
-			)
-			return response, normalizedErr
-		}
-		if failure, ok := providerFailure(err); ok {
-			response := runnerFailureResult(failure, request)
-			normalizedErr := normalizeProviderFailure(ctx, failure, err, response)
-			s.publishFailureProgress(
-				identity,
-				failure,
-				response.Continuation,
-				provider,
-			)
-			s.publishTerminalFailure(
-				identity,
-				normalizedErr,
-				response.Continuation,
-				failure.SessionRef,
-				failure.Message,
-				provider,
-			)
-			return response, normalizedErr
-		}
-		normalizedErr := normalizeExecutionError(ctx, err)
-		s.publishTerminalFailure(identity, normalizedErr, nil, nil, "", provider)
-		return workers.RunnerExecutionResult{}, normalizedErr
-	}
+	result, attemptErr := s.executeProviderAttempt(ctx, request, identity)
 	result = result.Clone()
 	response := runnerResult(result, providerIDForRequest(request))
-	if request.Continuation != nil {
-		response.Continuation = cloneContinuation(request.Continuation)
+	response = preserveContinuation(response, request, resumeReference)
+	var resultErr error
+	// An empty result does not carry a candidate to normalize. Skipping the
+	// semantic decoder in that one case preserves the provider's original
+	// typed failure and avoids replacing a process/dependency route with a
+	// malformed empty decision envelope.
+	if hasAgentCandidate(result) || attemptErr == nil {
+		response, resultErr = s.normalizeAgentResponse(response, request)
 	}
-	if response.Continuation == nil && resumeReference != nil {
-		continuation := resumeReference.ContinuationRef()
-		response.Continuation = &continuation
+	if resultErr == nil && (attemptErr == nil || usableAgentResult(response, request)) {
+		response.Diagnostics = mergeSuppressedAttemptDiagnostics(response.Diagnostics, attemptErr)
+		s.publishProgress(identity, result, response.Continuation, provider)
+		s.publishCompletedOnce(
+			publication,
+			identity,
+			response.Continuation,
+			provider,
+			response.Diagnostics,
+		)
+		return response, nil
 	}
-	if response.Continuation == nil && strings.TrimSpace(request.SessionID) != "" {
-		continuation := (providers.SessionRef{
-			Provider: providerIDForRequest(request),
-			Kind:     providers.SessionIDKind,
-			ID:       request.SessionID,
-		}).ContinuationRef()
-		response.Continuation = &continuation
+	if resultErr != nil {
+		attemptErr = resultErr
 	}
-	response, err = s.normalizeAgentResponse(response, request)
-	if err != nil {
-		return response, err
-	}
-	s.publishProgress(identity, result, response.Continuation, provider)
-	if !hasTerminalRunProgress(result.Diagnostics) {
-		s.publish(workers.ProgressFragment{
-			Correlation:       identity.correlation,
-			DispatchID:        identity.dispatchID,
-			Kind:              workers.CompletedFragmentKind,
-			Type:              "COMPLETED",
-			Provider:          provider,
-			Continuation:      continuationFromSessionRef(result.SessionRef),
-			ExternalEventType: "STREAM_COMPLETED",
-		})
-	}
-	return response, nil
+	return s.publishAttemptFailure(
+		ctx,
+		publication,
+		identity,
+		request,
+		response,
+		attemptErr,
+		resumeReference,
+		provider,
+	)
 }
 
 func (s *service) normalizeAgentResponse(
@@ -311,20 +334,375 @@ func evaluateAgentOutcome(content, stopToken string) workers.WorkOutcome {
 	return workers.OutcomeRejected
 }
 
-func hasTerminalRunProgress(diagnostics *providers.ExecuteDiagnostics) bool {
-	if diagnostics == nil {
+func hasAgentCandidate(result providers.ExecuteResult) bool {
+	return strings.TrimSpace(result.Content) != "" || result.Outcome != ""
+}
+
+// usableAgentResult is the only semantic success predicate in this runner.
+// Providers may return a normalized result beside a later attempt error; a
+// classified Work result or non-empty native output is still the authoritative
+// attempt outcome, while failed/canceled classifications remain failures.
+func usableAgentResult(
+	response workers.RunnerExecutionResult,
+	_ workers.RunnerExecutionRequest,
+) bool {
+	switch response.Outcome {
+	case workers.OutcomeAccepted, workers.OutcomeContinue, workers.OutcomeRejected:
+		return true
+	case workers.OutcomeFailed, workers.OutcomeCanceled:
 		return false
+	default:
+		return strings.TrimSpace(response.Content) != ""
 	}
-	for _, progress := range diagnostics.Progress {
-		switch strings.ToLower(strings.TrimSpace(progress.Phase)) {
-		case "run.completed", "turn.completed":
-			return true
+}
+
+func preserveContinuation(
+	response workers.RunnerExecutionResult,
+	request workers.RunnerExecutionRequest,
+	resumeReference *providers.SessionRef,
+) workers.RunnerExecutionResult {
+	if request.Continuation != nil {
+		response.Continuation = cloneContinuation(request.Continuation)
+	}
+	if response.Continuation == nil && resumeReference != nil {
+		continuation := resumeReference.ContinuationRef()
+		response.Continuation = &continuation
+	}
+	if response.Continuation == nil && strings.TrimSpace(request.SessionID) != "" {
+		continuation := (providers.SessionRef{
+			Provider: providerIDForRequest(request),
+			Kind:     providers.SessionIDKind,
+			ID:       request.SessionID,
+		}).ContinuationRef()
+		response.Continuation = &continuation
+	}
+	return response
+}
+
+func (s *service) publishCompletedOnce(
+	publication *terminalPublication,
+	identity progressIdentity,
+	continuation *workers.ProviderContinuationRef,
+	provider string,
+	diagnostics *workers.WorkDiagnostics,
+) {
+	fragment := workers.ProgressFragment{
+		Correlation:       identity.correlation,
+		DispatchID:        identity.dispatchID,
+		Kind:              workers.CompletedFragmentKind,
+		Type:              "COMPLETED",
+		Provider:          provider,
+		Continuation:      cloneContinuation(continuation),
+		ExternalEventType: "STREAM_COMPLETED",
+		Metadata:          terminalSuppressedMetadata(diagnostics),
+	}
+	if publication != nil {
+		publication.terminal(fragment)
+		return
+	}
+	s.publish(fragment)
+}
+
+func (s *service) publishAttemptFailure(
+	ctx context.Context,
+	publication *terminalPublication,
+	identity progressIdentity,
+	request workers.RunnerExecutionRequest,
+	response workers.RunnerExecutionResult,
+	attemptErr error,
+	resumeReference *providers.SessionRef,
+	provider string,
+) (workers.RunnerExecutionResult, error) {
+	if attemptErr == nil {
+		attemptErr = errors.New(noUsableAgentResultMessage)
+	}
+	response = preserveContinuation(response, request, resumeReference)
+
+	if continuationResponse, normalizedErr, handled := continuationFailureResult(ctx, request, attemptErr); handled {
+		response = mergeFailureResponse(response, continuationResponse)
+		markFailureOutcome(&response, normalizedErr)
+		s.publishTerminalFailureOnce(
+			publication,
+			identity,
+			normalizedErr,
+			response.Continuation,
+			resumeReference,
+			"",
+			provider,
+		)
+		return response, normalizedErr
+	}
+	if failure, ok := providerFailure(attemptErr); ok {
+		response = mergeFailureResponse(response, runnerFailureResult(failure, request))
+		normalizedErr := normalizeProviderFailure(ctx, failure, attemptErr, response)
+		markFailureOutcome(&response, normalizedErr)
+		s.publishFailureProgress(
+			identity,
+			failure,
+			response.Continuation,
+			provider,
+		)
+		s.publishTerminalFailureOnce(
+			publication,
+			identity,
+			normalizedErr,
+			response.Continuation,
+			failure.SessionRef,
+			failure.Message,
+			provider,
+		)
+		return response, normalizedErr
+	}
+
+	var providerErr *workers.ProviderError
+	if errors.As(attemptErr, &providerErr) && providerErr != nil {
+		response = mergeFailureResponse(response, runnerResultFromProviderError(providerErr))
+		markFailureOutcome(&response, providerErr)
+		s.publishTerminalFailureOnce(
+			publication,
+			identity,
+			providerErr,
+			response.Continuation,
+			nil,
+			"",
+			provider,
+		)
+		return response, providerErr
+	}
+
+	normalizedErr := normalizeExecutionError(ctx, attemptErr)
+	markFailureOutcome(&response, normalizedErr)
+	s.publishTerminalFailureOnce(
+		publication,
+		identity,
+		normalizedErr,
+		response.Continuation,
+		nil,
+		"",
+		provider,
+	)
+	return response, normalizedErr
+}
+
+func mergeFailureResponse(
+	response workers.RunnerExecutionResult,
+	failure workers.RunnerExecutionResult,
+) workers.RunnerExecutionResult {
+	if failure.Continuation != nil {
+		response.Continuation = cloneContinuation(failure.Continuation)
+	}
+	if response.Diagnostics == nil {
+		response.Diagnostics = workers.CloneWorkDiagnostics(failure.Diagnostics)
+	} else if failure.Diagnostics != nil {
+		response.Diagnostics = mergeDecisionEnvelopeDiagnostics(response.Diagnostics, failure.Diagnostics)
+	}
+	if response.Outcome == "" {
+		response.Outcome = failure.Outcome
+	}
+	if strings.TrimSpace(response.Content) == "" {
+		response.Content = failure.Content
+	}
+	return response
+}
+
+func runnerResultFromProviderError(
+	providerErr *workers.ProviderError,
+) workers.RunnerExecutionResult {
+	if providerErr == nil {
+		return workers.RunnerExecutionResult{}
+	}
+	return workers.RunnerExecutionResult{
+		Continuation: cloneContinuation(providerErr.Continuation),
+		Diagnostics:  workers.CloneWorkDiagnostics(providerErr.Diagnostics),
+	}
+}
+
+func markFailureOutcome(
+	response *workers.RunnerExecutionResult,
+	err error,
+) {
+	if response == nil || response.Outcome != "" {
+		return
+	}
+	if errors.Is(err, context.Canceled) {
+		response.Outcome = workers.OutcomeCanceled
+		return
+	}
+	response.Outcome = workers.OutcomeFailed
+}
+
+func mergeSuppressedAttemptDiagnostics(
+	base *workers.WorkDiagnostics,
+	attemptErr error,
+) *workers.WorkDiagnostics {
+	if attemptErr == nil {
+		return base
+	}
+	kind := suppressedAttemptErrorKind(attemptErr)
+	stage := suppressedAttemptFailureStage(attemptErr)
+	merged := workers.CloneWorkDiagnostics(base)
+	if merged == nil {
+		merged = &workers.WorkDiagnostics{}
+	}
+	if merged.Metadata == nil {
+		merged.Metadata = make(map[string]string, 2)
+	}
+	merged.Metadata[suppressedTerminalErrorKindMetadata] = kind
+	if stage != "" {
+		merged.Metadata[workers.ProviderResponseMetadataFailureStage] = stage
+	}
+	if merged.Provider == nil {
+		merged.Provider = &workers.ProviderDiagnostic{}
+	}
+	if merged.Provider.ResponseMetadata == nil {
+		merged.Provider.ResponseMetadata = make(map[string]string, 2)
+	}
+	merged.Provider.ResponseMetadata[suppressedTerminalErrorKindMetadata] = kind
+	if stage != "" {
+		merged.Provider.ResponseMetadata[workers.ProviderResponseMetadataFailureStage] = stage
+	}
+	return merged
+}
+
+func terminalSuppressedMetadata(
+	diagnostics *workers.WorkDiagnostics,
+) map[string]string {
+	if diagnostics == nil {
+		return nil
+	}
+	metadata := make(map[string]string, 2)
+	if diagnostics.Metadata != nil {
+		if value := strings.TrimSpace(diagnostics.Metadata[suppressedTerminalErrorKindMetadata]); value != "" {
+			metadata[suppressedTerminalErrorKindMetadata] = value
+		}
+		if value := strings.TrimSpace(diagnostics.Metadata[workers.ProviderResponseMetadataFailureStage]); value != "" {
+			metadata[workers.ProviderResponseMetadataFailureStage] = value
 		}
 	}
-	return false
+	if diagnostics.Provider != nil && diagnostics.Provider.ResponseMetadata != nil {
+		for _, key := range []string{
+			suppressedTerminalErrorKindMetadata,
+			workers.ProviderResponseMetadataFailureStage,
+		} {
+			if _, exists := metadata[key]; exists {
+				continue
+			}
+			if value := strings.TrimSpace(diagnostics.Provider.ResponseMetadata[key]); value != "" {
+				metadata[key] = value
+			}
+		}
+	}
+	if len(metadata) == 0 {
+		return nil
+	}
+	return metadata
+}
+
+func suppressedAttemptErrorKind(err error) string {
+	if failure, ok := providerFailure(err); ok {
+		return boundedExecuteFailureKind(failure.Kind)
+	}
+	var providerErr *workers.ProviderError
+	if errors.As(err, &providerErr) && providerErr != nil && providerErr.ProviderFailureKind != "" {
+		return boundedExecuteFailureKind(providerErr.ProviderFailureKind)
+	}
+	if errors.Is(err, context.Canceled) {
+		return string(providers.ExecuteFailureKindCanceled)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return string(providers.ExecuteFailureKindTimeout)
+	}
+	return string(providers.ExecuteFailureKindUnknown)
+}
+
+func boundedExecuteFailureKind(kind providers.ExecuteFailureKind) string {
+	switch kind {
+	case providers.ExecuteFailureKindCanceled,
+		providers.ExecuteFailureKindTimeout,
+		providers.ExecuteFailureKindAuthentication,
+		providers.ExecuteFailureKindInvalidRequest,
+		providers.ExecuteFailureKindMisconfigured,
+		providers.ExecuteFailureKindThrottled,
+		providers.ExecuteFailureKindDependency,
+		providers.ExecuteFailureKindCapabilityMismatch,
+		providers.ExecuteFailureKindSessionNotFound:
+		return string(kind)
+	case providers.ExecuteFailureKindUnknown:
+		fallthrough
+	default:
+		return string(providers.ExecuteFailureKindUnknown)
+	}
+}
+
+func suppressedAttemptFailureStage(err error) string {
+	stage := ""
+	if failure, ok := providerFailure(err); ok && failure.Diagnostics != nil {
+		stage = failure.Diagnostics.Metadata[workers.ProviderResponseMetadataFailureStage]
+	}
+	if stage == "" {
+		var providerErr *workers.ProviderError
+		if errors.As(err, &providerErr) && providerErr != nil && providerErr.Diagnostics != nil {
+			if providerErr.Diagnostics.Metadata != nil {
+				stage = providerErr.Diagnostics.Metadata[workers.ProviderResponseMetadataFailureStage]
+			}
+			if stage == "" && providerErr.Diagnostics.Provider != nil {
+				stage = providerErr.Diagnostics.Provider.ResponseMetadata[workers.ProviderResponseMetadataFailureStage]
+			}
+		}
+	}
+	return boundedFailureStage(stage)
+}
+
+func boundedFailureStage(stage string) string {
+	switch strings.ToLower(strings.TrimSpace(stage)) {
+	case "native", "decode", "flush", "final_parse", "process", "stream", "teardown":
+		return strings.ToLower(strings.TrimSpace(stage))
+	default:
+		return ""
+	}
 }
 
 func (s *service) publishTerminalFailure(
+	identity progressIdentity,
+	err error,
+	continuation *workers.ProviderContinuationRef,
+	reference *providers.SessionRef,
+	providerMessage string,
+	provider string,
+) {
+	s.publishTerminalFailureTo(
+		nil,
+		identity,
+		err,
+		continuation,
+		reference,
+		providerMessage,
+		provider,
+	)
+}
+
+func (s *service) publishTerminalFailureOnce(
+	publication *terminalPublication,
+	identity progressIdentity,
+	err error,
+	continuation *workers.ProviderContinuationRef,
+	reference *providers.SessionRef,
+	providerMessage string,
+	provider string,
+) {
+	s.publishTerminalFailureTo(
+		publication,
+		identity,
+		err,
+		continuation,
+		reference,
+		providerMessage,
+		provider,
+	)
+}
+
+func (s *service) publishTerminalFailureTo(
+	publication *terminalPublication,
 	identity progressIdentity,
 	err error,
 	continuation *workers.ProviderContinuationRef,
@@ -357,7 +735,7 @@ func (s *service) publishTerminalFailure(
 	if len(metadata) == 0 {
 		metadata = nil
 	}
-	s.publish(workers.ProgressFragment{
+	fragment := workers.ProgressFragment{
 		Correlation:       identity.correlation,
 		DispatchID:        identity.dispatchID,
 		Kind:              workers.FailedFragmentKind,
@@ -367,7 +745,12 @@ func (s *service) publishTerminalFailure(
 		Continuation:      cloneContinuation(continuation),
 		ExternalEventType: "STREAM_FAILED",
 		Metadata:          metadata,
-	})
+	}
+	if publication != nil {
+		publication.terminal(fragment)
+		return
+	}
+	s.publish(fragment)
 }
 
 func (s *service) publishFailureProgress(

--- a/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner.go
+++ b/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner.go
@@ -3,10 +3,8 @@ package service
 import (
 	"context"
 	"errors"
-	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/providers"
@@ -76,6 +74,15 @@ func (publication *terminalPublication) terminal(fragment workers.ProgressFragme
 	}
 	publication.closed = true
 	publication.publish(fragment)
+}
+
+func (publication *terminalPublication) close() {
+	if publication == nil {
+		return
+	}
+	publication.mu.Lock()
+	publication.closed = true
+	publication.mu.Unlock()
 }
 
 func progressIdentityForRequest(request workers.RunnerExecutionRequest) progressIdentity {
@@ -171,16 +178,24 @@ func (s *service) executeWithTerminalPublication(
 	if hasAgentCandidate(result) || attemptErr == nil {
 		response, resultErr = s.normalizeAgentResponse(response, request)
 	}
-	if resultErr == nil && (attemptErr == nil || usableAgentResult(response, request)) {
+	if resultErr == nil && hasAgentCandidate(result) &&
+		(attemptErr == nil || usableAgentResult(response, request)) {
 		response.Diagnostics = mergeSuppressedAttemptDiagnostics(response.Diagnostics, attemptErr)
 		s.publishProgress(identity, result, response.Continuation, provider)
-		s.publishCompletedOnce(
-			publication,
-			identity,
-			response.Continuation,
-			provider,
-			response.Diagnostics,
-		)
+		if hasTerminalRunProgress(result.Diagnostics) {
+			// Native provider lifecycle progress is already the authoritative
+			// terminal observation. Close the callback edge without adding a
+			// duplicate synthetic COMPLETED fragment.
+			publication.close()
+		} else {
+			s.publishCompletedOnce(
+				publication,
+				identity,
+				response.Continuation,
+				provider,
+				response.Diagnostics,
+			)
+		}
 		return response, nil
 	}
 	if resultErr != nil {
@@ -338,17 +353,37 @@ func hasAgentCandidate(result providers.ExecuteResult) bool {
 	return strings.TrimSpace(result.Content) != "" || result.Outcome != ""
 }
 
+func hasTerminalRunProgress(diagnostics *providers.ExecuteDiagnostics) bool {
+	if diagnostics == nil {
+		return false
+	}
+	for _, progress := range diagnostics.Progress {
+		switch strings.ToLower(strings.TrimSpace(progress.Phase)) {
+		case "run.completed", "turn.completed":
+			return true
+		}
+	}
+	return false
+}
+
 // usableAgentResult is the only semantic success predicate in this runner.
 // Providers may return a normalized result beside a later attempt error; a
-// classified Work result or non-empty native output is still the authoritative
-// attempt outcome, while failed/canceled classifications remain failures.
+// classified decision-envelope result or a native output that satisfies the
+// configured stop policy is still the authoritative attempt outcome. A native
+// REJECTED result means the stop token was absent, so partial output beside a
+// provider error remains unusable instead of becoming a false success.
 func usableAgentResult(
 	response workers.RunnerExecutionResult,
-	_ workers.RunnerExecutionRequest,
+	request workers.RunnerExecutionRequest,
 ) bool {
 	switch response.Outcome {
-	case workers.OutcomeAccepted, workers.OutcomeContinue, workers.OutcomeRejected:
+	case workers.OutcomeAccepted, workers.OutcomeContinue:
 		return true
+	case workers.OutcomeRejected:
+		return request.DecisionEnvelope || strings.EqualFold(
+			strings.TrimSpace(request.OutputFormat),
+			interfaces.DecisionEnvelopeOutcomeFormat,
+		)
 	case workers.OutcomeFailed, workers.OutcomeCanceled:
 		return false
 	default:
@@ -662,25 +697,6 @@ func boundedFailureStage(stage string) string {
 	}
 }
 
-func (s *service) publishTerminalFailure(
-	identity progressIdentity,
-	err error,
-	continuation *workers.ProviderContinuationRef,
-	reference *providers.SessionRef,
-	providerMessage string,
-	provider string,
-) {
-	s.publishTerminalFailureTo(
-		nil,
-		identity,
-		err,
-		continuation,
-		reference,
-		providerMessage,
-		provider,
-	)
-}
-
 func (s *service) publishTerminalFailureOnce(
 	publication *terminalPublication,
 	identity progressIdentity,
@@ -946,404 +962,4 @@ func (s *service) executeProviderAttempt(
 		return providers.ExecuteResult{}, continuationUnsupportedError{reference: reference}
 	}
 	return continued.Result, nil
-}
-
-func continueLegacyProvider(
-	ctx context.Context,
-	service providers.Service,
-	request providers.ContinueRequest,
-) (providers.ContinueResult, error) {
-	return service.Continue(ctx, request)
-}
-
-func continuedExecuteResultFromOpaque(
-	continued providers.ContinueReferenceResult,
-	requested providers.SessionRef,
-	returned providers.SessionRef,
-) (providers.ExecuteResult, error) {
-	return continuedExecuteResult(
-		providers.ContinueResult{
-			Reference: returned,
-			Outcome:   continued.Outcome,
-			Result:    continued.Result,
-		},
-		requested,
-	)
-}
-
-// observeProviderSession forwards only a provider-authored exact reference to
-// the session-local progress bridge while the Provider attempt is still live.
-// The bridge owns association validation and commits it before allowing the
-// later response or terminal fragments for this dispatch to proceed.
-func (s *service) observeProviderSession(
-	identity progressIdentity,
-	live *liveProviderSession,
-) providers.SessionObserver {
-	return func(reference providers.SessionRef) {
-		reference = reference.Clone()
-		live.set(reference)
-		s.publish(workers.ProgressFragment{
-			Correlation:  identity.correlation,
-			DispatchID:   identity.dispatchID,
-			Kind:         workers.ProviderSessionObservedFragmentKind,
-			Continuation: continuationFromSessionRef(&reference),
-		})
-	}
-}
-
-// observeProviderProgress publishes each bounded provider progress fact while
-// the attempt is still live, so a Worker's execution trace reaches the
-// response-event stream as it is produced rather than in one burst when the
-// attempt ends.
-//
-// Each fact carries whatever provider session the attempt has already
-// observed, so a streamed trace is attributed to the same provider and session
-// as the buffered diagnostics it replaces. A fact reported before the provider
-// authored a session simply carries none.
-func (s *service) observeProviderProgress(
-	identity progressIdentity,
-	live *liveProviderSession,
-	provider string,
-) providers.ProgressObserver {
-	return func(progress providers.ExecuteProgress) {
-		continuation := live.snapshot()
-		s.publishProviderProgress(identity, progress, continuation, provider)
-	}
-}
-
-// liveProviderSession retains the exact provider-authored session reference
-// observed during one attempt. Progress observation and session observation
-// arrive on different callbacks and, for a streaming provider, on different
-// goroutines, so the reference is guarded rather than passed by value.
-type liveProviderSession struct {
-	mu        sync.Mutex
-	reference *providers.SessionRef
-}
-
-func (l *liveProviderSession) set(reference providers.SessionRef) {
-	clone := reference.Clone()
-	l.mu.Lock()
-	l.reference = &clone
-	l.mu.Unlock()
-}
-
-// snapshot returns the opaque continuation for the provider-authored session,
-// or nil when the provider has not authored a session yet.
-func (l *liveProviderSession) snapshot() *workers.ProviderContinuationRef {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	if l.reference == nil {
-		return nil
-	}
-	reference := l.reference.Clone()
-	continuation := reference.ContinuationRef()
-	return &continuation
-}
-
-// continuedExecuteResult admits only a provider response that affirms the
-// exact typed Provider Session requested for the continuation. It also carries
-// that canonical reference into the result when the provider omits the
-// redundant ExecuteResult field, so progress and terminal output retain the
-// same identity without rebuilding it from a legacy session ID.
-func continuedExecuteResult(continued providers.ContinueResult, reference providers.SessionRef) (providers.ExecuteResult, error) {
-	if continued.Reference != reference {
-		return providers.ExecuteResult{}, invalidContinuationReference(reference)
-	}
-	result := continued.Result.Clone()
-	if result.SessionRef != nil && *result.SessionRef != reference {
-		return providers.ExecuteResult{}, invalidContinuationReference(reference)
-	}
-	continuedReference := reference.Clone()
-	result.SessionRef = &continuedReference
-	return result, nil
-}
-
-func invalidContinuationReference(reference providers.SessionRef) providers.ContinuationFailure {
-	return providers.ContinuationFailure{
-		Kind:      providers.ContinuationFailureKindInvalid,
-		Message:   "provider continuation returned a different session reference",
-		Reference: reference.Clone(),
-	}
-}
-
-// providerIDForRunner translates stable Workers runner identities at the
-// Providers boundary.
-func providerIDForRunner(runnerID string) providers.ID {
-	return providers.ID(workers.NormalizeRunnerID(runnerID))
-}
-
-// providerIDForRequest makes the opaque continuation's provider identity the
-// authority for continuation routing. Runner IDs remain the selection input
-// for ordinary execution, but cannot redirect or invalidate an admitted
-// continuation.
-func providerIDForRequest(request workers.RunnerExecutionRequest) providers.ID {
-	if request.Continuation != nil {
-		return providers.ID(strings.TrimSpace(request.Continuation.Provider))
-	}
-	return providerIDForRunner(request.RunnerID)
-}
-
-func continuationSessionRef(
-	request workers.RunnerExecutionRequest,
-) *providers.SessionRef {
-	if request.Continuation != nil {
-		if reference, err := request.Continuation.ToSessionRef(); err == nil {
-			return &reference
-		}
-	}
-	if sessionID := strings.TrimSpace(request.SessionID); sessionID != "" {
-		return &providers.SessionRef{
-			Provider: providerIDForRunner(request.RunnerID),
-			Kind:     providers.SessionIDKind,
-			ID:       sessionID,
-		}
-	}
-	return nil
-}
-
-func runnerResult(
-	result providers.ExecuteResult,
-	providerID providers.ID,
-) workers.RunnerExecutionResult {
-	result = result.Clone()
-	response := workers.RunnerExecutionResult{
-		Content: result.Content,
-		Outcome: workers.WorkOutcome(result.Outcome),
-	}
-	if result.SessionRef != nil {
-		response.Continuation = continuationFromSessionRef(result.SessionRef)
-	}
-	if result.Diagnostics != nil {
-		metadata := cloneMetadata(result.Diagnostics.Metadata)
-		if result.Diagnostics.DurationMillis != 0 {
-			if metadata == nil {
-				metadata = make(map[string]string, 1)
-			}
-			metadata[workers.ProviderResponseMetadataDurationMS] =
-				strconv.FormatInt(result.Diagnostics.DurationMillis, 10)
-		}
-		response.Diagnostics = &workers.WorkDiagnostics{
-			Provider: &workers.ProviderDiagnostic{
-				Provider:         providerID.String(),
-				ResponseMetadata: cloneMetadata(metadata),
-			},
-			Metadata: metadata,
-		}
-		if result.Diagnostics.Command != nil {
-			response.Diagnostics.Command = &workers.CommandDiagnostic{
-				Command:    result.Diagnostics.Command.Command,
-				Args:       append([]string(nil), result.Diagnostics.Command.Args...),
-				Env:        cloneMetadata(result.Diagnostics.Command.Env),
-				Stdin:      result.Diagnostics.Command.Stdin,
-				Stdout:     result.Diagnostics.Command.Stdout,
-				Stderr:     result.Diagnostics.Command.Stderr,
-				ExitCode:   result.Diagnostics.Command.ExitCode,
-				TimedOut:   result.Diagnostics.Command.TimedOut,
-				Duration:   time.Duration(result.Diagnostics.Command.DurationMS) * time.Millisecond,
-				WorkingDir: result.Diagnostics.Command.WorkingDir,
-			}
-		}
-		if result.Diagnostics.Panic != nil {
-			response.Diagnostics.Panic = &workers.PanicDiagnostic{
-				Message: result.Diagnostics.Panic.Message,
-				Stack:   result.Diagnostics.Panic.Stack,
-			}
-		}
-	}
-	return response
-}
-
-func runnerFailureResult(
-	failure providers.ExecuteFailure,
-	request workers.RunnerExecutionRequest,
-) workers.RunnerExecutionResult {
-	response := runnerResult(providers.ExecuteResult{
-		SessionRef:  failure.SessionRef,
-		Diagnostics: failure.Diagnostics,
-	}, providerIDForRequest(request))
-	if response.Continuation == nil && failure.SessionRef != nil {
-		response.Continuation = continuationFromSessionRef(failure.SessionRef)
-	}
-	if response.Continuation == nil {
-		if reference := continuationSessionRef(request); reference != nil {
-			response.Continuation = continuationFromSessionRef(reference)
-		}
-	}
-	if response.Continuation == nil && strings.TrimSpace(request.SessionID) != "" {
-		response.Continuation = continuationFromSessionRef(&providers.SessionRef{
-			Provider: providerIDForRequest(request),
-			Kind:     providers.SessionIDKind,
-			ID:       request.SessionID,
-		})
-	}
-	if response.Continuation == nil {
-		response.Continuation = &workers.ProviderContinuationRef{
-			Provider: providers.ID(request.RunnerID).CanonicalSessionProvider(),
-		}
-	} else if strings.TrimSpace(response.Continuation.Provider) == "" {
-		response.Continuation.Provider = providers.ID(request.RunnerID).CanonicalSessionProvider()
-	}
-	return response
-}
-
-func providerFailure(err error) (providers.ExecuteFailure, bool) {
-	var value providers.ExecuteFailure
-	if errors.As(err, &value) {
-		return value.Clone(), true
-	}
-	var pointer *providers.ExecuteFailure
-	if errors.As(err, &pointer) && pointer != nil {
-		return pointer.Clone(), true
-	}
-	return providers.ExecuteFailure{}, false
-}
-
-func normalizeProviderFailure(
-	ctx context.Context,
-	failure providers.ExecuteFailure,
-	cause error,
-	result workers.RunnerExecutionResult,
-) error {
-	interruption := ctx.Err()
-	if errors.Is(interruption, context.Canceled) {
-		return canceledProviderError(errors.Join(context.Canceled, cause), result)
-	}
-	if interruption == nil {
-		switch failure.Kind {
-		case providers.ExecuteFailureKindCanceled:
-			interruption = context.Canceled
-		case providers.ExecuteFailureKindTimeout:
-			interruption = context.DeadlineExceeded
-		}
-	}
-	if failure.Kind == providers.ExecuteFailureKindCanceled {
-		return canceledProviderError(errors.Join(interruption, cause), result)
-	}
-	failureType := failureTypeForProviderFailure(failure)
-	if failure.Diagnostics != nil {
-		switch failure.Diagnostics.Metadata["work-failure-type"] {
-		case string(workers.WorkFailureTypeMissingExecutable):
-			failureType = workers.WorkFailureTypeMissingExecutable
-		case string(workers.WorkFailureTypeMisconfigured):
-			failureType = workers.WorkFailureTypeMisconfigured
-		case string(workers.WorkFailureTypeCommandLineTooLong):
-			failureType = workers.WorkFailureTypeCommandLineTooLong
-		}
-	}
-	if errors.Is(interruption, context.DeadlineExceeded) {
-		failureType = workers.WorkFailureTypeTimeout
-	}
-	normalized := workers.NewProviderError(
-		failureType,
-		boundedFailureMessage(canonicalAgentFailureMessage(failure, failureType, failure.Message)),
-		errors.Join(interruption, cause),
-	)
-	// Providers has already normalized and sanitized this message. Retain the
-	// provider failure kind on fresh attempts as well as continuations so the
-	// downstream invocation/child boundary can distinguish provider-owned safe
-	// detail from an arbitrary Worker error.
-	normalized.ProviderFailureKind = failure.Kind
-	normalized.Continuation = cloneContinuation(result.Continuation)
-	normalized.Diagnostics = workers.CloneWorkDiagnostics(result.Diagnostics)
-	return normalized
-}
-
-// continuationUnsupportedError keeps Providers' successful unsupported
-// capability result distinct from an invalid Execute failure until Workers has
-// copied that exact classification into its own in-process result boundary.
-type continuationUnsupportedError struct {
-	reference providers.SessionRef
-}
-
-func (continuationUnsupportedError) Error() string {
-	return "provider does not support resuming this Provider Session"
-}
-
-func continuationFailureResult(
-	ctx context.Context,
-	request workers.RunnerExecutionRequest,
-	err error,
-) (workers.RunnerExecutionResult, error, bool) {
-	if unsupported, ok := unsupportedContinuation(err); ok {
-		response := runnerContinuationFailureResult(request, unsupported.reference)
-		normalized := workers.NewProviderError(
-			workers.WorkFailureTypePermanentBadRequest,
-			"provider session continuation is unsupported",
-			err,
-		)
-		normalized.ProviderContinuationOutcome = providers.ContinuationOutcomeUnsupported
-		normalized.Continuation = cloneContinuation(response.Continuation)
-		return response, normalized, true
-	}
-	if failure, ok := continuationFailure(err); ok {
-		response := runnerContinuationFailureResult(request, failure.Reference)
-		normalized := workers.NewProviderError(
-			workers.WorkFailureTypePermanentBadRequest,
-			"provider session continuation was rejected",
-			errors.Join(ctx.Err(), err),
-		)
-		normalized.ProviderContinuationFailureKind = failure.Kind
-		normalized.Continuation = cloneContinuation(response.Continuation)
-		return response, normalized, true
-	}
-	return workers.RunnerExecutionResult{}, nil, false
-}
-
-func runnerContinuationFailureResult(
-	request workers.RunnerExecutionRequest,
-	fallback providers.SessionRef,
-) workers.RunnerExecutionResult {
-	reference := fallback.Clone()
-	if requested := continuationSessionRef(request); requested != nil {
-		reference = requested.Clone()
-	}
-	result := runnerFailureResult(providers.ExecuteFailure{SessionRef: &reference}, request)
-	if request.Continuation != nil {
-		result.Continuation = cloneContinuation(request.Continuation)
-	}
-	return result
-}
-
-func unsupportedContinuation(err error) (continuationUnsupportedError, bool) {
-	var unsupported continuationUnsupportedError
-	if errors.As(err, &unsupported) {
-		return unsupported, true
-	}
-	return continuationUnsupportedError{}, false
-}
-
-func continuationFailure(err error) (providers.ContinuationFailure, bool) {
-	var value providers.ContinuationFailure
-	if errors.As(err, &value) {
-		return value.Clone(), true
-	}
-	var pointer *providers.ContinuationFailure
-	if errors.As(err, &pointer) && pointer != nil {
-		return pointer.Clone(), true
-	}
-	return providers.ContinuationFailure{}, false
-}
-
-func cloneContinuation(reference *workers.ProviderContinuationRef) *workers.ProviderContinuationRef {
-	if reference == nil {
-		return nil
-	}
-	clone := reference.Clone()
-	return &clone
-}
-
-func continuationFromSessionRef(reference *providers.SessionRef) *workers.ProviderContinuationRef {
-	if reference == nil {
-		return nil
-	}
-	continuation := reference.ContinuationRef()
-	return &continuation
-}
-
-func cloneSessionRef(reference *providers.SessionRef) *providers.SessionRef {
-	if reference == nil {
-		return nil
-	}
-	clone := reference.Clone()
-	return &clone
 }

--- a/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner_helpers.go
+++ b/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner_helpers.go
@@ -1,0 +1,413 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/services/providers"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+func continueLegacyProvider(
+	ctx context.Context,
+	service providers.Service,
+	request providers.ContinueRequest,
+) (providers.ContinueResult, error) {
+	return service.Continue(ctx, request)
+}
+
+func continuedExecuteResultFromOpaque(
+	continued providers.ContinueReferenceResult,
+	requested providers.SessionRef,
+	returned providers.SessionRef,
+) (providers.ExecuteResult, error) {
+	return continuedExecuteResult(
+		providers.ContinueResult{
+			Reference: returned,
+			Outcome:   continued.Outcome,
+			Result:    continued.Result,
+		},
+		requested,
+	)
+}
+
+// observeProviderSession forwards only a provider-authored exact reference to
+// the session-local progress bridge while the Provider attempt is still live.
+// The bridge owns association validation and commits it before allowing the
+// later response or terminal fragments for this dispatch to proceed.
+func (s *service) observeProviderSession(
+	identity progressIdentity,
+	live *liveProviderSession,
+) providers.SessionObserver {
+	return func(reference providers.SessionRef) {
+		reference = reference.Clone()
+		live.set(reference)
+		s.publish(workers.ProgressFragment{
+			Correlation:  identity.correlation,
+			DispatchID:   identity.dispatchID,
+			Kind:         workers.ProviderSessionObservedFragmentKind,
+			Continuation: continuationFromSessionRef(&reference),
+		})
+	}
+}
+
+// observeProviderProgress publishes each bounded provider progress fact while
+// the attempt is still live, so a Worker's execution trace reaches the
+// response-event stream as it is produced rather than in one burst when the
+// attempt ends.
+//
+// Each fact carries whatever provider session the attempt has already
+// observed, so a streamed trace is attributed to the same provider and session
+// as the buffered diagnostics it replaces. A fact reported before the provider
+// authored a session simply carries none.
+func (s *service) observeProviderProgress(
+	identity progressIdentity,
+	live *liveProviderSession,
+	provider string,
+) providers.ProgressObserver {
+	return func(progress providers.ExecuteProgress) {
+		continuation := live.snapshot()
+		s.publishProviderProgress(identity, progress, continuation, provider)
+	}
+}
+
+// liveProviderSession retains the exact provider-authored session reference
+// observed during one attempt. Progress observation and session observation
+// arrive on different callbacks and, for a streaming provider, on different
+// goroutines, so the reference is guarded rather than passed by value.
+type liveProviderSession struct {
+	mu        sync.Mutex
+	reference *providers.SessionRef
+}
+
+func (l *liveProviderSession) set(reference providers.SessionRef) {
+	clone := reference.Clone()
+	l.mu.Lock()
+	l.reference = &clone
+	l.mu.Unlock()
+}
+
+// snapshot returns the opaque continuation for the provider-authored session,
+// or nil when the provider has not authored a session yet.
+func (l *liveProviderSession) snapshot() *workers.ProviderContinuationRef {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.reference == nil {
+		return nil
+	}
+	reference := l.reference.Clone()
+	continuation := reference.ContinuationRef()
+	return &continuation
+}
+
+// continuedExecuteResult admits only a provider response that affirms the
+// exact typed Provider Session requested for the continuation. It also carries
+// that canonical reference into the result when the provider omits the
+// redundant ExecuteResult field, so progress and terminal output retain the
+// same identity without rebuilding it from a legacy session ID.
+func continuedExecuteResult(continued providers.ContinueResult, reference providers.SessionRef) (providers.ExecuteResult, error) {
+	if continued.Reference != reference {
+		return providers.ExecuteResult{}, invalidContinuationReference(reference)
+	}
+	result := continued.Result.Clone()
+	if result.SessionRef != nil && *result.SessionRef != reference {
+		return providers.ExecuteResult{}, invalidContinuationReference(reference)
+	}
+	continuedReference := reference.Clone()
+	result.SessionRef = &continuedReference
+	return result, nil
+}
+
+func invalidContinuationReference(reference providers.SessionRef) providers.ContinuationFailure {
+	return providers.ContinuationFailure{
+		Kind:      providers.ContinuationFailureKindInvalid,
+		Message:   "provider continuation returned a different session reference",
+		Reference: reference.Clone(),
+	}
+}
+
+// providerIDForRunner translates stable Workers runner identities at the
+// Providers boundary.
+func providerIDForRunner(runnerID string) providers.ID {
+	return providers.ID(workers.NormalizeRunnerID(runnerID))
+}
+
+// providerIDForRequest makes the opaque continuation's provider identity the
+// authority for continuation routing. Runner IDs remain the selection input
+// for ordinary execution, but cannot redirect or invalidate an admitted
+// continuation.
+func providerIDForRequest(request workers.RunnerExecutionRequest) providers.ID {
+	if request.Continuation != nil {
+		return providers.ID(strings.TrimSpace(request.Continuation.Provider))
+	}
+	return providerIDForRunner(request.RunnerID)
+}
+
+func continuationSessionRef(
+	request workers.RunnerExecutionRequest,
+) *providers.SessionRef {
+	if request.Continuation != nil {
+		if reference, err := request.Continuation.ToSessionRef(); err == nil {
+			return &reference
+		}
+	}
+	if sessionID := strings.TrimSpace(request.SessionID); sessionID != "" {
+		return &providers.SessionRef{
+			Provider: providerIDForRunner(request.RunnerID),
+			Kind:     providers.SessionIDKind,
+			ID:       sessionID,
+		}
+	}
+	return nil
+}
+
+func runnerResult(
+	result providers.ExecuteResult,
+	providerID providers.ID,
+) workers.RunnerExecutionResult {
+	result = result.Clone()
+	response := workers.RunnerExecutionResult{
+		Content: result.Content,
+		Outcome: workers.WorkOutcome(result.Outcome),
+	}
+	if result.SessionRef != nil {
+		response.Continuation = continuationFromSessionRef(result.SessionRef)
+	}
+	if result.Diagnostics != nil {
+		metadata := cloneMetadata(result.Diagnostics.Metadata)
+		if result.Diagnostics.DurationMillis != 0 {
+			if metadata == nil {
+				metadata = make(map[string]string, 1)
+			}
+			metadata[workers.ProviderResponseMetadataDurationMS] =
+				strconv.FormatInt(result.Diagnostics.DurationMillis, 10)
+		}
+		response.Diagnostics = &workers.WorkDiagnostics{
+			Provider: &workers.ProviderDiagnostic{
+				Provider:         providerID.String(),
+				ResponseMetadata: cloneMetadata(metadata),
+			},
+			Metadata: metadata,
+		}
+		if result.Diagnostics.Command != nil {
+			response.Diagnostics.Command = &workers.CommandDiagnostic{
+				Command:    result.Diagnostics.Command.Command,
+				Args:       append([]string(nil), result.Diagnostics.Command.Args...),
+				Env:        cloneMetadata(result.Diagnostics.Command.Env),
+				Stdin:      result.Diagnostics.Command.Stdin,
+				Stdout:     result.Diagnostics.Command.Stdout,
+				Stderr:     result.Diagnostics.Command.Stderr,
+				ExitCode:   result.Diagnostics.Command.ExitCode,
+				TimedOut:   result.Diagnostics.Command.TimedOut,
+				Duration:   time.Duration(result.Diagnostics.Command.DurationMS) * time.Millisecond,
+				WorkingDir: result.Diagnostics.Command.WorkingDir,
+			}
+		}
+		if result.Diagnostics.Panic != nil {
+			response.Diagnostics.Panic = &workers.PanicDiagnostic{
+				Message: result.Diagnostics.Panic.Message,
+				Stack:   result.Diagnostics.Panic.Stack,
+			}
+		}
+	}
+	return response
+}
+
+func runnerFailureResult(
+	failure providers.ExecuteFailure,
+	request workers.RunnerExecutionRequest,
+) workers.RunnerExecutionResult {
+	response := runnerResult(providers.ExecuteResult{
+		SessionRef:  failure.SessionRef,
+		Diagnostics: failure.Diagnostics,
+	}, providerIDForRequest(request))
+	if response.Continuation == nil && failure.SessionRef != nil {
+		response.Continuation = continuationFromSessionRef(failure.SessionRef)
+	}
+	if response.Continuation == nil {
+		if reference := continuationSessionRef(request); reference != nil {
+			response.Continuation = continuationFromSessionRef(reference)
+		}
+	}
+	if response.Continuation == nil && strings.TrimSpace(request.SessionID) != "" {
+		response.Continuation = continuationFromSessionRef(&providers.SessionRef{
+			Provider: providerIDForRequest(request),
+			Kind:     providers.SessionIDKind,
+			ID:       request.SessionID,
+		})
+	}
+	if response.Continuation == nil {
+		response.Continuation = &workers.ProviderContinuationRef{
+			Provider: providers.ID(request.RunnerID).CanonicalSessionProvider(),
+		}
+	} else if strings.TrimSpace(response.Continuation.Provider) == "" {
+		response.Continuation.Provider = providers.ID(request.RunnerID).CanonicalSessionProvider()
+	}
+	return response
+}
+
+func providerFailure(err error) (providers.ExecuteFailure, bool) {
+	var value providers.ExecuteFailure
+	if errors.As(err, &value) {
+		return value.Clone(), true
+	}
+	var pointer *providers.ExecuteFailure
+	if errors.As(err, &pointer) && pointer != nil {
+		return pointer.Clone(), true
+	}
+	return providers.ExecuteFailure{}, false
+}
+
+func normalizeProviderFailure(
+	ctx context.Context,
+	failure providers.ExecuteFailure,
+	cause error,
+	result workers.RunnerExecutionResult,
+) error {
+	interruption := ctx.Err()
+	if errors.Is(interruption, context.Canceled) {
+		return canceledProviderError(errors.Join(context.Canceled, cause), result)
+	}
+	if interruption == nil {
+		switch failure.Kind {
+		case providers.ExecuteFailureKindCanceled:
+			interruption = context.Canceled
+		case providers.ExecuteFailureKindTimeout:
+			interruption = context.DeadlineExceeded
+		}
+	}
+	if failure.Kind == providers.ExecuteFailureKindCanceled {
+		return canceledProviderError(errors.Join(interruption, cause), result)
+	}
+	failureType := failureTypeForProviderFailure(failure)
+	if failure.Diagnostics != nil {
+		switch failure.Diagnostics.Metadata["work-failure-type"] {
+		case string(workers.WorkFailureTypeMissingExecutable):
+			failureType = workers.WorkFailureTypeMissingExecutable
+		case string(workers.WorkFailureTypeMisconfigured):
+			failureType = workers.WorkFailureTypeMisconfigured
+		case string(workers.WorkFailureTypeCommandLineTooLong):
+			failureType = workers.WorkFailureTypeCommandLineTooLong
+		}
+	}
+	if errors.Is(interruption, context.DeadlineExceeded) {
+		failureType = workers.WorkFailureTypeTimeout
+	}
+	normalized := workers.NewProviderError(
+		failureType,
+		boundedFailureMessage(canonicalAgentFailureMessage(failure, failureType, failure.Message)),
+		errors.Join(interruption, cause),
+	)
+	// Providers has already normalized and sanitized this message. Retain the
+	// provider failure kind on fresh attempts as well as continuations so the
+	// downstream invocation/child boundary can distinguish provider-owned safe
+	// detail from an arbitrary Worker error.
+	normalized.ProviderFailureKind = failure.Kind
+	normalized.Continuation = cloneContinuation(result.Continuation)
+	normalized.Diagnostics = workers.CloneWorkDiagnostics(result.Diagnostics)
+	return normalized
+}
+
+// continuationUnsupportedError keeps Providers' successful unsupported
+// capability result distinct from an invalid Execute failure until Workers has
+// copied that exact classification into its own in-process result boundary.
+type continuationUnsupportedError struct {
+	reference providers.SessionRef
+}
+
+func (continuationUnsupportedError) Error() string {
+	return "provider does not support resuming this Provider Session"
+}
+
+func continuationFailureResult(
+	ctx context.Context,
+	request workers.RunnerExecutionRequest,
+	err error,
+) (workers.RunnerExecutionResult, error, bool) {
+	if unsupported, ok := unsupportedContinuation(err); ok {
+		response := runnerContinuationFailureResult(request, unsupported.reference)
+		normalized := workers.NewProviderError(
+			workers.WorkFailureTypePermanentBadRequest,
+			"provider session continuation is unsupported",
+			err,
+		)
+		normalized.ProviderContinuationOutcome = providers.ContinuationOutcomeUnsupported
+		normalized.Continuation = cloneContinuation(response.Continuation)
+		return response, normalized, true
+	}
+	if failure, ok := continuationFailure(err); ok {
+		response := runnerContinuationFailureResult(request, failure.Reference)
+		normalized := workers.NewProviderError(
+			workers.WorkFailureTypePermanentBadRequest,
+			"provider session continuation was rejected",
+			errors.Join(ctx.Err(), err),
+		)
+		normalized.ProviderContinuationFailureKind = failure.Kind
+		normalized.Continuation = cloneContinuation(response.Continuation)
+		return response, normalized, true
+	}
+	return workers.RunnerExecutionResult{}, nil, false
+}
+
+func runnerContinuationFailureResult(
+	request workers.RunnerExecutionRequest,
+	fallback providers.SessionRef,
+) workers.RunnerExecutionResult {
+	reference := fallback.Clone()
+	if requested := continuationSessionRef(request); requested != nil {
+		reference = requested.Clone()
+	}
+	result := runnerFailureResult(providers.ExecuteFailure{SessionRef: &reference}, request)
+	if request.Continuation != nil {
+		result.Continuation = cloneContinuation(request.Continuation)
+	}
+	return result
+}
+
+func unsupportedContinuation(err error) (continuationUnsupportedError, bool) {
+	var unsupported continuationUnsupportedError
+	if errors.As(err, &unsupported) {
+		return unsupported, true
+	}
+	return continuationUnsupportedError{}, false
+}
+
+func continuationFailure(err error) (providers.ContinuationFailure, bool) {
+	var value providers.ContinuationFailure
+	if errors.As(err, &value) {
+		return value.Clone(), true
+	}
+	var pointer *providers.ContinuationFailure
+	if errors.As(err, &pointer) && pointer != nil {
+		return pointer.Clone(), true
+	}
+	return providers.ContinuationFailure{}, false
+}
+
+func cloneContinuation(reference *workers.ProviderContinuationRef) *workers.ProviderContinuationRef {
+	if reference == nil {
+		return nil
+	}
+	clone := reference.Clone()
+	return &clone
+}
+
+func continuationFromSessionRef(reference *providers.SessionRef) *workers.ProviderContinuationRef {
+	if reference == nil {
+		return nil
+	}
+	continuation := reference.ContinuationRef()
+	return &continuation
+}
+
+func cloneSessionRef(reference *providers.SessionRef) *providers.SessionRef {
+	if reference == nil {
+		return nil
+	}
+	clone := reference.Clone()
+	return &clone
+}

--- a/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/terminal_finalization_test.go
+++ b/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/terminal_finalization_test.go
@@ -1,0 +1,288 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/providers"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+func TestExecuteResultAndErrorSelectsCompletedTerminal(t *testing.T) {
+	t.Parallel()
+
+	failure := providers.ExecuteFailure{
+		Kind:    providers.ExecuteFailureKindDependency,
+		Message: "stream flush failed after the final answer",
+		Diagnostics: &providers.ExecuteDiagnostics{
+			Metadata: map[string]string{
+				workers.ProviderResponseMetadataFailureStage: "flush",
+			},
+		},
+	}
+	envelopes := &recordingDecisionEnvelopeService{
+		result: workers.WorkResult{
+			Outcome: workers.OutcomeAccepted,
+			Output:  "accepted output",
+		},
+	}
+	provider := &resultErrorProvidersFake{
+		result: providers.ExecuteResult{Content: `{"decision":"ACCEPTED"}`},
+		err:    failure,
+	}
+	recorder := &progressFragmentRecorder{}
+	runner, err := New(provider, recorder.publish, envelopes)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	request := baseAgentRequest()
+	request.DecisionEnvelope = true
+	result, err := runner.Execute(t.Context(), request)
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want the usable result to win", err)
+	}
+	if result.Content != "accepted output" || result.Outcome != workers.OutcomeAccepted {
+		t.Fatalf("result = %#v, want the accepted normalized result", result)
+	}
+	if calls := len(envelopes.snapshot()); calls != 1 {
+		t.Fatalf("decision-envelope normalization calls = %d, want exactly one", calls)
+	}
+	if result.Diagnostics == nil || result.Diagnostics.Metadata[suppressedTerminalErrorKindMetadata] != string(providers.ExecuteFailureKindDependency) {
+		t.Fatalf("result diagnostics = %#v, want bounded suppressed dependency kind", result.Diagnostics)
+	}
+	if result.Diagnostics.Metadata[workers.ProviderResponseMetadataFailureStage] != "flush" {
+		t.Fatalf("result diagnostics = %#v, want bounded flush stage", result.Diagnostics)
+	}
+
+	fragments := recorder.snapshot()
+	if countFragmentsByKind(fragments, workers.CompletedFragmentKind) != 1 {
+		t.Fatalf("completed terminal fragments = %#v, want exactly one", fragments)
+	}
+	if countFragmentsByKind(fragments, workers.FailedFragmentKind) != 0 {
+		t.Fatalf("failed terminal fragments = %#v, want none", fragments)
+	}
+	completed := fragmentByKind(fragments, workers.CompletedFragmentKind)
+	if completed.Metadata[suppressedTerminalErrorKindMetadata] != string(providers.ExecuteFailureKindDependency) ||
+		completed.Metadata[workers.ProviderResponseMetadataFailureStage] != "flush" {
+		t.Fatalf("completed metadata = %#v, want bounded suppressed dependency/flush facts", completed.Metadata)
+	}
+}
+
+func TestExecuteUnusableResultKeepsTypedFailureTerminal(t *testing.T) {
+	t.Parallel()
+
+	provider := &resultErrorProvidersFake{
+		err: providers.ExecuteFailure{
+			Kind:    providers.ExecuteFailureKindDependency,
+			Message: "provider failed without a result",
+		},
+	}
+	recorder := &progressFragmentRecorder{}
+	runner, err := New(provider, recorder.publish)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	result, err := runner.Execute(t.Context(), baseAgentRequest())
+	if err == nil {
+		t.Fatal("Execute() error = nil, want the typed provider failure")
+	}
+	var providerErr *workers.ProviderError
+	if !errors.As(err, &providerErr) {
+		t.Fatalf("Execute() error = %v, want *workers.ProviderError", err)
+	}
+	if providerErr.Type != workers.WorkFailureTypeInternalServerError {
+		t.Fatalf("ProviderError.Type = %q, want internal_server_error", providerErr.Type)
+	}
+	if result.Outcome != workers.OutcomeFailed {
+		t.Fatalf("result.Outcome = %q, want FAILED", result.Outcome)
+	}
+
+	fragments := recorder.snapshot()
+	if countFragmentsByKind(fragments, workers.CompletedFragmentKind) != 0 {
+		t.Fatalf("completed terminal fragments = %#v, want none", fragments)
+	}
+	if countFragmentsByKind(fragments, workers.FailedFragmentKind) != 1 {
+		t.Fatalf("failed terminal fragments = %#v, want exactly one", fragments)
+	}
+}
+
+func TestExecuteMalformedResultPublishesFailureTerminal(t *testing.T) {
+	t.Parallel()
+
+	envelopes := &recordingDecisionEnvelopeService{
+		result: workers.WorkResult{
+			Outcome: workers.OutcomeFailed,
+			Error:   "decision envelope is malformed",
+			FailureMetadata: &workers.WorkFailureMetadata{
+				Family: workers.WorkFailureFamilyTerminal,
+				Type:   workers.WorkFailureTypeUnknown,
+			},
+		},
+	}
+	recorder := &progressFragmentRecorder{}
+	runner, err := New(&providersFake{content: "not-json"}, recorder.publish, envelopes)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	_, err = runner.Execute(t.Context(), func() workers.RunnerExecutionRequest {
+		request := baseAgentRequest()
+		request.DecisionEnvelope = true
+		return request
+	}())
+	if err == nil {
+		t.Fatal("Execute() error = nil, want malformed decision-envelope failure")
+	}
+	if calls := len(envelopes.snapshot()); calls != 1 {
+		t.Fatalf("decision-envelope normalization calls = %d, want exactly one", calls)
+	}
+	fragments := recorder.snapshot()
+	if countFragmentsByKind(fragments, workers.CompletedFragmentKind) != 0 {
+		t.Fatalf("completed terminal fragments = %#v, want none", fragments)
+	}
+	if countFragmentsByKind(fragments, workers.FailedFragmentKind) != 1 {
+		t.Fatalf("failed terminal fragments = %#v, want exactly one", fragments)
+	}
+}
+
+func TestTerminalFinalizationSuppressesConcurrentDuplicates(t *testing.T) {
+	recorder := &progressFragmentRecorder{}
+	publication := newTerminalPublication(recorder.publish)
+	fragment := workers.ProgressFragment{
+		Kind:              workers.CompletedFragmentKind,
+		Type:              "COMPLETED",
+		ExternalEventType: "STREAM_COMPLETED",
+	}
+
+	var waitGroup sync.WaitGroup
+	for index := 0; index < 32; index++ {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			publication.terminal(fragment)
+		}()
+	}
+	waitGroup.Wait()
+	publication.progress(workers.ProgressFragment{Type: "late.progress"})
+
+	fragments := recorder.snapshot()
+	if len(fragments) != 1 || fragments[0].Kind != workers.CompletedFragmentKind {
+		t.Fatalf("terminal publications = %#v, want one canonical completion and no late progress", fragments)
+	}
+}
+
+func TestExecuteFinalizationIgnoresLateProviderProgress(t *testing.T) {
+	t.Parallel()
+
+	provider := &lateProgressProvidersFake{}
+	recorder := &progressFragmentRecorder{}
+	runner, err := New(provider, recorder.publish)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if _, err := runner.Execute(t.Context(), baseAgentRequest()); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	observer := provider.progressObserver()
+	if observer == nil {
+		t.Fatal("provider progress observer = nil, want the runner callback seam")
+	}
+	observer(providers.ExecuteProgress{Phase: "late.progress", Detail: "must be ignored"})
+
+	fragments := recorder.snapshot()
+	for _, fragment := range fragments {
+		if fragment.Type == "late.progress" {
+			t.Fatalf("late provider progress was published: %#v", fragments)
+		}
+	}
+	if countFragmentsByKind(fragments, workers.CompletedFragmentKind) != 1 {
+		t.Fatalf("completed terminal fragments = %#v, want exactly one", fragments)
+	}
+}
+
+type resultErrorProvidersFake struct {
+	providers.Service
+	result providers.ExecuteResult
+	err    error
+}
+
+func (fake *resultErrorProvidersFake) Execute(
+	_ context.Context,
+	_ providers.ExecuteRequest,
+) (providers.ExecuteResult, error) {
+	return fake.result.Clone(), fake.err
+}
+
+type lateProgressProvidersFake struct {
+	providers.Service
+	mu       sync.Mutex
+	observer providers.ProgressObserver
+}
+
+func (fake *lateProgressProvidersFake) Execute(
+	_ context.Context,
+	request providers.ExecuteRequest,
+) (providers.ExecuteResult, error) {
+	fake.mu.Lock()
+	fake.observer = request.ProgressObserver
+	fake.mu.Unlock()
+	return providers.ExecuteResult{Content: "accepted output"}, nil
+}
+
+func (fake *lateProgressProvidersFake) progressObserver() providers.ProgressObserver {
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	return fake.observer
+}
+
+type progressFragmentRecorder struct {
+	mu        sync.Mutex
+	fragments []workers.ProgressFragment
+}
+
+func (recorder *progressFragmentRecorder) publish(fragment workers.ProgressFragment) {
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	fragment.Metadata = cloneMetadata(fragment.Metadata)
+	recorder.fragments = append(recorder.fragments, fragment)
+}
+
+func (recorder *progressFragmentRecorder) snapshot() []workers.ProgressFragment {
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	fragments := append([]workers.ProgressFragment(nil), recorder.fragments...)
+	for index := range fragments {
+		fragments[index].Metadata = cloneMetadata(fragments[index].Metadata)
+	}
+	return fragments
+}
+
+func countFragmentsByKind(
+	fragments []workers.ProgressFragment,
+	kind string,
+) int {
+	count := 0
+	for _, fragment := range fragments {
+		if fragment.Kind == kind {
+			count++
+		}
+	}
+	return count
+}
+
+func fragmentByKind(
+	fragments []workers.ProgressFragment,
+	kind string,
+) workers.ProgressFragment {
+	for _, fragment := range fragments {
+		if fragment.Kind == kind {
+			return fragment
+		}
+	}
+	return workers.ProgressFragment{}
+}

--- a/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/terminal_finalization_test.go
+++ b/pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/terminal_finalization_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 
@@ -101,6 +102,73 @@ func TestExecuteUnusableResultKeepsTypedFailureTerminal(t *testing.T) {
 		t.Fatalf("result.Outcome = %q, want FAILED", result.Outcome)
 	}
 
+	fragments := recorder.snapshot()
+	if countFragmentsByKind(fragments, workers.CompletedFragmentKind) != 0 {
+		t.Fatalf("completed terminal fragments = %#v, want none", fragments)
+	}
+	if countFragmentsByKind(fragments, workers.FailedFragmentKind) != 1 {
+		t.Fatalf("failed terminal fragments = %#v, want exactly one", fragments)
+	}
+}
+
+func TestExecutePartialNativeResultOnTimeoutKeepsTypedFailure(t *testing.T) {
+	t.Parallel()
+
+	provider := &resultErrorProvidersFake{
+		result: providers.ExecuteResult{Content: "partial output before timeout"},
+		err: providers.ExecuteFailure{
+			Kind:    providers.ExecuteFailureKindTimeout,
+			Message: "provider invocation timed out",
+		},
+	}
+	recorder := &progressFragmentRecorder{}
+	runner, err := New(provider, recorder.publish)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	request := baseAgentRequest()
+	request.StopToken = "COMPLETE"
+	result, err := runner.Execute(t.Context(), request)
+	if err == nil {
+		t.Fatal("Execute() error = nil, want timeout failure for partial native output")
+	}
+	var providerErr *workers.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Type != workers.WorkFailureTypeTimeout {
+		t.Fatalf("Execute() error = %v, want typed timeout ProviderError", err)
+	}
+	if result.Content != "partial output before timeout" {
+		t.Fatalf("result.Content = %q, want retained partial output", result.Content)
+	}
+
+	fragments := recorder.snapshot()
+	if countFragmentsByKind(fragments, workers.CompletedFragmentKind) != 0 {
+		t.Fatalf("completed terminal fragments = %#v, want none", fragments)
+	}
+	if countFragmentsByKind(fragments, workers.FailedFragmentKind) != 1 {
+		t.Fatalf("failed terminal fragments = %#v, want exactly one", fragments)
+	}
+}
+
+func TestExecuteEmptyResultPublishesNoUsableFailure(t *testing.T) {
+	t.Parallel()
+
+	recorder := &progressFragmentRecorder{}
+	runner, err := New(&resultErrorProvidersFake{}, recorder.publish)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	result, err := runner.Execute(t.Context(), baseAgentRequest())
+	var providerErr *workers.ProviderError
+	if err == nil || !errors.As(err, &providerErr) ||
+		providerErr.Type != workers.WorkFailureTypeInternalServerError ||
+		strings.Contains(err.Error(), noUsableAgentResultMessage) {
+		t.Fatalf("Execute() error = %v, want bounded no-usable-result failure", err)
+	}
+	if result.Outcome != workers.OutcomeFailed {
+		t.Fatalf("result.Outcome = %q, want FAILED", result.Outcome)
+	}
 	fragments := recorder.snapshot()
 	if countFragmentsByKind(fragments, workers.CompletedFragmentKind) != 0 {
 		t.Fatalf("completed terminal fragments = %#v, want none", fragments)
@@ -285,4 +353,135 @@ func fragmentByKind(
 		}
 	}
 	return workers.ProgressFragment{}
+}
+
+func TestTerminalPublicationNilIsNoop(t *testing.T) {
+	var publication *terminalPublication
+	fragment := workers.ProgressFragment{Kind: workers.ProgressFragmentKind}
+
+	publication.progress(fragment)
+	publication.terminal(fragment)
+	publication.close()
+}
+
+func TestExecuteNativeLifecycleDoesNotSynthesizeCompletion(t *testing.T) {
+	t.Parallel()
+
+	recorder := &progressFragmentRecorder{}
+	provider := &resultProvidersFake{result: providers.ExecuteResult{
+		Content: "native completed output",
+		Diagnostics: &providers.ExecuteDiagnostics{Progress: []providers.ExecuteProgress{{
+			Phase:  "turn.completed",
+			Detail: "native terminal lifecycle",
+		}}},
+	}}
+	runner, err := New(provider, recorder.publish)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if _, err := runner.Execute(t.Context(), baseAgentRequest()); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	fragments := recorder.snapshot()
+	if countFragmentsByKind(fragments, workers.CompletedFragmentKind) != 0 {
+		t.Fatalf("completed terminal fragments = %#v, want native lifecycle only", fragments)
+	}
+	if len(fragments) != 2 || fragments[0].Type != "turn.completed" ||
+		fragments[1].Type != "message.completed" {
+		t.Fatalf("native lifecycle fragments = %#v, want native lifecycle and ordered message progress", fragments)
+	}
+}
+
+func TestMergeDecisionEnvelopeDiagnosticsCopiesOwnerLayers(t *testing.T) {
+	t.Parallel()
+
+	envelope := &workers.WorkDiagnostics{
+		Provider: &workers.ProviderDiagnostic{
+			Provider: "definitions",
+			ResponseMetadata: map[string]string{
+				"classification": "accepted",
+			},
+		},
+		Metadata: map[string]string{"decision": "owner"},
+	}
+	if merged := mergeDecisionEnvelopeDiagnostics(nil, envelope); merged == nil ||
+		merged.Provider == nil || merged.Provider.ResponseMetadata["classification"] != "accepted" {
+		t.Fatalf("nil-base diagnostics = %#v, want cloned owner diagnostics", merged)
+	}
+
+	baseWithoutProvider := &workers.WorkDiagnostics{}
+	merged := mergeDecisionEnvelopeDiagnostics(baseWithoutProvider, envelope)
+	if merged.Provider == nil || merged.Provider.Provider != "definitions" {
+		t.Fatalf("provider overlay = %#v, want owner provider", merged.Provider)
+	}
+
+	baseWithoutMetadata := &workers.WorkDiagnostics{
+		Provider: &workers.ProviderDiagnostic{Provider: "codex"},
+	}
+	merged = mergeDecisionEnvelopeDiagnostics(baseWithoutMetadata, envelope)
+	if merged.Provider.ResponseMetadata["classification"] != "accepted" ||
+		merged.Metadata["decision"] != "owner" {
+		t.Fatalf("layered diagnostics = %#v, want provider and top-level metadata", merged)
+	}
+}
+
+func TestRunnerResultCopiesDetachedProviderDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	response := runnerResult(providers.ExecuteResult{
+		Content: "diagnosed output",
+		SessionRef: &providers.SessionRef{
+			Provider: providers.IDCodex,
+			Kind:     providers.SessionIDKind,
+			ID:       "diagnosed-session",
+		},
+		Diagnostics: &providers.ExecuteDiagnostics{
+			DurationMillis: 7,
+			Command: &providers.ExecuteCommandDiagnostics{
+				Command: "codex", Args: []string{"exec"}, Env: map[string]string{"SAFE": "1"},
+				Stdin: "prompt", Stdout: "out", Stderr: "err", ExitCode: 3,
+				TimedOut: true, DurationMS: 4, WorkingDir: "work",
+			},
+			Panic: &providers.ExecutePanicDiagnostics{Message: "panic", Stack: "stack"},
+		},
+	}, providers.IDCodex)
+	if response.Diagnostics == nil || response.Diagnostics.Provider == nil ||
+		response.Diagnostics.Provider.ResponseMetadata[workers.ProviderResponseMetadataDurationMS] != "7" {
+		t.Fatalf("provider diagnostics = %#v, want duration metadata", response.Diagnostics)
+	}
+	if response.Diagnostics.Command == nil || !response.Diagnostics.Command.TimedOut ||
+		response.Diagnostics.Panic == nil || response.Diagnostics.Panic.Message != "panic" {
+		t.Fatalf("detached command/panic diagnostics = %#v, want copied facts", response.Diagnostics)
+	}
+}
+
+func TestLiveProviderSessionSnapshotCopiesAuthoredReference(t *testing.T) {
+	t.Parallel()
+
+	live := &liveProviderSession{}
+	live.set(providers.SessionRef{
+		Provider: providers.IDCodex,
+		Kind:     providers.SessionIDKind,
+		ID:       "live-session",
+	})
+	snapshot := live.snapshot()
+	if snapshot == nil || snapshot.ProviderSessionID != "live-session" {
+		t.Fatalf("live session snapshot = %#v, want authored continuation", snapshot)
+	}
+}
+
+func TestPreserveContinuationUsesLegacySessionID(t *testing.T) {
+	t.Parallel()
+
+	request := baseAgentRequest()
+	request.SessionID = "legacy-session"
+	response := preserveContinuation(
+		workers.RunnerExecutionResult{},
+		request,
+		nil,
+	)
+	if response.Continuation == nil || response.Continuation.ProviderSessionID != "legacy-session" {
+		t.Fatalf("preserved continuation = %#v, want legacy session", response.Continuation)
+	}
 }

--- a/tests/functional/factory/packaged/full_flow/invocation_test.go
+++ b/tests/functional/factory/packaged/full_flow/invocation_test.go
@@ -247,6 +247,13 @@ type fullFlowRunner struct {
 	stallImplementation             bool
 	implementationCalls             int
 	detectConcurrentImplementations bool
+	singleTask                      bool
+	failImplementation              bool
+	acceptedResultWithError         bool
+	pauseAcceptedResult             bool
+	acceptedResultStarted           chan struct{}
+	acceptedResultRelease           chan struct{}
+	acceptedResultOnce              sync.Once
 }
 
 func (runner *fullFlowRunner) Run(_ context.Context, request platformprocess.CommandRequest) (platformprocess.CommandResult, error) {
@@ -269,6 +276,9 @@ func (runner *fullFlowRunner) Run(_ context.Context, request platformprocess.Com
 		call := runner.plannerCalls
 		runner.mu.Unlock()
 		if call == 1 {
+			if runner.singleTask || runner.failImplementation {
+				return fullFlowCodexResult(`{"request":{"type":"FACTORY_REQUEST_BATCH","works":[{"name":"task-a","workTypeName":"delivery-task","payload":"implement task a"},{"name":"work-1","workTypeName":"cycle-control","payload":"continue"}],"relations":[{"type":"DEPENDS_ON","sourceWorkName":"work-1","targetWorkName":"task-a","requiredState":"merged"}]}}`), nil
+			}
 			return fullFlowCodexResult(`{"request":{"type":"FACTORY_REQUEST_BATCH","works":[{"name":"task-a","workTypeName":"delivery-task","payload":"implement task a"},{"name":"task-b","workTypeName":"delivery-task","payload":"implement task b"},{"name":"work-1","workTypeName":"cycle-control","payload":"continue"}],"relations":[{"type":"DEPENDS_ON","sourceWorkName":"work-1","targetWorkName":"task-a","requiredState":"merged"},{"type":"DEPENDS_ON","sourceWorkName":"work-1","targetWorkName":"task-b","requiredState":"merged"}]}}`), nil
 		}
 		return fullFlowCodexResult(`{"request":{"type":"FACTORY_REQUEST_BATCH","works":[{"name":"work-1","workTypeName":"cycle-control","payload":"complete"}]}}`), nil
@@ -276,6 +286,7 @@ func (runner *fullFlowRunner) Run(_ context.Context, request platformprocess.Com
 		task := filepath.Base(request.WorkDir)
 		runner.mu.Lock()
 		runner.implementationCalls++
+		call := runner.implementationCalls
 		runner.active++
 		if runner.active > runner.maxActive {
 			runner.maxActive = runner.active
@@ -290,6 +301,15 @@ func (runner *fullFlowRunner) Run(_ context.Context, request platformprocess.Com
 			runner.mu.Unlock()
 			return fullFlowCodexResult("<CONTINUE>"), nil
 		}
+		if runner.failImplementation {
+			runner.mu.Lock()
+			runner.active--
+			runner.mu.Unlock()
+			return platformprocess.CommandResult{
+				Stderr:   []byte("provider exited before producing a result"),
+				ExitCode: 17,
+			}, nil
+		}
 		if err := os.WriteFile(filepath.Join(request.WorkDir, task+".txt"), []byte(task+"\n"), 0o600); err != nil {
 			return platformprocess.CommandResult{}, err
 		}
@@ -298,6 +318,16 @@ func (runner *fullFlowRunner) Run(_ context.Context, request platformprocess.Com
 		}
 		if _, err := fullFlowGit(request.WorkDir, "commit", "-m", "implement "+task); err != nil {
 			return platformprocess.CommandResult{}, err
+		}
+		if runner.acceptedResultWithError && call == 1 {
+			if runner.pauseAcceptedResult {
+				runner.acceptedResultOnce.Do(func() { close(runner.acceptedResultStarted) })
+				<-runner.acceptedResultRelease
+			}
+			runner.mu.Lock()
+			runner.active--
+			runner.mu.Unlock()
+			return fullFlowCodexResultWithExit("<COMPLETE>", 17), nil
 		}
 		runner.mu.Lock()
 		runner.active--
@@ -400,4 +430,10 @@ func fullFlowGit(directory string, args ...string) (string, error) {
 
 func fullFlowCodexResult(text string) platformprocess.CommandResult {
 	return platformprocess.CommandResult{Stdout: support.CodexSuccessStdout(text)}
+}
+
+func fullFlowCodexResultWithExit(text string, exitCode int) platformprocess.CommandResult {
+	result := fullFlowCodexResult(text)
+	result.ExitCode = exitCode
+	return result
 }

--- a/tests/functional/factory/packaged/full_flow/invocation_test.go
+++ b/tests/functional/factory/packaged/full_flow/invocation_test.go
@@ -260,79 +260,9 @@ func (runner *fullFlowRunner) Run(_ context.Context, request platformprocess.Com
 	prompt := string(request.Stdin)
 	switch {
 	case strings.Contains(prompt, "You are the planning stage for one bounded delivery cycle"):
-		for _, required := range []string{
-			"you docs agents",
-			"Never run bare `you`",
-			`{"request":{"type":"FACTORY_REQUEST_BATCH"`,
-			`"type":"DEPENDS_ON"`,
-			`"workTypeName":"cycle-control"`,
-		} {
-			if !strings.Contains(prompt, required) {
-				return platformprocess.CommandResult{}, fmt.Errorf("full-flow planner prompt missing required contract %q", required)
-			}
-		}
-		runner.mu.Lock()
-		runner.plannerCalls++
-		call := runner.plannerCalls
-		runner.mu.Unlock()
-		if call == 1 {
-			if runner.singleTask || runner.failImplementation {
-				return fullFlowCodexResult(`{"request":{"type":"FACTORY_REQUEST_BATCH","works":[{"name":"task-a","workTypeName":"delivery-task","payload":"implement task a"},{"name":"work-1","workTypeName":"cycle-control","payload":"continue"}],"relations":[{"type":"DEPENDS_ON","sourceWorkName":"work-1","targetWorkName":"task-a","requiredState":"merged"}]}}`), nil
-			}
-			return fullFlowCodexResult(`{"request":{"type":"FACTORY_REQUEST_BATCH","works":[{"name":"task-a","workTypeName":"delivery-task","payload":"implement task a"},{"name":"task-b","workTypeName":"delivery-task","payload":"implement task b"},{"name":"work-1","workTypeName":"cycle-control","payload":"continue"}],"relations":[{"type":"DEPENDS_ON","sourceWorkName":"work-1","targetWorkName":"task-a","requiredState":"merged"},{"type":"DEPENDS_ON","sourceWorkName":"work-1","targetWorkName":"task-b","requiredState":"merged"}]}}`), nil
-		}
-		return fullFlowCodexResult(`{"request":{"type":"FACTORY_REQUEST_BATCH","works":[{"name":"work-1","workTypeName":"cycle-control","payload":"complete"}]}}`), nil
+		return runner.runPlanning(prompt)
 	case strings.Contains(prompt, "implementation agent for one assigned delivery task"):
-		task := filepath.Base(request.WorkDir)
-		runner.mu.Lock()
-		runner.implementationCalls++
-		call := runner.implementationCalls
-		runner.active++
-		if runner.active > runner.maxActive {
-			runner.maxActive = runner.active
-		}
-		runner.mu.Unlock()
-		if runner.detectConcurrentImplementations {
-			runner.awaitConcurrentImplementation()
-		}
-		if runner.stallImplementation {
-			runner.mu.Lock()
-			runner.active--
-			runner.mu.Unlock()
-			return fullFlowCodexResult("<CONTINUE>"), nil
-		}
-		if runner.failImplementation {
-			runner.mu.Lock()
-			runner.active--
-			runner.mu.Unlock()
-			return platformprocess.CommandResult{
-				Stderr:   []byte("provider exited before producing a result"),
-				ExitCode: 17,
-			}, nil
-		}
-		if err := os.WriteFile(filepath.Join(request.WorkDir, task+".txt"), []byte(task+"\n"), 0o600); err != nil {
-			return platformprocess.CommandResult{}, err
-		}
-		if _, err := fullFlowGit(request.WorkDir, "add", task+".txt"); err != nil {
-			return platformprocess.CommandResult{}, err
-		}
-		if _, err := fullFlowGit(request.WorkDir, "commit", "-m", "implement "+task); err != nil {
-			return platformprocess.CommandResult{}, err
-		}
-		if runner.acceptedResultWithError && call == 1 {
-			if runner.pauseAcceptedResult {
-				runner.acceptedResultOnce.Do(func() { close(runner.acceptedResultStarted) })
-				<-runner.acceptedResultRelease
-			}
-			runner.mu.Lock()
-			runner.active--
-			runner.mu.Unlock()
-			return fullFlowCodexResultWithExit("<COMPLETE>", 17), nil
-		}
-		runner.mu.Lock()
-		runner.active--
-		runner.mu.Unlock()
-		return fullFlowCodexResult("<COMPLETE>"), nil
+		return runner.runImplementation(request)
 	case strings.Contains(prompt, "independent reviewer with no shared conversation"):
 		return fullFlowCodexResult("<COMPLETE>"), nil
 	case strings.Contains(prompt, "verification stage for an independently reviewed task"):
@@ -359,6 +289,84 @@ func (runner *fullFlowRunner) Run(_ context.Context, request platformprocess.Com
 		runner.mu.Unlock()
 		return platformprocess.CommandResult{}, fmt.Errorf("unexpected full-flow prompt: %s", prompt)
 	}
+}
+
+func (runner *fullFlowRunner) runPlanning(prompt string) (platformprocess.CommandResult, error) {
+	for _, required := range []string{
+		"you docs agents",
+		"Never run bare `you`",
+		`{"request":{"type":"FACTORY_REQUEST_BATCH"`,
+		`"type":"DEPENDS_ON"`,
+		`"workTypeName":"cycle-control"`,
+	} {
+		if !strings.Contains(prompt, required) {
+			return platformprocess.CommandResult{}, fmt.Errorf("full-flow planner prompt missing required contract %q", required)
+		}
+	}
+	runner.mu.Lock()
+	runner.plannerCalls++
+	call := runner.plannerCalls
+	runner.mu.Unlock()
+	if call == 1 {
+		if runner.singleTask || runner.failImplementation {
+			return fullFlowCodexResult(`{"request":{"type":"FACTORY_REQUEST_BATCH","works":[{"name":"task-a","workTypeName":"delivery-task","payload":"implement task a"},{"name":"work-1","workTypeName":"cycle-control","payload":"continue"}],"relations":[{"type":"DEPENDS_ON","sourceWorkName":"work-1","targetWorkName":"task-a","requiredState":"merged"}]}}`), nil
+		}
+		return fullFlowCodexResult(`{"request":{"type":"FACTORY_REQUEST_BATCH","works":[{"name":"task-a","workTypeName":"delivery-task","payload":"implement task a"},{"name":"task-b","workTypeName":"delivery-task","payload":"implement task b"},{"name":"work-1","workTypeName":"cycle-control","payload":"continue"}],"relations":[{"type":"DEPENDS_ON","sourceWorkName":"work-1","targetWorkName":"task-a","requiredState":"merged"},{"type":"DEPENDS_ON","sourceWorkName":"work-1","targetWorkName":"task-b","requiredState":"merged"}]}}`), nil
+	}
+	return fullFlowCodexResult(`{"request":{"type":"FACTORY_REQUEST_BATCH","works":[{"name":"work-1","workTypeName":"cycle-control","payload":"complete"}]}}`), nil
+}
+
+func (runner *fullFlowRunner) runImplementation(request platformprocess.CommandRequest) (platformprocess.CommandResult, error) {
+	task := filepath.Base(request.WorkDir)
+	runner.mu.Lock()
+	runner.implementationCalls++
+	call := runner.implementationCalls
+	runner.active++
+	if runner.active > runner.maxActive {
+		runner.maxActive = runner.active
+	}
+	runner.mu.Unlock()
+	if runner.detectConcurrentImplementations {
+		runner.awaitConcurrentImplementation()
+	}
+	if runner.stallImplementation {
+		runner.mu.Lock()
+		runner.active--
+		runner.mu.Unlock()
+		return fullFlowCodexResult("<CONTINUE>"), nil
+	}
+	if runner.failImplementation {
+		runner.mu.Lock()
+		runner.active--
+		runner.mu.Unlock()
+		return platformprocess.CommandResult{
+			Stderr:   []byte("provider exited before producing a result"),
+			ExitCode: 17,
+		}, nil
+	}
+	if err := os.WriteFile(filepath.Join(request.WorkDir, task+".txt"), []byte(task+"\n"), 0o600); err != nil {
+		return platformprocess.CommandResult{}, err
+	}
+	if _, err := fullFlowGit(request.WorkDir, "add", task+".txt"); err != nil {
+		return platformprocess.CommandResult{}, err
+	}
+	if _, err := fullFlowGit(request.WorkDir, "commit", "-m", "implement "+task); err != nil {
+		return platformprocess.CommandResult{}, err
+	}
+	if runner.acceptedResultWithError && call == 1 {
+		if runner.pauseAcceptedResult {
+			runner.acceptedResultOnce.Do(func() { close(runner.acceptedResultStarted) })
+			<-runner.acceptedResultRelease
+		}
+		runner.mu.Lock()
+		runner.active--
+		runner.mu.Unlock()
+		return fullFlowCodexResultWithExit("<COMPLETE>", 17), nil
+	}
+	runner.mu.Lock()
+	runner.active--
+	runner.mu.Unlock()
+	return fullFlowCodexResult("<COMPLETE>"), nil
 }
 
 func optionalString(value *string) string {

--- a/tests/functional/factory/packaged/full_flow/terminal_finalization_test.go
+++ b/tests/functional/factory/packaged/full_flow/terminal_finalization_test.go
@@ -1,0 +1,429 @@
+package fullflow
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+func TestPackagedFullFlowDispatchTerminalFinalization(t *testing.T) {
+	fixture := newFullFlowSharedFixture(t)
+	t.Run("PreservesAcceptedResultWithLaterError", func(t *testing.T) {
+		t.Parallel()
+		testPackagedFullFlowDispatchTerminalFinalizationPreservesAcceptedResult(t, fixture)
+	})
+	t.Run("RoutesNoResultFailureToLead", func(t *testing.T) {
+		t.Parallel()
+		testPackagedFullFlowDispatchTerminalFinalizationRoutesFailureToLead(t, fixture)
+	})
+	t.Run("SuppressesConcurrentDuplicateInvocation", func(t *testing.T) {
+		t.Parallel()
+		testPackagedFullFlowDispatchTerminalFinalizationSuppressesDuplicateInvocation(t, fixture)
+	})
+}
+
+func testPackagedFullFlowDispatchTerminalFinalizationPreservesAcceptedResult(
+	t *testing.T,
+	fixture *fullFlowSharedFixture,
+) {
+	runner := &fullFlowRunner{
+		singleTask:              true,
+		acceptedResultWithError: true,
+		pauseAcceptedResult:     true,
+		acceptedResultStarted:   make(chan struct{}),
+		acceptedResultRelease:   make(chan struct{}),
+	}
+	scenario := fixture.newScenario(t, runner)
+	runner.repository = scenario.repository
+	scenario.open(t)
+	defer func() {
+		select {
+		case <-runner.acceptedResultRelease:
+		default:
+			close(runner.acceptedResultRelease)
+		}
+	}()
+
+	result := startFullFlowInvocation(t, scenario, map[string]any{
+		"request":    "Preserve an accepted result when the provider exits afterward",
+		"baseBranch": "main", "maxCycles": "3", "maxTasksPerCycle": "1",
+	})
+	select {
+	case <-runner.acceptedResultStarted:
+	case <-time.After(fullFlowSharedFixtureTimeout):
+		t.Fatal("timed out waiting for the controlled accepted-result provider call")
+	}
+	processing := waitForFullFlowSessionStatus(t, scenario, fullFlowSharedFixtureTimeout, func(status factoryapi.StatusResponse) bool {
+		usage, ok := fullFlowResourceUsage(status, "full-flow-task-slots")
+		return ok && usage.Available < usage.Total && status.Categories.Processing > 0
+	})
+	if usage, ok := fullFlowResourceUsage(processing, "full-flow-task-slots"); !ok || usage.Available != usage.Total-1 {
+		t.Fatalf("in-flight task resource = %#v, want one held slot", usage)
+	}
+	close(runner.acceptedResultRelease)
+	response := receiveFullFlowInvocation(t, result)
+	if response.Status != factoryapi.InvocationTerminalStatusCompleted {
+		t.Fatalf("response = %#v, want completed accepted invocation", response)
+	}
+
+	works := support.GetJSON[factoryapi.ListWorkResponse](t, support.SessionWorkURL(
+		fixture.baseURL, scenario.sessionID, "/work?terminal=true&includeSuperseded=true",
+	))
+	assertFullFlowWorkStates(t, works.Results, "project", "complete", 1)
+	tasks := assertFullFlowWorkStates(t, works.Results, "delivery-task", "merged", 1)
+	for _, work := range works.Results {
+		if work.WorkTypeName == nil || *work.WorkTypeName != "delivery-task" {
+			continue
+		}
+		if work.SupersededBy != nil {
+			t.Fatalf("work %q (type %q) has successor %q, want no second successor", work.Name, *work.WorkTypeName, *work.SupersededBy)
+		}
+	}
+
+	events := support.GetFactoryEventsForSessionAt(t, fixture.baseURL, scenario.sessionID)
+	dispatches := fullFlowDispatchesForTransition(t, events, "implement-task")
+	if len(dispatches) != 1 || dispatches[0].Response == nil {
+		t.Fatalf("implement dispatches = %#v, want one completed observation", dispatches)
+	}
+	if dispatches[0].Response.Outcome != factoryapi.WorkOutcomeAccepted {
+		t.Fatalf("implement dispatch outcome = %q, want ACCEPTED", dispatches[0].Response.Outcome)
+	}
+	if dispatches[0].Response.Output == nil || !strings.Contains(*dispatches[0].Response.Output, "<COMPLETE>") {
+		t.Fatalf("implement dispatch output = %#v, want canonical completion", dispatches[0].Response.Output)
+	}
+	agentRuns := fullFlowAgentRunResponsesForDispatch(t, events, dispatches[0].DispatchID)
+	if len(agentRuns) != 1 || agentRuns[0].Outcome != factoryapi.WorkOutcomeAccepted {
+		t.Fatalf("agent-run responses = %#v, want one accepted terminal response", agentRuns)
+	}
+	if agentRuns[0].Diagnostics == nil || agentRuns[0].Diagnostics.Provider == nil || agentRuns[0].Diagnostics.Provider.ResponseMetadata == nil {
+		t.Fatalf("accepted agent-run diagnostics = %#v, want bounded provider metadata", agentRuns[0].Diagnostics)
+	}
+	metadata := *agentRuns[0].Diagnostics.Provider.ResponseMetadata
+	if metadata["completion_evidence"] != "agent_message" || strings.TrimSpace(metadata["failure_stage"]) == "" {
+		t.Fatalf("accepted agent-run response metadata = %#v, want completion evidence and bounded later-error stage", metadata)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("merged tasks = %d, want one", len(tasks))
+	}
+	terminal := waitForFullFlowSessionStatus(t, scenario, fullFlowSharedFixtureTimeout, func(status factoryapi.StatusResponse) bool {
+		usage, ok := fullFlowResourceUsage(status, "full-flow-task-slots")
+		return ok && usage.Available == usage.Total
+	})
+	if usage, ok := fullFlowResourceUsage(terminal, "full-flow-task-slots"); !ok || usage.Available != usage.Total {
+		t.Fatalf("terminal task resource = %#v, want fully released resource", usage)
+	}
+}
+
+func testPackagedFullFlowDispatchTerminalFinalizationRoutesFailureToLead(
+	t *testing.T,
+	fixture *fullFlowSharedFixture,
+) {
+	runner := &fullFlowRunner{singleTask: true, failImplementation: true}
+	scenario := fixture.newScenario(t, runner)
+	runner.repository = scenario.repository
+	scenario.open(t)
+	response := invokeFullFlowSession(t, scenario, map[string]any{
+		"request":    "Route a provider failure to the existing project failure lead",
+		"baseBranch": "main", "maxCycles": "3", "maxTasksPerCycle": "1",
+	})
+	if response.Status != factoryapi.InvocationTerminalStatusFailed || response.WorkState == nil || !strings.HasSuffix(*response.WorkState, ":failed") {
+		t.Fatalf("response = %#v, want failed project invocation", response)
+	}
+
+	works := support.GetJSON[factoryapi.ListWorkResponse](t, support.SessionWorkURL(
+		fixture.baseURL, scenario.sessionID, "/work?terminal=true&includeSuperseded=true",
+	))
+	assertFullFlowWorkStates(t, works.Results, "project", "failed", 1)
+	tasks := assertFullFlowWorkStates(t, works.Results, "delivery-task", "failed", 1)
+	for _, work := range works.Results {
+		if work.State != nil && work.State.Name == "complete" {
+			t.Fatalf("work %q reached complete after provider failure", work.Name)
+		}
+	}
+
+	events := support.GetFactoryEventsForSessionAt(t, fixture.baseURL, scenario.sessionID)
+	dispatches := fullFlowDispatchesForTransition(t, events, "implement-task")
+	if len(dispatches) != 1 || dispatches[0].Response == nil {
+		t.Fatalf("implement failure dispatches = %#v, want one terminal failure", dispatches)
+	}
+	if dispatches[0].Response.Outcome != factoryapi.WorkOutcomeFailed || dispatches[0].Response.FailureDetail == nil {
+		t.Fatalf("implement failure response = %#v, want typed FAILED outcome", dispatches[0].Response)
+	}
+	agentRuns := fullFlowAgentRunResponsesForDispatch(t, events, dispatches[0].DispatchID)
+	if len(agentRuns) != 1 || agentRuns[0].Outcome != factoryapi.WorkOutcomeFailed {
+		t.Fatalf("failure agent-run responses = %#v, want one FAILED response", agentRuns)
+	}
+	if len(tasks) != 1 || tasks[0].State == nil || tasks[0].State.Type != factoryapi.WorkStateTypeFAILED {
+		t.Fatalf("failed tasks = %#v, want one typed failed Work", tasks)
+	}
+	workerSessions := support.ListSessionWorkerSessions(t, fixture.baseURL, scenario.sessionID, requiredFullFlowWorkID(t, tasks[0]))
+	failedSessions := 0
+	for _, session := range workerSessions.Sessions {
+		if session.State == factoryapi.WorkerSessionObservationStateFailed && session.Failure != nil {
+			failedSessions++
+		}
+	}
+	if failedSessions != 1 {
+		t.Fatalf("worker session observations = %#v, want one failed session with failure detail", workerSessions.Sessions)
+	}
+	if usage, ok := fullFlowResourceUsage(waitForFullFlowSessionStatus(t, scenario, fullFlowSharedFixtureTimeout, func(status factoryapi.StatusResponse) bool {
+		usage, found := fullFlowResourceUsage(status, "full-flow-task-slots")
+		return found && usage.Available == usage.Total
+	}), "full-flow-task-slots"); !ok || usage.Available != usage.Total {
+		t.Fatalf("failed task resource = %#v, want fully released resource", usage)
+	}
+}
+
+func testPackagedFullFlowDispatchTerminalFinalizationSuppressesDuplicateInvocation(
+	t *testing.T,
+	fixture *fullFlowSharedFixture,
+) {
+	runner := &fullFlowRunner{
+		singleTask:              true,
+		acceptedResultWithError: true,
+		pauseAcceptedResult:     true,
+		acceptedResultStarted:   make(chan struct{}),
+		acceptedResultRelease:   make(chan struct{}),
+	}
+	scenario := fixture.newScenario(t, runner)
+	runner.repository = scenario.repository
+	scenario.open(t)
+	defer func() {
+		select {
+		case <-runner.acceptedResultRelease:
+		default:
+			close(runner.acceptedResultRelease)
+		}
+	}()
+
+	args := map[string]any{
+		"request":    "Deliver one task while the same invocation is delivered twice",
+		"baseBranch": "main", "maxCycles": "3", "maxTasksPerCycle": "1",
+	}
+	requestID := fmt.Sprintf("full-flow-duplicate-%d", fixture.nextRequestID())
+	start := make(chan struct{})
+	results := make(chan fullFlowInvocationResult, 2)
+	for range 2 {
+		go func() {
+			<-start
+			response, err := postFullFlowInvocation(scenario, args, requestID)
+			results <- fullFlowInvocationResult{response: response, err: err}
+		}()
+	}
+	close(start)
+	select {
+	case <-runner.acceptedResultStarted:
+	case <-time.After(fullFlowSharedFixtureTimeout):
+		t.Fatal("timed out waiting for duplicate invocation to reach the provider")
+	}
+	close(runner.acceptedResultRelease)
+	for range 2 {
+		result := receiveFullFlowInvocationResult(t, results)
+		if result.response.Status != factoryapi.InvocationTerminalStatusCompleted || result.response.RequestId != requestID {
+			t.Fatalf("duplicate invocation result = %#v, want the same completed request", result.response)
+		}
+	}
+
+	works := support.GetJSON[factoryapi.ListWorkResponse](t, support.SessionWorkURL(
+		fixture.baseURL, scenario.sessionID, "/work?terminal=true&includeSuperseded=true",
+	))
+	assertFullFlowWorkStates(t, works.Results, "project", "complete", 1)
+	assertFullFlowWorkStates(t, works.Results, "delivery-task", "merged", 1)
+	for _, work := range works.Results {
+		if work.WorkTypeName == nil || *work.WorkTypeName != "delivery-task" {
+			continue
+		}
+		if work.SupersededBy != nil {
+			t.Fatalf("duplicate delivery created successor for %q: %q", work.Name, *work.SupersededBy)
+		}
+	}
+	events := support.GetFactoryEventsForSessionAt(t, fixture.baseURL, scenario.sessionID)
+	dispatches := fullFlowDispatchesForTransition(t, events, "implement-task")
+	if len(dispatches) != 1 || dispatches[0].Response == nil || dispatches[0].Response.Outcome != factoryapi.WorkOutcomeAccepted {
+		t.Fatalf("duplicate implement dispatches = %#v, want one canonical accepted dispatch", dispatches)
+	}
+	if got := len(fullFlowAgentRunResponsesForDispatch(t, events, dispatches[0].DispatchID)); got != 1 {
+		t.Fatalf("duplicate agent-run responses = %d, want one canonical response", got)
+	}
+}
+
+type fullFlowInvocationResult struct {
+	response factoryapi.InvocationResponse
+	err      error
+}
+
+func startFullFlowInvocation(
+	t *testing.T,
+	scenario *fullFlowScenario,
+	args map[string]any,
+) <-chan fullFlowInvocationResult {
+	t.Helper()
+	requestID := fmt.Sprintf("full-flow-shared-%d", scenario.fixture.nextRequestID())
+	result := make(chan fullFlowInvocationResult, 1)
+	go func() {
+		response, err := postFullFlowInvocation(scenario, args, requestID)
+		result <- fullFlowInvocationResult{response: response, err: err}
+	}()
+	return result
+}
+
+func receiveFullFlowInvocation(t *testing.T, result <-chan fullFlowInvocationResult) factoryapi.InvocationResponse {
+	t.Helper()
+	return receiveFullFlowInvocationResult(t, result).response
+}
+
+func receiveFullFlowInvocationResult(t *testing.T, result <-chan fullFlowInvocationResult) fullFlowInvocationResult {
+	t.Helper()
+	select {
+	case received := <-result:
+		if received.err != nil {
+			t.Fatalf("full-flow invocation: %v", received.err)
+		}
+		return received
+	case <-time.After(fullFlowSharedFixtureTimeout):
+		t.Fatal("timed out waiting for full-flow invocation")
+		return fullFlowInvocationResult{}
+	}
+}
+
+func postFullFlowInvocation(
+	scenario *fullFlowScenario,
+	args map[string]any,
+	requestID string,
+) (factoryapi.InvocationResponse, error) {
+	payload, err := json.Marshal(factoryapi.InvocationRequest{RequestId: &requestID, Args: &args})
+	if err != nil {
+		return factoryapi.InvocationResponse{}, fmt.Errorf("marshal shared full-flow invocation: %w", err)
+	}
+	endpoint := strings.TrimSuffix(scenario.fixture.baseURL, "/") +
+		"/factory-sessions/" + url.PathEscape(scenario.sessionID) + "/invocations"
+	response, err := http.Post(endpoint, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		return factoryapi.InvocationResponse{}, fmt.Errorf("POST shared full-flow invocation: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		return factoryapi.InvocationResponse{}, fmt.Errorf("POST shared full-flow invocation status = %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var decoded factoryapi.InvocationResponse
+	if err := json.NewDecoder(response.Body).Decode(&decoded); err != nil {
+		return factoryapi.InvocationResponse{}, fmt.Errorf("decode shared full-flow invocation: %w", err)
+	}
+	return decoded, nil
+}
+
+func waitForFullFlowSessionStatus(
+	t *testing.T,
+	scenario *fullFlowScenario,
+	timeout time.Duration,
+	accept func(factoryapi.StatusResponse) bool,
+) factoryapi.StatusResponse {
+	t.Helper()
+	endpoint := strings.TrimSuffix(scenario.fixture.baseURL, "/") +
+		"/factory-sessions/" + url.PathEscape(scenario.sessionID) + "/status"
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	var latest factoryapi.StatusResponse
+	for {
+		latest = support.GetJSON[factoryapi.StatusResponse](t, endpoint)
+		if accept(latest) {
+			return latest
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for Factory Session status at %s: %#v", endpoint, latest)
+		case <-ticker.C:
+		}
+	}
+}
+
+func fullFlowResourceUsage(status factoryapi.StatusResponse, name string) (factoryapi.ResourceUsage, bool) {
+	if status.Resources == nil {
+		return factoryapi.ResourceUsage{}, false
+	}
+	for _, usage := range *status.Resources {
+		if usage.Name == name {
+			return usage, true
+		}
+	}
+	return factoryapi.ResourceUsage{}, false
+}
+
+func assertFullFlowWorkStates(
+	t *testing.T,
+	works []factoryapi.Work,
+	workTypeName, stateName string,
+	want int,
+) []factoryapi.Work {
+	t.Helper()
+	matched := make([]factoryapi.Work, 0)
+	for _, work := range works {
+		if work.WorkTypeName == nil || *work.WorkTypeName != workTypeName {
+			continue
+		}
+		matched = append(matched, work)
+		if work.State == nil || work.State.Name != stateName {
+			t.Fatalf("%s work %q state = %#v, want %q", workTypeName, work.Name, work.State, stateName)
+		}
+	}
+	if len(matched) != want {
+		t.Fatalf("%s works = %#v, want %d in state %q", workTypeName, matched, want, stateName)
+	}
+	return matched
+}
+
+func requiredFullFlowWorkID(t *testing.T, work factoryapi.Work) string {
+	t.Helper()
+	if work.WorkId == nil || strings.TrimSpace(*work.WorkId) == "" {
+		t.Fatalf("work %q has no public work id", work.Name)
+	}
+	return *work.WorkId
+}
+
+func fullFlowDispatchesForTransition(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+	transition string,
+) []support.DispatchEventObservation {
+	t.Helper()
+	all := support.ObserveDispatchEvents(t, events)
+	filtered := make([]support.DispatchEventObservation, 0)
+	for _, dispatch := range all {
+		if dispatch.Request.TransitionId == transition {
+			filtered = append(filtered, dispatch)
+		}
+	}
+	return filtered
+}
+
+func fullFlowAgentRunResponsesForDispatch(
+	t *testing.T,
+	events []factoryapi.FactoryEvent,
+	dispatchID string,
+) []factoryapi.AgentRunResponseEventPayload {
+	t.Helper()
+	responses := make([]factoryapi.AgentRunResponseEventPayload, 0)
+	for _, event := range events {
+		if event.Type != factoryapi.FactoryEventTypeAgentRunResponse || event.Context.DispatchId == nil || *event.Context.DispatchId != dispatchID {
+			continue
+		}
+		payload, err := event.Payload.AsAgentRunResponseEventPayload()
+		if err != nil {
+			t.Fatalf("decode agent-run response for dispatch %q: %v", dispatchID, err)
+		}
+		responses = append(responses, payload)
+	}
+	return responses
+}

--- a/tests/functional/internal/support/command_runner.go
+++ b/tests/functional/internal/support/command_runner.go
@@ -66,7 +66,13 @@ func (r *ShapedProviderCommandRunner) Run(ctx context.Context, req platformproce
 	if err != nil {
 		return result, err
 	}
-	result.Stdout = shapedProviderCommandStdout(req.Command, result.Stdout)
+	// A nonzero process result is a provider failure, not a successful empty
+	// stream. Preserve its raw output so the runner can make the terminal
+	// failure decision from the process result instead of this test edge
+	// manufacturing a Codex/Claude success fixture.
+	if result.ExitCode == 0 {
+		result.Stdout = shapedProviderCommandStdout(req.Command, result.Stdout)
+	}
 	return result, nil
 }
 

--- a/tests/functional/providers/codex/shared_process_test.go
+++ b/tests/functional/providers/codex/shared_process_test.go
@@ -727,7 +727,12 @@ func (runner *codexSharedCommandRunner) Run(
 	runner.requests = append(runner.requests, cloneCodexCommandRequest(request))
 	runner.mu.Unlock()
 	result := route.result
-	result.Stdout = support.CodexSuccessStdout(string(result.Stdout))
+	// A nonzero process result is a provider refusal, not a successful empty
+	// stream. Keep its raw stdout so Workers can route the typed failure rather
+	// than letting this shared fixture manufacture a completion record beside it.
+	if result.ExitCode == 0 {
+		result.Stdout = support.CodexSuccessStdout(string(result.Stdout))
+	}
 	result.Stderr = append([]byte(nil), result.Stderr...)
 	return result, nil
 }

--- a/tests/functional/workers/inference/recording_gate_test.go
+++ b/tests/functional/workers/inference/recording_gate_test.go
@@ -276,8 +276,16 @@ func queueWSRFT004ProviderResult(
 	if len(stderr) > 0 {
 		resultStderr = stderr[0]
 	}
+	resultStdout := loaded.Stdout.Raw
+	if exitCode != 0 {
+		// This helper models a genuine failed execution. A successful Codex
+		// transcript beside a nonzero exit is the separate terminal-finalization
+		// contract exercised by the Full Flow fixture, so do not accidentally
+		// turn this recording-health failure case into an accepted candidate.
+		resultStdout = nil
+	}
 	runner.delegate.Queue(platformprocess.CommandResult{
-		Stdout:   append([]byte(nil), loaded.Stdout.Raw...),
+		Stdout:   append([]byte(nil), resultStdout...),
 		Stderr:   []byte(resultStderr),
 		ExitCode: exitCode,
 	})


### PR DESCRIPTION
{
  "project": "factory-reliability",
  "branchName": "factory-reliability-dispatch-terminal-finalization-001",
  "description": "Preserve a sanitized provider result beside a later terminal error, let the Workers agent runner choose one canonical semantic outcome, and prove exactly-once Work advancement or failure-to-lead routing through the root-composed Factory path.",
  "context": {
    "customerAsk": "Correct the provider-to-Workers terminal finalization boundary so a valid accepted or classified worker result cannot be overwritten by a later provider process, stream, teardown error, or competing completion callback; exactly one canonical terminal outcome advances Work while genuine no-result failures retain their typed failure route.",
    "sourcePlan": "C:/Users/andre/work/portos/infinite-you/docs/temp/projects/factory-reliability/source-plan.md",
    "problem": "The Codex adapter and Providers execution service erase a simultaneous candidate result on error, and the Workers agent runner checks the error before normalizing the result, so accepted output can be replaced by failure and competing terminal delivery cannot share one semantic authority.",
    "solution": "Have the Codex adapter and Providers execution normalizer preserve a validated sanitized result-and-error tuple, make the Workers agent runner the sole semantic selector, retain suppressed error kind/stage as bounded diagnostics, and rely on existing Worker Sessions/Runtime absorbing commits for exactly-once advancement. Prove the behavior at provider, runner, race, and root-composed Factory boundaries without public schema or remote-provider changes."
  },
  "acceptanceCriteria": [
    {
      "id": "ASK-01",
      "requirement": "The plan records exact Current and Proposed native result/error/finalization shapes, the single authority that chooses a terminal result, every consumer, compatibility, migration and rollback; no public schema is changed without a separately justified contract block.",
      "localOwnership": "Owned by stories 001 and 002 and checked by REVIEW-PR."
    },
    {
      "id": "ASK-02",
      "requirement": "When a provider returns a usable accepted result and a later process, stream or teardown error for the same attempt, the usable result is normalized once, one completed terminal fragment is published, and Work advances once; the later error remains diagnostic evidence and cannot replace the accepted outcome.",
      "localOwnership": "Stories 001-003 own the complete local and root-composed proof."
    },
    {
      "id": "ASK-03",
      "requirement": "When no usable result exists, genuine provider refusal, cancellation, timeout, malformed decision envelope and process failure preserve their typed failure classification and reach exactly one existing failure route; no PASS or completion is fabricated.",
      "localOwnership": "Story 002 owns the complete focused taxonomy; story 003 owns the representative root failure route."
    },
    {
      "id": "ASK-04",
      "requirement": "Both callback orders and concurrent duplicate delivery are deterministic and idempotent: one canonical result, one resource release, no late output mutation, and no second successor.",
      "localOwnership": "Stories 002 and 003 own focused race and composed public evidence."
    },
    {
      "id": "ASK-05",
      "requirement": "Focused normal and race tests plus a root-composed failure-to-lead witness pass. Applicable CI and independent review pass and merge the final head.",
      "localOwnership": "Stories 001-003 own local evidence; REVIEW-PR owns terminal CI, conflicts, independent review, and merge."
    },
    {
      "id": "FR-A1",
      "requirement": "Restart the preserved real recording and an adversarial fixture; every historical Work ID remains unique and admitted/consumed/failure history is preserved. Compare exact board and associations before/after; zero unexplained resurrection or disappearance.",
      "localOwnership": "Not owned by this slice.",
      "laterGate": "FR1-REPLAY-IDENTITY-VALIDATION"
    },
    {
      "id": "FR-A2",
      "requirement": "Same-name old failed work cannot fail a new exact-ID successor. Concurrent submission/allocation and duplicate request tests prove idempotency without accidental completion.",
      "localOwnership": "This slice proves only dispatch-result duplicate idempotency.",
      "laterGate": "FR1-REPLAY-IDENTITY-VALIDATION"
    },
    {
      "id": "FR-A3",
      "requirement": "Inject terminal CI/review failure; exactly one corrective implementation or lead owns the next action. No unchanged review loop, repeated per-agent retry allowance, or idle planning churn. Demonstrate failure -> repair -> independent review -> merge -> consumption.",
      "localOwnership": "Story 003 proves one provider failure-to-lead successor and this packet preserves the implementation/review responsibility split.",
      "laterGate": "REVIEW-PR and FR-VAL-INTEGRATED"
    },
    {
      "id": "FR-A4",
      "requirement": "Completed implementation reaches review with independent gates still pending; no downstream PASS is fabricated. Loaded versus authored instruction identity and activation state are correctly exposed and tested.",
      "localOwnership": "This packet owns no-fabricated-PASS delivery handoff only.",
      "laterGate": "FR3-INSTRUCTION-ACTIVATION and FR-VAL-INTEGRATED"
    },
    {
      "id": "FR-A5",
      "requirement": "Worker list/counts reconcile with preserved ledger associations across restart, with explicit unavailable/gap states. Local representative list and stream first response meet2s target; stream replay/reconnect/backpressure and UI attempts are independently verified.",
      "localOwnership": "Not owned by this slice.",
      "laterGate": "FR5-WORKER-SESSION-BOUNDED-LIST and integrated validation"
    },
    {
      "id": "FR-A6",
      "requirement": "Cancel and interrupt target exactly one attempt, stop its child, ignore late results, release resources exactly once and admit at most one authorized successor. Repeat requests are idempotent; API/CLI semantics match and errors are actionable.",
      "localOwnership": "Stories 001-003 own accepted-result/error precedence, late/duplicate suppression, one release, and at-most-one successor.",
      "laterGate": "FR5-CONTROL-INTEGRATED owns cancel/interrupt targeting, child stop, replacement, and API/CLI parity"
    },
    {
      "id": "FR-A7",
      "requirement": "A host/service restart restores one useful factory instance without duplicate execution, using the correct recorded definition. Missed report intervals and failed starts are observable; unattended retry is bounded.",
      "localOwnership": "Not owned by this slice.",
      "laterGate": "FR6-RESTART"
    },
    {
      "id": "FR-A8",
      "requirement": "Cleanup dry-run explains every candidate and owner. Live, dirty, unmerged and useful failed evidence survives; merged/abandoned disposable worktrees and expired artifacts can be reclaimed under explicit policy. Disk-pressure simulation does not corrupt history.",
      "localOwnership": "Not owned by this slice.",
      "laterGate": "FR7-RETENTION"
    },
    {
      "id": "FR-A9",
      "requirement": "Independent engineering validates corrected compiled bytes, replay/control invariants, resource trends and a24h injected-failure soak; no unbounded growth or silent stuck-ready work. Root causes must be exact test/event evidence, not generic CI package prefixes.",
      "localOwnership": "Story 003 supplies exact local event evidence only.",
      "laterGate": "FR-A9-SOAK"
    },
    {
      "id": "FR-A10",
      "requirement": "Independent source-blind Luna/max clean-install probes complete the operator mission using only public docs and interfaces. They can distinguish active implementation, CI wait, review, completed delivery and failed attempts; inspect logs, recover work, cancel/reconnect and preview cleanup. Both UX and engineering gates must pass.",
      "localOwnership": "Not owned by this slice.",
      "laterGate": "FR-A10-BLIND"
    },
    {
      "id": "Q-FOCUSED",
      "requirement": "The named Provider, Workers, and Runtime normal suites and focused Workers race suite pass and record the property each proves; generic green output alone is insufficient.",
      "localOwnership": "Stories 001-003."
    },
    {
      "id": "Q-FAST",
      "requirement": "make verify-fast passes on the final head and proves its repository compile/typecheck, short UI/unit, and short Go properties.",
      "localOwnership": "Story 003."
    },
    {
      "id": "REVIEW-PR",
      "requirement": "Independent review records PASS/FAIL/BLOCKED for this slice's criteria, drives current-head required CI terminal-and-passing, resolves conflicts, and merges the PR. CI evidence is posted to the PR, never committed.",
      "localOwnership": "Independent reviewer after implementation handoff."
    },
    {
      "id": "FR-VAL-INTEGRATED",
      "requirement": "A fresh source-blind Luna/max validator stages the exact merged immutable artifact by SHA-256 into a clean isolated directory, uses only the declared public journey and fixtures, reruns the terminal-finalization cases at the highest authorized local fidelity, and reports through factory/docs/standards/validation-loopback-template.md without inspecting this plan or silently repairing defects.",
      "localOwnership": "Later clean-room validation loopback; FAIL/BLOCKED preserves evidence and requests a delta plan."
    },
    {
      "id": "DELIVERY",
      "requirement": "Implementation-stage delivery criterion: The implementation stage marks this criterion satisfied and stops after its final head is pushed, the PR is open, CI has started, and all blocking review feedback is addressed. It does not poll or re-check CI after this finish line. The review stage owns driving CI to terminal-and-passing, resolving merge conflicts, and merging the PR; merge remains the lane-wide delivery boundary. CI-run evidence goes in a PR comment and never in a commit.",
      "localOwnership": "Implementation owns the handoff finish line; REVIEW-PR owns terminal CI and merge."
    }
  ],
  "behaviorLanes": [
    {
      "id": "BEH-001",
      "behavior": "One authoritative terminal outcome survives provider result/error and callback races and advances Work at most once.",
      "executableSpine": "Codex adapter -> Providers Execution normalization -> Workers agent selection/publication -> Worker Sessions absorbing commit -> Factory Runtime retirement -> Work route",
      "owner": "One Luna/max implementation worker executes all three dependent stories in one isolated worktree; one independent Luna/max reviewer owns terminal CI, review, conflicts, and merge.",
      "parallelAssessment": "Ready concurrently with the Worker Session bounded-list slice because that sibling exclusively owns fleet paging while this packet owns Providers/Workers finalization. The operator's one-light-LocalAI-task-alongside-TTS experiment remains independently admitted and owns model/cache/backend code and heavy artifacts; this non-LocalAI packet starts zero such processes and cannot establish modality independence, which stays with the LocalAI lead and its named integrated-build gate. Story 003 coordinates exact Full Flow test-package ownership before editing."
    }
  ],
  "contractChanges": [
    {
      "name": "Codex native result and lifecycle-error tuple",
      "authoredSource": "pkg/services/providers/internal/services/execution/internal/adapters/codex/adapter.go:newContinuationAttempt",
      "format": "go",
      "classification": "compatible internal semantic correction",
      "current": "effectResult, effectErr := effect.Execute(ctx, request, decoder.observe)\nflushErr := decoder.flush()\nif failure, failed := collectFailure(decoder, effectErr, flushErr); failed {\n\tif failure.SessionRef == nil {\n\t\tfailure.SessionRef = decoder.sessionRef()\n\t}\n\tif failure.Diagnostics == nil {\n\t\tfailure.Diagnostics = decoder.diagnostics()\n\t}\n\treturn providers.ExecuteResult{}, failure\n}\ncontent, session, finalErr := decoder.final()\nif finalErr != nil {\n\tfailure := execution.AttemptFailure{\n\t\tSessionRef:      decoder.sessionRef(),\n\t\tFinalParseError: finalErr,\n\t}\n\t// A skipped oversized record only fails the execution when the\n\t// stream ends without a recoverable final agent decision. Keep the\n\t// pre-existing record-limit classification for that terminal case.\n\tif skipped := decoder.skippedRecordFailure(); skipped != nil {\n\t\tfailure.Declared = skipped\n\t\tfailure.Diagnostics = decoder.diagnostics()\n\t}\n\treturn providers.ExecuteResult{}, failure\n}\nmetadata := cloneMetadata(effectResult.Metadata)\nif metadata == nil {\n\tmetadata = make(map[string]string, 4)\n}\nfor key, value := range decoder.diagnostics().Metadata {\n\tmetadata[key] = value\n}\nmetadata[\"completion_evidence\"] = \"agent_message\"\nreturn providers.ExecuteResult{\n\tContent:    content,\n\tSessionRef: session,\n\tDiagnostics: &providers.ExecuteDiagnostics{\n\t\tDurationMillis: effectResult.DurationMillis,\n\t\tProgress:       decoder.progressFacts(),\n\t\tMetadata:       metadata,\n\t},\n}, nil",
      "proposed": "effectResult, effectErr := effect.Execute(ctx, request, decoder.observe)\nflushErr := decoder.flush()\ncontent, session, finalErr := decoder.final()\nfailure, failed := collectFailure(decoder, effectErr, flushErr)\nif finalErr != nil {\n\tfailure.FinalParseError = finalErr\n\t// A skipped oversized record only fails the execution when the\n\t// stream ends without a recoverable final agent decision. Keep the\n\t// pre-existing record-limit classification for that terminal case.\n\tif skipped := decoder.skippedRecordFailure(); skipped != nil {\n\t\tfailure.Declared = skipped\n\t\tfailure.Diagnostics = decoder.diagnostics()\n\t}\n\tfailed = true\n}\nif failure.SessionRef == nil {\n\tfailure.SessionRef = decoder.sessionRef()\n}\nif failure.Diagnostics == nil {\n\tfailure.Diagnostics = decoder.diagnostics()\n}\nresult := providers.ExecuteResult{\n\tContent:    content,\n\tSessionRef: session,\n\tDiagnostics: &providers.ExecuteDiagnostics{\n\t\tDurationMillis: effectResult.DurationMillis,\n\t\tProgress:       decoder.progressFacts(),\n\t\tMetadata:       completedMetadata(effectResult.Metadata, decoder.diagnostics().Metadata),\n\t},\n}\nif failed {\n\treturn result, failure\n}\nreturn result, nil\n\nfunc completedMetadata(native, decoded map[string]string) map[string]string {\n\tmetadata := cloneMetadata(native)\n\tif metadata == nil {\n\t\tmetadata = make(map[string]string, 4)\n\t}\n\tfor key, value := range decoded {\n\t\tmetadata[key] = value\n\t}\n\tmetadata[\"completion_evidence\"] = \"agent_message\"\n\treturn metadata\n}",
      "compatibility": "Tuple types do not change. Valid final output may accompany a typed lifecycle error; malformed/partial output remains failure. Existing duration/progress/metadata are retained and sanitized. No migration; rollback atomically with the Providers/Workers changes.",
      "generatedOutputs": [],
      "consumers": ["Providers Execution service ordinary path", "Providers Execution continuation path", "Codex adapter tests"]
    },
    {
      "name": "Providers normalized result/error tuple",
      "authoredSource": "pkg/services/providers/internal/services/execution/internal/service/service.go:Execute",
      "format": "go",
      "classification": "compatible Go behavioral clarification; no field change",
      "current": "result, err = binding.attempt(ctx, detached)\nif err != nil {\n\treturn providers.ExecuteResult{}, normalizeAttemptFailure(ctx, err, detached)\n}\nreturn normalizeSuccess(result, resolved.Provider.ID, detached)",
      "proposed": "result, err = binding.attempt(ctx, detached)\nnormalizedResult, resultErr := normalizeSuccess(result, resolved.Provider.ID, detached)\nif resultErr != nil {\n\treturn providers.ExecuteResult{}, normalizeAttemptFailure(ctx, resultErr, detached)\n}\nif err != nil {\n\treturn normalizedResult, normalizeAttemptFailure(ctx, err, detached)\n}\nreturn normalizedResult, nil",
      "compatibility": "The existing (providers.ExecuteResult, error) shape remains. Error-first consumers retain current behavior; Workers explicitly opts into candidate inspection. Continue uses the same ordering with extraSecrets sanitization, and context errors no longer zero an already normalized candidate. No migration; rollback with the full atomic correction.",
      "generatedOutputs": [],
      "consumers": ["Providers root Execute/Continue dispatch", "Workers agent runner", "Workers inference callers", "provider HTTP adapter", "provider MCP adapter", "focused contract tests"]
    },
    {
      "name": "Providers continuation normalized result/error tuple",
      "authoredSource": "pkg/services/providers/internal/services/execution/internal/service/service.go:Continue",
      "format": "go",
      "classification": "compatible private continuation behavioral correction; no field change",
      "current": "result, err = binding.continueAttempt(ctx, detached)\nif err != nil {\n\treturn providers.ExecuteResult{}, normalizeAttemptFailure(ctx, err, detached.ExecuteRequest, secret...)\n}\nreturn normalizeSuccess(result, resolved.Provider.ID, detached.ExecuteRequest, secret...)",
      "proposed": "result, err = binding.continueAttempt(ctx, detached)\nnormalizedResult, resultErr := normalizeSuccess(result, resolved.Provider.ID, detached.ExecuteRequest, secret...)\nif resultErr != nil {\n\treturn providers.ExecuteResult{}, normalizeAttemptFailure(ctx, resultErr, detached.ExecuteRequest, secret...)\n}\nif err != nil {\n\treturn normalizedResult, normalizeAttemptFailure(ctx, err, detached.ExecuteRequest, secret...)\n}\nreturn normalizedResult, nil",
      "compatibility": "The exact-session continuation request and public result/error types remain, returned session validation and extraSecrets redaction are preserved, and no fallback to fresh Execute is added. No migration/generated outputs; rollback with the ordinary tuple and Workers selector.",
      "generatedOutputs": [],
      "consumers": ["Providers root Continue", "Providers root ContinueReference", "Workers continuation and retry", "focused continuation tests"]
    },
    {
      "name": "Providers ordinary context terminal finalizer",
      "authoredSource": "pkg/services/providers/internal/services/execution/internal/service/service.go:Execute defer",
      "format": "go",
      "classification": "compatible private terminal-finalization correction; no field change",
      "current": "defer func() {\n\tif contextErr := normalizeContextFailureWithExisting(ctx, detached, executeErr); contextErr != nil {\n\t\tresult = providers.ExecuteResult{}\n\t\texecuteErr = contextErr\n\t}\n}()",
      "proposed": "defer func() {\n\tif contextErr := normalizeContextFailureWithExisting(ctx, detached, executeErr); contextErr != nil {\n\t\texecuteErr = contextErr\n\t}\n}()",
      "compatibility": "Context failure retains its existing typed precedence while no longer erasing an already normalized candidate. Pre-attempt cancellation still returns an empty result. No migration/generated outputs; rollback with both tuple paths and Workers selection.",
      "generatedOutputs": [],
      "consumers": ["Providers root Execute", "Workers agent and inference callers", "focused context-race tests"]
    },
    {
      "name": "Providers continuation context terminal finalizer",
      "authoredSource": "pkg/services/providers/internal/services/execution/internal/service/service.go:Continue defer",
      "format": "go",
      "classification": "compatible private continuation-finalization correction; no field change",
      "current": "defer func() {\n\tif contextErr := normalizeContextFailureWithExisting(ctx, detached.ExecuteRequest, executeErr, secret...); contextErr != nil {\n\t\tresult = providers.ExecuteResult{}\n\t\texecuteErr = contextErr\n\t}\n}()",
      "proposed": "defer func() {\n\tif contextErr := normalizeContextFailureWithExisting(ctx, detached.ExecuteRequest, executeErr, secret...); contextErr != nil {\n\t\texecuteErr = contextErr\n\t}\n}()",
      "compatibility": "Continuation context failure retains typed precedence and extraSecrets redaction while no longer erasing an already normalized candidate. Pre-attempt cancellation stays failure-only. No migration/generated outputs; rollback atomically.",
      "generatedOutputs": [],
      "consumers": ["Providers root Continue", "Providers root ContinueReference", "Workers continuation callers", "focused context-race tests"]
    },
    {
      "name": "Workers terminal-selection result",
      "authoredSource": "pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner.go:service.execute",
      "format": "go",
      "classification": "compatible internal semantic correction",
      "current": "resumeReference := continuationSessionRef(request)\nresult, err := s.executeProviderAttempt(ctx, request, identity)\nif err != nil {\n\tif response, normalizedErr, handled := continuationFailureResult(ctx, request, err); handled {\n\t\ts.publishTerminalFailure(\n\t\t\tidentity,\n\t\t\tnormalizedErr,\n\t\t\tresponse.Continuation,\n\t\t\tresumeReference,\n\t\t\t\"\",\n\t\t\tprovider,\n\t\t)\n\t\treturn response, normalizedErr\n\t}\n\tif failure, ok := providerFailure(err); ok {\n\t\tresponse := runnerFailureResult(failure, request)\n\t\tnormalizedErr := normalizeProviderFailure(ctx, failure, err, response)\n\t\ts.publishFailureProgress(\n\t\t\tidentity,\n\t\t\tfailure,\n\t\t\tresponse.Continuation,\n\t\t\tprovider,\n\t\t)\n\t\ts.publishTerminalFailure(\n\t\t\tidentity,\n\t\t\tnormalizedErr,\n\t\t\tresponse.Continuation,\n\t\t\tfailure.SessionRef,\n\t\t\tfailure.Message,\n\t\t\tprovider,\n\t\t)\n\t\treturn response, normalizedErr\n\t}\n\tnormalizedErr := normalizeExecutionError(ctx, err)\n\ts.publishTerminalFailure(identity, normalizedErr, nil, nil, \"\", provider)\n\treturn workers.RunnerExecutionResult{}, normalizedErr\n}\nresult = result.Clone()\nresponse := runnerResult(result, providerIDForRequest(request))\nif request.Continuation != nil {\n\tresponse.Continuation = cloneContinuation(request.Continuation)\n}\nif response.Continuation == nil && resumeReference != nil {\n\tcontinuation := resumeReference.ContinuationRef()\n\tresponse.Continuation = &continuation\n}\nif response.Continuation == nil && strings.TrimSpace(request.SessionID) != \"\" {\n\tcontinuation := (providers.SessionRef{\n\t\tProvider: providerIDForRequest(request),\n\t\tKind:     providers.SessionIDKind,\n\t\tID:       request.SessionID,\n\t}).ContinuationRef()\n\tresponse.Continuation = &continuation\n}\nresponse, err = s.normalizeAgentResponse(response, request)\nif err != nil {\n\treturn response, err\n}\ns.publishProgress(identity, result, response.Continuation, provider)\nif !hasTerminalRunProgress(result.Diagnostics) {\n\ts.publish(workers.ProgressFragment{\n\t\tCorrelation:       identity.correlation,\n\t\tDispatchID:        identity.dispatchID,\n\t\tKind:              workers.CompletedFragmentKind,\n\t\tType:              \"COMPLETED\",\n\t\tProvider:          provider,\n\t\tContinuation:      continuationFromSessionRef(result.SessionRef),\n\t\tExternalEventType: \"STREAM_COMPLETED\",\n\t})\n}\nreturn response, nil",
      "proposed": "resumeReference := continuationSessionRef(request)\nresult, attemptErr := s.executeProviderAttempt(ctx, request, identity)\nresult = result.Clone()\nresponse := runnerResult(result, providerIDForRequest(request))\nresponse = preserveContinuation(response, request, resumeReference)\nresponse, resultErr := s.normalizeAgentResponse(response, request)\nif resultErr == nil && (attemptErr == nil || usableAgentResult(response, request)) {\n\tresponse.Diagnostics = mergeSuppressedAttemptDiagnostics(response.Diagnostics, attemptErr)\n\ts.publishProgress(identity, result, response.Continuation, provider)\n\ts.publishCompletedOnce(identity, result, response.Continuation, provider)\n\treturn response, nil\n}\nif resultErr != nil {\n\tattemptErr = resultErr\n}\nreturn s.publishAttemptFailure(identity, request, response, attemptErr, resumeReference, provider)",
      "compatibility": "Existing Workers result/error structs and decision-envelope policy remain. A usable normalized result wins over only its same-attempt later error; failure-only behavior is unchanged. No migration/generated outputs; rollback atomically with Providers tuple preservation.",
      "generatedOutputs": [],
      "consumers": ["runner registry", "Workers normalization and retry", "workstation invocation", "Worker Sessions publisher", "Factory Runtime dispatch", "focused runner tests"]
    },
    {
      "name": "Worker progress terminal-fragment sequence",
      "authoredSource": "pkg/services/workers/progress_observations.go and pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner.go",
      "format": "go",
      "classification": "compatible message cardinality/order correction; shape unchanged",
      "current": "[]workers.ProgressFragment{\n\t{Kind: \"PROGRESS_FRAGMENT\", Type: \"message.completed\", Payload: \"accepted output\"},\n\t{Kind: \"STREAM_FAILED\", Type: \"FAILED\", ExternalEventType: \"STREAM_FAILED\"},\n}",
      "proposed": "[]workers.ProgressFragment{\n\t{Kind: \"PROGRESS_FRAGMENT\", Type: \"message.completed\", Payload: \"accepted output\"},\n\t{\n\t\tKind: \"STREAM_COMPLETED\", Type: \"COMPLETED\",\n\t\tExternalEventType: \"STREAM_COMPLETED\",\n\t\tMetadata: map[string]string{\n\t\t\t\"suppressed_terminal_error_kind\": \"dependency\",\n\t\t\t\"failure_stage\": \"flush\",\n\t\t},\n\t},\n}",
      "compatibility": "ProgressFragment fields and terminal kind vocabulary remain. Exactly one terminal fragment is observable; failure-only attempts retain STREAM_FAILED. Historical records need no rewrite. Rollback with tuple/selector changes.",
      "generatedOutputs": [],
      "consumers": ["Worker Sessions publication", "Events and Chat response bridges", "Factory Session response streams", "Workers tests", "Factory Runtime dispatch completion"]
    }
  ],
  "userStories": [
    {
      "id": "factory-reliability-dispatch-terminal-finalization-001-001",
      "title": "Preserve a normalized provider result beside its later error",
      "description": "Reorder Codex final extraction and Providers execution normalization so a validated sanitized candidate and typed lifecycle error both reach Workers.",
      "parentBehavior": "BEH-001",
      "outcome": "Ordinary and continuation attempts preserve the unchanged result/error tuple without changing failure taxonomy or public schema.",
      "sourcePlanRef": "7. Failure modes and quality attributes; 9. Implementation strategy; 12. Tasks — FR5",
      "dependencies": ["origin/main contains 8f1e2e5415dca7ffef5cca5ae1d4a7a0475475dd"],
      "sharedSurfaceOwner": "Sole owner of the smallest Codex adapter, Providers Execution normalizer, and focused tests; Worker Sessions fleet paging and LocalAI work remain disjoint and concurrent.",
      "scope": {
        "in": ["Codex final parsing order", "Providers ordinary and continuation tuple normalization", "context-result preservation", "sanitized diagnostic facts", "focused package tests"],
        "out": ["public structs or schemas", "unnecessary other provider adapters", "Workers selection", "Runtime or Worker Sessions mutation", "remote provider calls"]
      },
      "contractChanges": [
        {
          "name": "Codex native result and lifecycle-error tuple",
          "authoredSource": "pkg/services/providers/internal/services/execution/internal/adapters/codex/adapter.go:newContinuationAttempt",
          "current": "effectResult, effectErr := effect.Execute(ctx, request, decoder.observe)\nflushErr := decoder.flush()\nif failure, failed := collectFailure(decoder, effectErr, flushErr); failed {\n\tif failure.SessionRef == nil {\n\t\tfailure.SessionRef = decoder.sessionRef()\n\t}\n\tif failure.Diagnostics == nil {\n\t\tfailure.Diagnostics = decoder.diagnostics()\n\t}\n\treturn providers.ExecuteResult{}, failure\n}\ncontent, session, finalErr := decoder.final()\nif finalErr != nil {\n\tfailure := execution.AttemptFailure{\n\t\tSessionRef:      decoder.sessionRef(),\n\t\tFinalParseError: finalErr,\n\t}\n\t// A skipped oversized record only fails the execution when the\n\t// stream ends without a recoverable final agent decision. Keep the\n\t// pre-existing record-limit classification for that terminal case.\n\tif skipped := decoder.skippedRecordFailure(); skipped != nil {\n\t\tfailure.Declared = skipped\n\t\tfailure.Diagnostics = decoder.diagnostics()\n\t}\n\treturn providers.ExecuteResult{}, failure\n}\nmetadata := cloneMetadata(effectResult.Metadata)\nif metadata == nil {\n\tmetadata = make(map[string]string, 4)\n}\nfor key, value := range decoder.diagnostics().Metadata {\n\tmetadata[key] = value\n}\nmetadata[\"completion_evidence\"] = \"agent_message\"\nreturn providers.ExecuteResult{\n\tContent:    content,\n\tSessionRef: session,\n\tDiagnostics: &providers.ExecuteDiagnostics{\n\t\tDurationMillis: effectResult.DurationMillis,\n\t\tProgress:       decoder.progressFacts(),\n\t\tMetadata:       metadata,\n\t},\n}, nil",
          "proposed": "effectResult, effectErr := effect.Execute(ctx, request, decoder.observe)\nflushErr := decoder.flush()\ncontent, session, finalErr := decoder.final()\nfailure, failed := collectFailure(decoder, effectErr, flushErr)\nif finalErr != nil {\n\tfailure.FinalParseError = finalErr\n\t// A skipped oversized record only fails the execution when the\n\t// stream ends without a recoverable final agent decision. Keep the\n\t// pre-existing record-limit classification for that terminal case.\n\tif skipped := decoder.skippedRecordFailure(); skipped != nil {\n\t\tfailure.Declared = skipped\n\t\tfailure.Diagnostics = decoder.diagnostics()\n\t}\n\tfailed = true\n}\nif failure.SessionRef == nil {\n\tfailure.SessionRef = decoder.sessionRef()\n}\nif failure.Diagnostics == nil {\n\tfailure.Diagnostics = decoder.diagnostics()\n}\nresult := providers.ExecuteResult{\n\tContent:    content,\n\tSessionRef: session,\n\tDiagnostics: &providers.ExecuteDiagnostics{\n\t\tDurationMillis: effectResult.DurationMillis,\n\t\tProgress:       decoder.progressFacts(),\n\t\tMetadata:       completedMetadata(effectResult.Metadata, decoder.diagnostics().Metadata),\n\t},\n}\nif failed {\n\treturn result, failure\n}\nreturn result, nil\n\nfunc completedMetadata(native, decoded map[string]string) map[string]string {\n\tmetadata := cloneMetadata(native)\n\tif metadata == nil {\n\t\tmetadata = make(map[string]string, 4)\n\t}\n\tfor key, value := range decoded {\n\t\tmetadata[key] = value\n\t}\n\tmetadata[\"completion_evidence\"] = \"agent_message\"\n\treturn metadata\n}"
        },
        {
          "name": "Providers normalized result/error tuple",
          "authoredSource": "pkg/services/providers/internal/services/execution/internal/service/service.go:Execute",
          "current": "result, err = binding.attempt(ctx, detached)\nif err != nil {\n\treturn providers.ExecuteResult{}, normalizeAttemptFailure(ctx, err, detached)\n}\nreturn normalizeSuccess(result, resolved.Provider.ID, detached)",
          "proposed": "result, err = binding.attempt(ctx, detached)\nnormalizedResult, resultErr := normalizeSuccess(result, resolved.Provider.ID, detached)\nif resultErr != nil {\n\treturn providers.ExecuteResult{}, normalizeAttemptFailure(ctx, resultErr, detached)\n}\nif err != nil {\n\treturn normalizedResult, normalizeAttemptFailure(ctx, err, detached)\n}\nreturn normalizedResult, nil"
        },
        {
          "name": "Providers continuation normalized result/error tuple",
          "authoredSource": "pkg/services/providers/internal/services/execution/internal/service/service.go:Continue",
          "current": "result, err = binding.continueAttempt(ctx, detached)\nif err != nil {\n\treturn providers.ExecuteResult{}, normalizeAttemptFailure(ctx, err, detached.ExecuteRequest, secret...)\n}\nreturn normalizeSuccess(result, resolved.Provider.ID, detached.ExecuteRequest, secret...)",
          "proposed": "result, err = binding.continueAttempt(ctx, detached)\nnormalizedResult, resultErr := normalizeSuccess(result, resolved.Provider.ID, detached.ExecuteRequest, secret...)\nif resultErr != nil {\n\treturn providers.ExecuteResult{}, normalizeAttemptFailure(ctx, resultErr, detached.ExecuteRequest, secret...)\n}\nif err != nil {\n\treturn normalizedResult, normalizeAttemptFailure(ctx, err, detached.ExecuteRequest, secret...)\n}\nreturn normalizedResult, nil"
        },
        {
          "name": "Providers ordinary context terminal finalizer",
          "authoredSource": "pkg/services/providers/internal/services/execution/internal/service/service.go:Execute defer",
          "current": "defer func() {\n\tif contextErr := normalizeContextFailureWithExisting(ctx, detached, executeErr); contextErr != nil {\n\t\tresult = providers.ExecuteResult{}\n\t\texecuteErr = contextErr\n\t}\n}()",
          "proposed": "defer func() {\n\tif contextErr := normalizeContextFailureWithExisting(ctx, detached, executeErr); contextErr != nil {\n\t\texecuteErr = contextErr\n\t}\n}()"
        },
        {
          "name": "Providers continuation context terminal finalizer",
          "authoredSource": "pkg/services/providers/internal/services/execution/internal/service/service.go:Continue defer",
          "current": "defer func() {\n\tif contextErr := normalizeContextFailureWithExisting(ctx, detached.ExecuteRequest, executeErr, secret...); contextErr != nil {\n\t\tresult = providers.ExecuteResult{}\n\t\texecuteErr = contextErr\n\t}\n}()",
          "proposed": "defer func() {\n\tif contextErr := normalizeContextFailureWithExisting(ctx, detached.ExecuteRequest, executeErr, secret...); contextErr != nil {\n\t\texecuteErr = contextErr\n\t}\n}()"
        }
      ],
      "acceptanceCriteria": [
        "Given a parseable final candidate plus typed process or flush error, both the normalized detached result and sanitized typed error are returned.",
        "Given empty, malformed, foreign-session, cancellation, timeout, refusal, or process-failure output, the result remains unusable and the existing typed classification is preserved.",
        "Ordinary and continuation focused tests prove identical tuple and sanitization policy with no public or generated diff."
      ],
      "verification": {
        "behavioralWitness": "A returned providers.ExecuteResult contains the accepted content/session/diagnostics while errors.As yields the expected ExecuteFailure; failure-only cases return no candidate.",
        "executableSpineEffect": "establish",
        "requiredEvidence": [
          {
            "scope": "unit/component",
            "dependencyFidelity": "controlled production Codex adapter and Providers Execution types",
            "cadence": "per change",
            "cost": "free; bounded Go test with at most four compiler/test children",
            "procedure": "go test ./pkg/services/providers/internal/services/execution/internal/adapters/codex ./pkg/services/providers/internal/services/execution/internal/service -run 'Test.*(ResultAndError|Terminal|Failure|Continuation)' -count=1 -p=4",
            "propertyProved": "tuple preservation, validation, sanitization, ordinary/continue parity, and unchanged no-result failure typing",
            "propertyNotProved": "Workers precedence, progress cardinality, Work routing, compiled artifact, or remote provider"
          }
        ],
        "highestFeasibleLevel": "Unit/component at the owning private adapter/service boundary; story 002 increases fidelity.",
        "remainingUnprovenEdges": [
          {"edge": "Workers semantic selection", "gateId": "factory-reliability-dispatch-terminal-finalization-001-002"},
          {"edge": "composed Work routing", "gateId": "factory-reliability-dispatch-terminal-finalization-001-003"},
          {"edge": "terminal hosted CI and merge", "gateId": "REVIEW-PR"}
        ],
        "testLayerDesign": "Package-owned adapter/service tests use deterministic effects and production values; parallel table cells own decoder/metadata state. No Factory Session/root process, executable artifact, load lane, or static inventory test applies."
      },
      "paidValidation": {
        "trigger": "none",
        "maximumCalls": 0,
        "maximumCostUSD": 0,
        "maximumDuration": "0",
        "fixtureAndOutputValidator": "none",
        "evidenceReuseKey": "not-applicable"
      },
      "priority": "P0",
      "passes": true,
      "notes": "Implemented in commit 1bcd1999e0. Focused normal/race execution tests, full Providers subtree tests, and go vet pass. Workers selection and composed Work routing remain in stories 002 and 003."
    },
    {
      "id": "factory-reliability-dispatch-terminal-finalization-001-002",
      "title": "Select and publish one Workers terminal outcome",
      "description": "Normalize one candidate before error routing, choose semantic precedence once, and emit exactly one completed or failed terminal fragment with bounded diagnostics.",
      "parentBehavior": "BEH-001",
      "outcome": "A usable accepted/classified result cannot be overwritten, while every no-result failure keeps its typed route and callback races remain deterministic.",
      "sourcePlanRef": "7. Failure modes and quality attributes; 9. Implementation strategy; 12. Tasks — FR5",
      "dependencies": ["factory-reliability-dispatch-terminal-finalization-001-001"],
      "sharedSurfaceOwner": "Sole owner of runner.go and focused same-package tests; Worker Sessions and Runtime production files remain read-only; fleet paging remains concurrent.",
      "scope": {
        "in": ["agent usability predicate", "single terminal selector", "completed/failure publication helpers", "bounded suppressed-error diagnostics", "callback-order and duplicate tests"],
        "out": ["retry-count policy", "Worker Sessions implementation", "Runtime dispatch planning", "public schemas", "other runner families"]
      },
      "contractChanges": [
        {
          "name": "Workers terminal-selection result",
          "authoredSource": "pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner.go:service.execute",
          "current": "resumeReference := continuationSessionRef(request)\nresult, err := s.executeProviderAttempt(ctx, request, identity)\nif err != nil {\n\tif response, normalizedErr, handled := continuationFailureResult(ctx, request, err); handled {\n\t\ts.publishTerminalFailure(\n\t\t\tidentity,\n\t\t\tnormalizedErr,\n\t\t\tresponse.Continuation,\n\t\t\tresumeReference,\n\t\t\t\"\",\n\t\t\tprovider,\n\t\t)\n\t\treturn response, normalizedErr\n\t}\n\tif failure, ok := providerFailure(err); ok {\n\t\tresponse := runnerFailureResult(failure, request)\n\t\tnormalizedErr := normalizeProviderFailure(ctx, failure, err, response)\n\t\ts.publishFailureProgress(\n\t\t\tidentity,\n\t\t\tfailure,\n\t\t\tresponse.Continuation,\n\t\t\tprovider,\n\t\t)\n\t\ts.publishTerminalFailure(\n\t\t\tidentity,\n\t\t\tnormalizedErr,\n\t\t\tresponse.Continuation,\n\t\t\tfailure.SessionRef,\n\t\t\tfailure.Message,\n\t\t\tprovider,\n\t\t)\n\t\treturn response, normalizedErr\n\t}\n\tnormalizedErr := normalizeExecutionError(ctx, err)\n\ts.publishTerminalFailure(identity, normalizedErr, nil, nil, \"\", provider)\n\treturn workers.RunnerExecutionResult{}, normalizedErr\n}\nresult = result.Clone()\nresponse := runnerResult(result, providerIDForRequest(request))\nif request.Continuation != nil {\n\tresponse.Continuation = cloneContinuation(request.Continuation)\n}\nif response.Continuation == nil && resumeReference != nil {\n\tcontinuation := resumeReference.ContinuationRef()\n\tresponse.Continuation = &continuation\n}\nif response.Continuation == nil && strings.TrimSpace(request.SessionID) != \"\" {\n\tcontinuation := (providers.SessionRef{\n\t\tProvider: providerIDForRequest(request),\n\t\tKind:     providers.SessionIDKind,\n\t\tID:       request.SessionID,\n\t}).ContinuationRef()\n\tresponse.Continuation = &continuation\n}\nresponse, err = s.normalizeAgentResponse(response, request)\nif err != nil {\n\treturn response, err\n}\ns.publishProgress(identity, result, response.Continuation, provider)\nif !hasTerminalRunProgress(result.Diagnostics) {\n\ts.publish(workers.ProgressFragment{\n\t\tCorrelation:       identity.correlation,\n\t\tDispatchID:        identity.dispatchID,\n\t\tKind:              workers.CompletedFragmentKind,\n\t\tType:              \"COMPLETED\",\n\t\tProvider:          provider,\n\t\tContinuation:      continuationFromSessionRef(result.SessionRef),\n\t\tExternalEventType: \"STREAM_COMPLETED\",\n\t})\n}\nreturn response, nil",
          "proposed": "resumeReference := continuationSessionRef(request)\nresult, attemptErr := s.executeProviderAttempt(ctx, request, identity)\nresult = result.Clone()\nresponse := runnerResult(result, providerIDForRequest(request))\nresponse = preserveContinuation(response, request, resumeReference)\nresponse, resultErr := s.normalizeAgentResponse(response, request)\nif resultErr == nil && (attemptErr == nil || usableAgentResult(response, request)) {\n\tresponse.Diagnostics = mergeSuppressedAttemptDiagnostics(response.Diagnostics, attemptErr)\n\ts.publishProgress(identity, result, response.Continuation, provider)\n\ts.publishCompletedOnce(identity, result, response.Continuation, provider)\n\treturn response, nil\n}\nif resultErr != nil {\n\tattemptErr = resultErr\n}\nreturn s.publishAttemptFailure(identity, request, response, attemptErr, resumeReference, provider)"
        },
        {
          "name": "Worker progress terminal-fragment sequence",
          "authoredSource": "pkg/services/workers/progress_observations.go and pkg/services/workers/internal/services/runners/internal/services/agent/internal/service/runner.go",
          "current": "[]workers.ProgressFragment{\n\t{Kind: \"PROGRESS_FRAGMENT\", Type: \"message.completed\", Payload: \"accepted output\"},\n\t{Kind: \"STREAM_FAILED\", Type: \"FAILED\", ExternalEventType: \"STREAM_FAILED\"},\n}",
          "proposed": "[]workers.ProgressFragment{\n\t{Kind: \"PROGRESS_FRAGMENT\", Type: \"message.completed\", Payload: \"accepted output\"},\n\t{\n\t\tKind: \"STREAM_COMPLETED\", Type: \"COMPLETED\",\n\t\tExternalEventType: \"STREAM_COMPLETED\",\n\t\tMetadata: map[string]string{\n\t\t\t\"suppressed_terminal_error_kind\": \"dependency\",\n\t\t\t\"failure_stage\": \"flush\",\n\t\t},\n\t},\n}"
        }
      ],
      "acceptanceCriteria": [
        "Given a valid accepted/classified result plus later error, the runner normalizes once, returns the result without execution error, records bounded kind/stage, and publishes exactly one completion terminal.",
        "Given no usable result, refusal, cancellation, timeout, malformed envelope, or process failure, the existing typed error and exactly one failure terminal are returned/published and no completion is fabricated.",
        "Given both callback orders and concurrent/repeated delivery, the first canonical result and fragment sequence remain deterministic with no race or late mutation."
      ],
      "verification": {
        "behavioralWitness": "Exact RunnerExecutionResult and ProviderError identities, ordered ProgressFragment slice, normalization-call count, and scenario-owned publisher count.",
        "executableSpineEffect": "extend",
        "requiredEvidence": [
          {
            "scope": "unit/component",
            "dependencyFidelity": "controlled real providers.Service contract and actual Workers publisher/types",
            "cadence": "per change",
            "cost": "free",
            "procedure": "go test ./pkg/services/workers/internal/services/runners/internal/services/agent/internal/service -run 'Test.*(Terminal|ResultAndError|Finalization|Failure)' -count=1 -p=4",
            "propertyProved": "precedence, one normalization, terminal fragment cardinality/order, and requested failure taxonomy",
            "propertyNotProved": "root wiring, Work transition, resource release, or remote provider"
          },
          {
            "scope": "unit/component race correctness",
            "dependencyFidelity": "controlled",
            "cadence": "per PR",
            "cost": "bounded CPU",
            "procedure": "go test -race ./pkg/services/workers/internal/services/runners/internal/services/agent/internal/service -run 'Test.*(Terminal|ResultAndError|Finalization|Failure)' -count=1 -p=4",
            "propertyProved": "focused callback and publisher synchronization is data-race free",
            "propertyNotProved": "load/soak or downstream composed idempotency"
          }
        ],
        "highestFeasibleLevel": "Component boundary with production types/publisher; story 003 promotes to root-composed functional proof.",
        "remainingUnprovenEdges": [
          {"edge": "Worker Sessions/Runtime composition and failure route", "gateId": "factory-reliability-dispatch-terminal-finalization-001-003"},
          {"edge": "terminal current-head CI and merge", "gateId": "REVIEW-PR"},
          {"edge": "remote provider semantics", "gateId": "outside this authorized USD 0 slice"}
        ],
        "testLayerDesign": "Package-local component tests use explicit provider/publisher fakes, unique state per parallel subtest, and deterministic channels/barriers instead of sleeps. No root process or executable. Race is a correctness gate, not load coverage."
      },
      "paidValidation": {
        "trigger": "none",
        "maximumCalls": 0,
        "maximumCostUSD": 0,
        "maximumDuration": "0",
        "fixtureAndOutputValidator": "none",
        "evidenceReuseKey": "not-applicable"
      },
      "priority": "P0",
      "passes": true,
      "notes": "Implemented in the Workers agent runner and terminal_finalization_test.go. Focused normal and race commands passed: go test ./pkg/services/workers/internal/services/runners/internal/services/agent/internal/service -run 'Test.*(Terminal|ResultAndError|Finalization|Failure)' -count=1 -p=4 and go test -race ./pkg/services/workers/internal/services/runners/internal/services/agent/internal/service -run 'Test.*(Terminal|ResultAndError|Finalization|Failure)' -count=1 -p=4. Full agent-runner package test and go vet passed. Proves candidate/error precedence, one normalization, bounded suppressed kind/stage diagnostics, typed no-result/malformed failure routing, one terminal fragment, duplicate and late-callback suppression. Root wiring, Work transition, resource release, and composed exactly-once behavior remain in story 003."
    },
    {
      "id": "factory-reliability-dispatch-terminal-finalization-001-003",
      "title": "Prove composed failure routing and exactly-once Work advancement",
      "description": "Run the complete accepted-result-plus-error, no-result failure-to-lead, and duplicate-delivery matrix through one shared root-built application and public Factory Session/Work/Event observers, then hand the final head to review.",
      "parentBehavior": "BEH-001",
      "outcome": "The assembled Factory advances accepted Work once or follows one genuine failure route, with one resource release, immutable late output, and no second successor.",
      "sourcePlanRef": "7. Failure modes and quality attributes; 9. Implementation strategy; 12. Tasks — FR2 and FR5; 13. Project acceptance criteria — FR-A3, FR-A4, FR-A6",
      "dependencies": ["factory-reliability-dispatch-terminal-finalization-001-002"],
      "sharedSurfaceOwner": "Owns one focused Full Flow functional file/cell and reuses its shared process/router after coordinating exact package ownership; Runtime/Worker Sessions production remain read-only; reviewer owns CI/conflicts/merge.",
      "scope": {
        "in": ["F-01 accepted result plus later error", "F-02 no-result failure-to-lead", "F-03 duplicate idempotency", "shared root process and unique Factory Sessions", "Runtime focused evidence", "make verify-fast", "PR handoff and loopback inputs"],
        "out": ["built CLI", "real provider", "deployment or restart", "24-hour soak", "final Project acceptance", "validator-authored fixes"]
      },
      "contractChanges": [],
      "acceptanceCriteria": [
        "Given F-01, public observations show one accepted/completed terminal outcome, one Work advancement, bounded later-error evidence, one resource release, and no second successor.",
        "Given F-02, public observations show the genuine typed failure reaches exactly one existing failure-to-lead route with no accepted/completed result or fabricated PASS.",
        "Given F-03, concurrent delivery resolves as one retired plus an idempotent duplicate, with the original canonical result and no late output mutation.",
        "The named Provider/Workers/Runtime normal suites, focused Workers race suite, functional package, and make verify-fast pass on the final head and record their properties.",
        "The final head is pushed, the PR is open, CI has started, and blocking review feedback is addressed; REVIEW-PR then drives terminal CI and merge."
      ],
      "verification": {
        "behavioralWitness": "Public Factory Event sequence and Work listing for each unique session show exact dispatch outcome, terminal fragment count, successor identities/count, failure lead route, no post-terminal mutation, and one scenario edge release.",
        "executableSpineEffect": "promote",
        "requiredEvidence": [
          {
            "scope": "functional",
            "dependencyFidelity": "local real root composition with controlled exact external provider command",
            "cadence": "per PR",
            "cost": "free; one shared process and bounded sessions",
            "procedure": "go test ./tests/functional/factory/packaged/full_flow -run 'Test.*DispatchTerminalFinalization' -count=1 -p=4",
            "propertyProved": "F-01/F-02/F-03 through real application composition and public observers",
            "propertyNotProved": "compiled executable, remote provider, deployment/restart, or soak"
          },
          {
            "scope": "component/runtime",
            "dependencyFidelity": "controlled production Runtime and Worker Sessions contracts",
            "cadence": "per PR",
            "cost": "free; bounded Go test",
            "procedure": "go test ./pkg/services/factory_runtime/internal/services/orchestration/runtime -run 'Test.*(Terminal|Idempotent|FailureRoute|WorkerSession)' -count=1 -p=4",
            "propertyProved": "terminal callback acceptance, idempotent retirement, one Runtime result, and resource/Work progression",
            "propertyNotProved": "root provider parsing or remote dependencies"
          },
          {
            "scope": "repository quality",
            "dependencyFidelity": "controlled",
            "cadence": "per PR",
            "cost": "bounded existing fast target",
            "procedure": "make verify-fast with GOMAXPROCS=4 and the repository job budget",
            "propertyProved": "repository compile/typecheck, short UI/unit, and short Go gates named by the target",
            "propertyNotProved": "terminal hosted CI or integrated Project acceptance"
          }
        ],
        "highestFeasibleLevel": "Functional root.BuildProcess with real internally owned services and a controlled exact external effect; remote/paid and built-artifact proof are not authorized.",
        "remainingUnprovenEdges": [
          {"edge": "terminal current-head hosted CI, conflicts, review, and merge", "gateId": "REVIEW-PR"},
          {"edge": "loaded/authored instruction identity", "gateId": "FR3-INSTRUCTION-ACTIVATION"},
          {"edge": "full cancel/interrupt and API/CLI parity", "gateId": "FR5-CONTROL-INTEGRATED"},
          {"edge": "restart, soak, and blind acceptance", "gateId": "FR6-RESTART / FR-A9-SOAK / FR-A10-BLIND"}
        ],
        "testLayerDesign": "Functional matrix F-01/F-02/F-03 uses one shared root.BuildProcess and Process.Execute/public Factory Session APIs and never builds a binary. Each parallel cell owns a valid Factory Session, profile, Work/request IDs, routes, directories, streams, provider-router state, and cleanup; deterministic gates force the same-dispatch race and parent fixtures use t.Cleanup. Runtime tests stay component-level. No integration/load/static test is added; the release lane owns any later prebuilt artifact."
      },
      "paidValidation": {
        "trigger": "none",
        "maximumCalls": 0,
        "maximumCostUSD": 0,
        "maximumDuration": "0",
        "fixtureAndOutputValidator": "none",
        "evidenceReuseKey": "not-applicable"
      },
      "priority": "P0",
      "passes": true,
      "notes": "Implemented root-composed Full Flow coverage in invocation_test.go and terminal_finalization_test.go. The shared root fixture runs F-01 accepted result plus later provider error, F-02 no-result failure-to-lead, and F-03 concurrent duplicate invocation through public Factory Session, Work, Event, and Worker Session observers. Exact functional, Runtime, Providers, Workers normal/race, full functional package, and make verify-fast commands passed. Public AGENT_RUN_RESPONSE evidence retains completion_evidence and bounded failure_stage; Work listings use terminal=true&includeSuperseded=true. Final review handoff remains: push the final head, open the PR, and start CI."
    }
  ]
}
